### PR TITLE
Fix package regex to handle 4 component package names

### DIFF
--- a/Pipelines/Scripts/pack-upm.ps1
+++ b/Pipelines/Scripts/pack-upm.ps1
@@ -66,7 +66,7 @@ try {
 
     # loop through package directories, update package version, assembly version, and build version hash for updating dependencies
     Get-ChildItem -Path $ProjectRoot/*/package.json | ForEach-Object {
-        $packageName = Select-String -Pattern "org\.mixedrealitytoolkit\.\w+|com\.microsoft\.mrtk\.\w+" -Path $_ | Select-Object -First 1
+        $packageName = Select-String -Pattern "org\.mixedrealitytoolkit\.\w+(\.\w+)*|com\.microsoft\.mrtk\.\w+(\.\w+)*" -Path $_ | Select-Object -First 1
 
         if (-not $packageName) {
             return # this is not an MRTK package, so skip
@@ -130,7 +130,8 @@ try {
 
     # update dependencies using the versionHash map
     Get-ChildItem -Path $ProjectRoot/*/package.json | ForEach-Object {
-        $currentPackageName = Select-String -Pattern "org\.mixedrealitytoolkit\.\w+|com\.microsoft\.mrtk\.\w+" -Path $_ | Select-Object -First 1
+        $currentPackageName = Select-String -Pattern "org\.mixedrealitytoolkit\.\w+(\.\w+)*|com\.microsoft\.mrtk\.\w+(\.\w+)*" -Path $_ | Select-Object -First 1
+        
         if (-not $currentPackageName) {
             return # this is not an MRTK package, so skip
         }
@@ -150,7 +151,7 @@ try {
                 continue
             }
 
-            $searchRegex = "$($packageName).*:.*""(.*)"""
+            $searchRegex = "$($packageName)\s*"":\s*""(.*)"""
             $searchMatches = Select-String $searchRegex -InputObject (Get-Content -Path $_)
             if ($searchMatches.Matches.Groups) {
                 $newVersion = $versionHash["$($packageName)"]

--- a/Pipelines/Scripts/repackage-for-release.ps1
+++ b/Pipelines/Scripts/repackage-for-release.ps1
@@ -46,7 +46,7 @@ try {
     Write-Output "PackageSearchPath: $packageSearchPath"
 
     Get-ChildItem -Path $packageSearchPath | ForEach-Object {
-        $packageName = Select-String -Pattern "org\.mixedrealitytoolkit\.\w+|com\.microsoft\.mrtk\.\w+" -Path $_.FullName | Select-Object -First 1
+        $packageName = Select-String -Pattern "org\.mixedrealitytoolkit\.\w+(\.\w+)*|com\.microsoft\.mrtk\.\w+(\.\w+)*" -Path $_.FullName | Select-Object -First 1
 
         if (-not $packageName) {
             return # this is not an MRTK package, so skip
@@ -91,7 +91,7 @@ try {
     }
     # update all dependencies and repackage
     Get-ChildItem -Path $packageSearchPath | ForEach-Object {
-        $currentPackageName = Select-String -Pattern "org\.mixedrealitytoolkit\.\w+|com\.microsoft\.mrtk\.\w+" -Path $_.FullName | Select-Object -First 1
+        $currentPackageName = Select-String -Pattern "org\.mixedrealitytoolkit\.\w+(\.\w+)*|com\.microsoft\.mrtk\.\w+(\.\w+)*" -Path $_.FullName | Select-Object -First 1
 
         if (-not $currentPackageName) {
             return # this is not an MRTK package, so skip


### PR DESCRIPTION
We have one package (org.mixedrealitytoolkit.uxcomponents.noncanvas) that was screwing up the version dependency hash lookup.  This resolves it so the package.json gets patched with the correct dependency.