### PR TITLE
Fix regex in repackaging script (#427)

### DIFF
--- a/Pipelines/Scripts/repackage-for-release.ps1
+++ b/Pipelines/Scripts/repackage-for-release.ps1
@@ -60,7 +60,7 @@ try {
         Write-Output "Creating $packageName"
         Write-Output "====================="
 
-        $inlineVersion = Select-String '^.*"version":.*"(?<sem>[0-9]\.[0-9]\.[0-9])-(?<prerelease>prerelease\.)*(?<tag>pre\.\d*)*\.*(?<build>\d{6}\.\d*)' -InputObject (Get-Content -Path $_)
+        $inlineVersion = Select-String '^.*"version":\s*"(?<sem>[0-9]\.[0-9]\.[0-9])-(?<prerelease>prerelease\.)*(?<tag>pre\.\d*)*\.*(?<build>\d{6}\.\d*)' -InputObject (Get-Content -Path $_)
         $version = $inlineVersion.Matches[0].Groups['sem'].Value
         $prerelease = $inlineVersion.Matches[0].Groups['prerelease'].Value
         $tag = $inlineVersion.Matches[0].Groups['tag'].Value


### PR DESCRIPTION
The regex for extracting the version number from the package.json file was grabbing the wrong version in some instances.  Fixed.

(cherry picked from commit 20a0728a751736b928f58fc0493c613e26839e05)