### PR TITLE
Fix issue #40: ExperimentalDrawer.cs doesn't compile in Unity Editor 2022.3.2f1 

### DIFF
--- a/Pipelines/Scripts/repackage-for-release.ps1
+++ b/Pipelines/Scripts/repackage-for-release.ps1
@@ -60,7 +60,7 @@ try {
         Write-Output "Creating $packageName"
         Write-Output "====================="
 
-        $inlineVersion = Select-String '^.*"version":.*"(?<sem>[0-9]\.[0-9]\.[0-9])-(?<prerelease>prerelease\.)*(?<tag>pre\.\d*)*\.*(?<build>\d{6}\.\d*)' -InputObject (Get-Content -Path $_)
+        $inlineVersion = Select-String '^.*"version":\s*"(?<sem>[0-9]\.[0-9]\.[0-9])-(?<prerelease>prerelease\.)*(?<tag>pre\.\d*)*\.*(?<build>\d{6}\.\d*)' -InputObject (Get-Content -Path $_)
         $version = $inlineVersion.Matches[0].Groups['sem'].Value
         $prerelease = $inlineVersion.Matches[0].Groups['prerelease'].Value
         $tag = $inlineVersion.Matches[0].Groups['tag'].Value

--- a/org.mixedrealitytoolkit.core/Editor/PropertyDrawers/ExperimentalDrawer.cs
+++ b/org.mixedrealitytoolkit.core/Editor/PropertyDrawers/ExperimentalDrawer.cs
@@ -12,6 +12,9 @@ namespace MixedReality.Toolkit.Editor
     [CustomPropertyDrawer(typeof(ExperimentalAttribute))]
     public class ExperimentalDrawer : DecoratorDrawer
     {
+        // Cached height calculated in OnGUI
+        private float lastHeight = 18;
+
         /// <summary>
         /// A function called by Unity to render and handle GUI events.
         /// </summary>
@@ -24,6 +27,7 @@ namespace MixedReality.Toolkit.Editor
                 EditorStyles.helpBox.richText = true;
                 EditorGUI.HelpBox(position, experimental.Text, MessageType.Warning);
                 EditorStyles.helpBox.richText = defaultValue;
+                lastHeight = EditorStyles.helpBox.CalcHeight(new GUIContent(experimental.Text), EditorGUIUtility.currentViewWidth);
             }
         }
 
@@ -35,7 +39,7 @@ namespace MixedReality.Toolkit.Editor
         {
             if (attribute is ExperimentalAttribute experimental)
             {
-                return EditorStyles.helpBox.CalcHeight(new GUIContent(experimental.Text), EditorGUIUtility.currentViewWidth);
+                return lastHeight;
             }
 
             return base.GetHeight();


### PR DESCRIPTION
Fix ExperimentalDrawer.cs doesn't compile in Unity Editor 2022.3.2f1 and above. https://github.com/MixedRealityToolkit/MixedRealityToolkit-Unity/issues/40

Use a cached height calculated in OnGUI().