### PR TITLE
Cherry pick #430 to release/3.0.0

### DIFF
--- a/org.mixedrealitytoolkit.core/Editor/PropertyDrawers/ExperimentalDrawer.cs
+++ b/org.mixedrealitytoolkit.core/Editor/PropertyDrawers/ExperimentalDrawer.cs
@@ -12,6 +12,9 @@ namespace MixedReality.Toolkit.Editor
     [CustomPropertyDrawer(typeof(ExperimentalAttribute))]
     public class ExperimentalDrawer : DecoratorDrawer
     {
+        // Cached height calculated in OnGUI
+        private float lastHeight = 18;
+
         /// <summary>
         /// A function called by Unity to render and handle GUI events.
         /// </summary>
@@ -24,6 +27,7 @@ namespace MixedReality.Toolkit.Editor
                 EditorStyles.helpBox.richText = true;
                 EditorGUI.HelpBox(position, experimental.Text, MessageType.Warning);
                 EditorStyles.helpBox.richText = defaultValue;
+                lastHeight = EditorStyles.helpBox.CalcHeight(new GUIContent(experimental.Text), EditorGUIUtility.currentViewWidth);
             }
         }
 
@@ -35,7 +39,7 @@ namespace MixedReality.Toolkit.Editor
         {
             if (attribute is ExperimentalAttribute experimental)
             {
-                return EditorStyles.helpBox.CalcHeight(new GUIContent(experimental.Text), EditorGUIUtility.currentViewWidth);
+                return lastHeight;
             }
 
             return base.GetHeight();


### PR DESCRIPTION

* Fix ExperimentalDrawer.cs doesn't compile in Unity Editor 2022.3.2f1 and above. #40 Use a cached height calculated in OnGUI().

(cherry picked from commit 770b1c41cb32479cd3a223023efd4fabb5b530a4)