### PR TITLE
Enable developer customers to access AudioSource at development time

### DIFF
--- a/org.mixedrealitytoolkit.uxcore/Slider/SliderSounds.cs
+++ b/org.mixedrealitytoolkit.uxcore/Slider/SliderSounds.cs
@@ -113,9 +113,27 @@ namespace MixedReality.Toolkit.UX
         [Tooltip("The source of the grab and release sounds")]
         private AudioSource grabReleaseAudioSource = null;
 
+        /// <summary>
+        /// Gets or sets the AudioSource used to play grab and release sounds.
+        /// </summary>
+        public AudioSource GrabReleaseAudioSource
+        {
+            get => grabReleaseAudioSource;
+            set => grabReleaseAudioSource = value;
+        }
+
         [SerializeField]
         [Tooltip("The source of the pass notch sounds")]
         private AudioSource passNotchAudioSource = null;
+
+        /// <summary>
+        /// Gets or sets the AudioSource used to play sound when the user moves the slider thumb past a notch.
+        /// </summary>
+        public AudioSource PassNotchAudioSource
+        {
+            get => passNotchAudioSource;
+            set => passNotchAudioSource = value;
+        }
 
         #region Private members
         private Slider slider;

--- a/org.mixedrealitytoolkit.uxcore/Slider/SliderSounds.cs
+++ b/org.mixedrealitytoolkit.uxcore/Slider/SliderSounds.cs
@@ -109,6 +109,13 @@ namespace MixedReality.Toolkit.UX
         /// </summary>
         public float MinSecondsBetweenTicks { get => minSecondsBetweenTicks; set => minSecondsBetweenTicks = value; }
 
+        [SerializeField]
+        [Tooltip("The source of the grab and release sounds")]
+        private AudioSource grabReleaseAudioSource = null;
+
+        [SerializeField]
+        [Tooltip("The source of the pass notch sounds")]
+        private AudioSource passNotchAudioSource = null;
 
         #region Private members
         private Slider slider;
@@ -119,9 +126,6 @@ namespace MixedReality.Toolkit.UX
         // Play sound when passing through slider notches
         private float accumulatedDeltaSliderValue = 0;
         private float lastSoundPlayTime;
-
-        private AudioSource grabReleaseAudioSource = null;
-        private AudioSource passNotchAudioSource = null;
         #endregion
 
         /// <summary>


### PR DESCRIPTION
This change serializes the grabReleaseAudioSource and passNotchAudioSource AudioSource fields, so that developer customers can configure options such as AudioMixerGroup, spatialization and play on awake.

Fixes: #435 

Verified in Unity editor by:

- Adding a single AudioSource to the slider in the HandInteractionExamplesScene
- Assigning the manually attached AudioSource to the Grab/Release and PassNotch fields (newly serialized)
- Playing the scene in the editor and moving the slider
- Noting
  - No additional AudioSource objects were added to the slider
  - Audio plays correctly
  - The expected AudioSource parameters are updated while interacting with the slider