### PR TITLE
Changes in Constraint-classes

### DIFF
--- a/AxisMovementConstraint.cs
+++ b/AxisMovementConstraint.cs
@@ -1,0 +1,156 @@
+using Microsoft.MixedReality.Toolkit;
+using Microsoft.MixedReality.Toolkit.SpatialManipulation;
+using UnityEngine;
+
+public class AxisMovementConstraint : TransformConstraint
+{
+    #region Properties
+
+    [SerializeField] 
+    [Tooltip("Allow movement along an X-Axis")]
+    private bool movementOnXAxis;
+
+
+    [SerializeField]
+    [Tooltip("Allow movement along an Y-Axis")]
+    private bool movementOnYAxis;
+
+
+    [SerializeField]
+    [Tooltip("Allow movement along an Z-Axis")]
+    private bool movementOnZAxis;
+
+    [SerializeField]
+    [Tooltip("Set the size of the steps for fixed movement")]
+    private float fixedStepSize = 1.0f;
+
+    [SerializeField]
+    [Tooltip("Enable to allow re-positioning only in fixed steps.")]
+    private bool bFixedStep = false;
+
+    [SerializeField]
+    [Tooltip("Relative to rotation at manipulation start or world")]
+    private bool useLocalSpaceForConstraint = false;
+
+    /// <summary>
+    /// Relative to rotation at manipulation start or world
+    /// </summary>
+    public bool UseLocalSpaceForConstraint
+    {
+        get => useLocalSpaceForConstraint;
+        set => useLocalSpaceForConstraint = value;
+    }
+
+    public override TransformFlags ConstraintType => TransformFlags.Move;
+
+    #endregion Properties
+
+
+    private void Start()
+    {
+        movementOnXAxis = true;
+        movementOnYAxis = true;
+        movementOnZAxis = true;
+    }
+
+    #region Public Methods
+
+    /// <summary>
+    /// Removes movement along a given axis if its flag is found
+    /// in ConstraintOnMovement
+    /// </summary>
+    public override void ApplyConstraint(ref MixedRealityTransform transform)
+    {
+        Quaternion inverseRotation = Quaternion.Inverse(WorldPoseOnManipulationStart.Rotation);
+        Vector3 position = transform.Position;
+
+        if (bFixedStep)
+        {
+            position.x = WorldPoseOnManipulationStart.Position.x + ((int)((position.x - WorldPoseOnManipulationStart.Position.x) / fixedStepSize)) * fixedStepSize;
+            position.y = WorldPoseOnManipulationStart.Position.y + ((int)((position.y - WorldPoseOnManipulationStart.Position.y) / fixedStepSize)) * fixedStepSize;
+            position.z = WorldPoseOnManipulationStart.Position.z + ((int)((position.z - WorldPoseOnManipulationStart.Position.z) / fixedStepSize)) * fixedStepSize;
+        }
+
+        if (useLocalSpaceForConstraint)
+        {
+            //movement considering local space
+            position = inverseRotation * position;
+
+            if (!movementOnXAxis)
+                position.x = (inverseRotation * WorldPoseOnManipulationStart.Position).x;
+
+            if (!movementOnYAxis)
+                position.y = (inverseRotation * WorldPoseOnManipulationStart.Position).y;
+
+            if (!movementOnZAxis)
+                position.z = (inverseRotation * WorldPoseOnManipulationStart.Position).z;
+
+
+            position = WorldPoseOnManipulationStart.Rotation * position;
+
+        }
+        else
+        {
+            //world manipulation
+            if (!movementOnXAxis)
+                position.x = WorldPoseOnManipulationStart.Position.x;
+            if (!movementOnYAxis)
+                position.y = WorldPoseOnManipulationStart.Position.y;
+            if (!movementOnZAxis)
+                position.z = WorldPoseOnManipulationStart.Position.z;
+
+        }
+        
+        transform.Position = position;
+    }
+
+
+    /// <summary>
+    /// checks, if user can move on given axis or not
+    /// </summary>
+    /// <param name="axis">Axis to check for</param>
+    /// <returns>true, if movement is possible, otherwise false</returns>
+    public bool CanMoveOnAxis(AxisFlags axis)
+    {
+        switch (axis)
+        {
+            case AxisFlags.XAxis: return movementOnXAxis;
+            case AxisFlags.YAxis: return movementOnYAxis;
+            case AxisFlags.ZAxis: return movementOnZAxis;
+        }
+
+        //function-complete return statement but will never occur
+        return false;
+    }
+
+    /// <summary>
+    /// sets movement on given axis
+    /// </summary>
+    /// <param name="axis">Axis to allow/disallow movement</param>
+    /// <param name="canMove">true, if movement is possible (standard) or not</param>
+    public void SetMoveOneAxis(AxisFlags axis, bool canMove)
+    {
+        switch (axis)
+        {
+            case AxisFlags.XAxis: movementOnXAxis = canMove; break;
+            case AxisFlags.YAxis: movementOnYAxis = canMove; break;
+            case AxisFlags.ZAxis: movementOnZAxis = canMove; break;
+        }
+    }
+
+
+    public bool AllowStepSize
+    {
+        get => bFixedStep;
+        set => bFixedStep = value;
+    }
+
+    public float StepSize
+    {
+        get => fixedStepSize;
+        set => fixedStepSize = value;
+
+    }
+
+    #endregion Public Methods
+}

--- a/AxisMovementConstraint.cs.meta
+++ b/AxisMovementConstraint.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a22a39c73159ee442b733ff14f8ed53b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/AxisRotationConstraint.cs
+++ b/AxisRotationConstraint.cs
@@ -1,0 +1,138 @@
+using Microsoft.MixedReality.Toolkit;
+using Microsoft.MixedReality.Toolkit.SpatialManipulation;
+using UnityEngine;
+
+public class AxisRotationConstraint : TransformConstraint
+{
+    #region Properties
+
+    [SerializeField]
+    [Tooltip("Set to true, if rotation around X-Axis is possible.")]
+    private bool allowRotationOnXAxis;
+
+    [SerializeField]
+    [Tooltip("Set to true, if rotation around Y-Axis is possible.")]
+    private bool allowRotationOnYAxis;
+
+    [SerializeField]
+    [Tooltip("Set to true, if rotation around Z-Axis is possible.")]
+    private bool allowRotationOnZAxis;
+
+    [SerializeField]
+    [Tooltip("Set the size of the steps for fixed rotation")]
+    private float fixedStepSize = 1.0f;
+
+    [SerializeField]
+    [Tooltip("Enable to allow rotation only in fixed steps.")]
+    private bool bFixedStep = false;
+
+    [SerializeField]
+    [Tooltip("Check if object rotation should be in local space of object being manipulated instead of world space.")]
+    private bool useLocalSpaceForConstraint = false;
+
+    /// <summary>
+    /// Gets or sets whether the constraints should be applied in local space of the object being manipulated or world space.
+    /// </summary>
+    public bool UseLocalSpaceForConstraint
+    {
+        get => useLocalSpaceForConstraint;
+        set => useLocalSpaceForConstraint = value;
+    }
+
+    public override TransformFlags ConstraintType => TransformFlags.Rotate;
+
+    #endregion Properties
+
+
+    private void Awake()
+    {
+        allowRotationOnXAxis = true;
+        allowRotationOnYAxis = true;
+        allowRotationOnZAxis = true;
+    }
+
+
+    #region Public Methods
+
+    /// <summary>
+    /// Removes rotation about given axis if its flag is found
+    /// in ConstraintOnRotation
+    /// </summary>
+    public override void ApplyConstraint(ref MixedRealityTransform transform)
+    {
+        Quaternion rotation = transform.Rotation * Quaternion.Inverse(WorldPoseOnManipulationStart.Rotation);
+        Vector3 eulers = rotation.eulerAngles;
+
+        if (bFixedStep)
+        {
+            Vector3 eulerStart = Quaternion.Inverse(WorldPoseOnManipulationStart.Rotation).eulerAngles;
+
+            eulers.x = ((int)(eulers.x / fixedStepSize)) * fixedStepSize;
+            eulers.y = ((int)(eulers.y / fixedStepSize)) * fixedStepSize;
+            eulers.z = ((int)(eulers.z / fixedStepSize)) * fixedStepSize;
+        }
+
+
+        if (!allowRotationOnXAxis)
+            eulers.x = 0;
+        
+        if (!allowRotationOnYAxis)
+            eulers.y = 0;
+        
+        if (!allowRotationOnZAxis)
+            eulers.z = 0;
+        
+
+        transform.Rotation = useLocalSpaceForConstraint
+            ? WorldPoseOnManipulationStart.Rotation * Quaternion.Euler(eulers)
+            : Quaternion.Euler(eulers) * WorldPoseOnManipulationStart.Rotation;
+    }
+
+    /// <summary>
+    /// checks, if user can rotate around given axis or not
+    /// </summary>
+    /// <param name="axis">Axis to check for</param>
+    /// <returns>true, if rotation is possible, otherwise false</returns>
+    public bool CanRotateOnAxis(AxisFlags axis)
+    {
+        switch (axis)
+        {
+            case AxisFlags.XAxis: return allowRotationOnXAxis;
+            case AxisFlags.YAxis: return allowRotationOnYAxis;
+            case AxisFlags.ZAxis: return allowRotationOnZAxis;
+        }
+
+        //function-complete return statement but will never occur
+        return false;
+    }
+
+    /// <summary>
+    /// sets rotation on given axis
+    /// </summary>
+    /// <param name="axis">Axis to allow/disallow rotation</param>
+    /// <param name="canMove">true, if rotation is possible (standard) or not</param>
+    public void SetRotateOneAxis(AxisFlags axis, bool canMove)
+    {
+        switch (axis)
+        {
+            case AxisFlags.XAxis: allowRotationOnXAxis = canMove; break;
+            case AxisFlags.YAxis: allowRotationOnYAxis = canMove; break;
+            case AxisFlags.ZAxis: allowRotationOnZAxis = canMove; break;
+        }
+    }
+
+    public bool AllowStepSize
+    {
+        get => bFixedStep;
+        set => bFixedStep = value;
+    }
+
+    public float StepSize
+    {
+        get => fixedStepSize;
+        set => fixedStepSize = value;
+
+    }
+
+    #endregion Public Methods
+}

--- a/AxisRotationConstraint.cs.meta
+++ b/AxisRotationConstraint.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 409767e978cdc0d46873a57264da60e3
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
# Overview

Create two new Constraint-types that might replace the current "RotationAxisConstraint" and "MoveAxisConstraint".

## Description

The current implementation creates a new constraint type (RotationAxisConstraint" and "MoveAxisConstraint" each time a new axis should be restricted. In some cases, we may have two constraint types of each class, resulting in four additional constraints. When a complete restriction is applied (without re-checking the current axis for each constraint) we may have six additional constraints in total.

For the new implementation I improved the behavior a little bit, so that in each constraint class every axis can be allowed/restricted, resulting in only two additional runtime objects.

Additionally I implemented an "step"-feature that rotates/moves the component object in a pre-given "stepSize" to allow a more granular transform manipulation. The stepSize is added on the WorldPoseOnManipulationStart-transform, so every start position/angle can be used. Those variables can be get/set in runtime without any issues as well.