### PR TITLE
Add Precompile Statements to Avoid Errors in < Unity 2021.3.18

### DIFF
--- a/org.mixedrealitytoolkit.core/MRTK.Core.asmdef
+++ b/org.mixedrealitytoolkit.core/MRTK.Core.asmdef
@@ -13,6 +13,12 @@
     "precompiledReferences": [],
     "autoReferenced": true,
     "defineConstraints": [],
-    "versionDefines": [],
+    "versionDefines": [
+        {
+            "name": "Unity",
+            "expression": "2021.3.18",
+            "define": "UNITY_2021_3_18_OR_NEWER"
+        }
+    ],
     "noEngineReferences": false
 }

--- a/org.mixedrealitytoolkit.core/Utilities/ComponentCache.cs
+++ b/org.mixedrealitytoolkit.core/Utilities/ComponentCache.cs
@@ -35,7 +35,11 @@ namespace MixedReality.Toolkit
         {
             if (cacheFirstInstance == null || !cacheFirstInstance.gameObject.activeInHierarchy)
             {
+#if UNITY_2021_3_18_OR_NEWER
                 cacheFirstInstance = Object.FindFirstObjectByType<T>();
+#else
+                cacheFirstInstance = Object.FindObjectOfType<T>();
+#endif
             }
 
             result = cacheFirstInstance;

--- a/org.mixedrealitytoolkit.core/Utilities/ControllerLookup.cs
+++ b/org.mixedrealitytoolkit.core/Utilities/ControllerLookup.cs
@@ -61,10 +61,17 @@ namespace MixedReality.Toolkit
         /// </summary>
         private void OnValidate()
         {
+#if UNITY_2021_3_18_OR_NEWER
             if (FindObjectsByType<ControllerLookup>(FindObjectsSortMode.None).Length > 1)
             {
                 Debug.LogWarning("Found more than one instance of the ControllerLookup class in the hierarchy. There should only be one");
             }
+#else
+            if (FindObjectsOfType<ControllerLookup>().Length > 1)
+            {
+                Debug.LogWarning("Found more than one instance of the ControllerLookup class in the hierarchy. There should only be one");
+            }
+#endif
         }
     }
 }

--- a/org.mixedrealitytoolkit.uxcore/Tests/Runtime/SeeItSayItLabelEnablerTests.cs
+++ b/org.mixedrealitytoolkit.uxcore/Tests/Runtime/SeeItSayItLabelEnablerTests.cs
@@ -27,7 +27,7 @@ namespace MixedReality.Toolkit.UX.Runtime.Tests
         public IEnumerator TestEnableAndSetLabel()
         {
 #if MRTK_INPUT_PRESENT && MRTK_SPEECH_PRESENT
-            SpeechInteractor interactor = Object.FindAnyObjectByType<SpeechInteractor>(FindObjectsInactive.Include);
+            SpeechInteractor interactor = Object.FindObjectOfType<SpeechInteractor>(true);
             interactor.gameObject.SetActive(true);
 
             GameObject testButton = SetUpButton(true, Control.None);
@@ -71,7 +71,7 @@ namespace MixedReality.Toolkit.UX.Runtime.Tests
         public IEnumerator TestPositionCanvasLabel()
         {
 #if MRTK_INPUT_PRESENT && MRTK_SPEECH_PRESENT
-            SpeechInteractor interactor = Object.FindAnyObjectByType<SpeechInteractor>(FindObjectsInactive.Include);
+            SpeechInteractor interactor = Object.FindObjectOfType<SpeechInteractor>(true);
             interactor.gameObject.SetActive(true);
 
             GameObject testButton = SetUpButton(true, Control.Canvas);
@@ -97,7 +97,7 @@ namespace MixedReality.Toolkit.UX.Runtime.Tests
         public IEnumerator TestPositionNonCanvasLabel()
         {
 #if MRTK_INPUT_PRESENT && MRTK_SPEECH_PRESENT
-            SpeechInteractor interactor = Object.FindAnyObjectByType<SpeechInteractor>(FindObjectsInactive.Include);
+            SpeechInteractor interactor = Object.FindObjectOfType<SpeechInteractor>(true);
             interactor.gameObject.SetActive(true);
 
             GameObject testButton = SetUpButton(true, Control.NonCanvas);


### PR DESCRIPTION
Adds ifdefs to allow < Unity 2021.3.18 to compile. 

Unity 2021.3.18 introduced several more efficient functions: Object.FindObjectsByType(), Object.FindFirstObjectByType(), Object.FindAnyObjectByType(). This PR adds back the ability to use the older versions of these calls if version < 2021.3.18. 

Resolves https://github.com/MixedRealityToolkit/MixedRealityToolkit-Unity/issues/467.