### PR TITLE
Add Samples folder to .gitignore

### DIFF
--- a/UnityProjects/.gitignore
+++ b/UnityProjects/.gitignore
@@ -84,6 +84,7 @@ crashlytics-build.properties
 # Project Specific List
 */[Aa]ssets/[Bb]uild[Rr]eports*
 */[Aa]ssets/[Oo]culus*
+*/[Aa]ssets/[Ss]amples*
 */[Aa]ssets/TextMesh Pro*
 *.pfx
 *.pfx.meta


### PR DESCRIPTION
Allows devs to import samples for testing without polluting their git changes. This is a Unity-generated folder when samples are imported via UPM.