### PR TITLE
Refactor out HandsProvider<T>

### DIFF
--- a/UnityProjects/MRTKDevTemplate/Packages/packages-lock.json
+++ b/UnityProjects/MRTKDevTemplate/Packages/packages-lock.json
@@ -344,7 +344,7 @@
       "source": "local",
       "dependencies": {
         "com.microsoft.mrtk.graphicstools.unity": "0.5.12",
-        "org.mixedrealitytoolkit.core": "3.0.0",
+        "org.mixedrealitytoolkit.core": "3.0.2",
         "com.unity.inputsystem": "1.6.1",
         "com.unity.xr.arfoundation": "5.0.5",
         "com.unity.xr.interaction.toolkit": "2.3.0",

--- a/org.mixedrealitytoolkit.core/Utilities/HandsUtils.cs
+++ b/org.mixedrealitytoolkit.core/Utilities/HandsUtils.cs
@@ -30,6 +30,11 @@ namespace MixedReality.Toolkit
             InputDeviceCharacteristics.HandTracking | InputDeviceCharacteristics.Right;
 
         /// <summary>
+        /// Provides the MRTK-default value for hand joint radius when the platform API doesn't provide one.
+        /// </summary>
+        internal const float DefaultHandJointRadius = 0.005f;
+
+        /// <summary>
         /// Converts a Unity finger bone into an MRTK hand joint.
         /// </summary>
         /// <remarks>
@@ -65,7 +70,7 @@ namespace MixedReality.Toolkit
         /// </summary>
         internal static TrackedHandJoint ConvertFromIndex(int index)
         {
-            return (TrackedHandJoint)(index);
+            return (TrackedHandJoint)index;
         }
 
         /// <summary>
@@ -240,7 +245,7 @@ namespace MixedReality.Toolkit
                     jointPoses[index].Rotation = item.Pose.rotation;
 
                     // No joint radii from the JSON poses.. yet!
-                    jointPoses[index].Radius = 0.005f;
+                    jointPoses[index].Radius = DefaultHandJointRadius;
                 }
             }
         }

--- a/org.mixedrealitytoolkit.core/Utilities/TrackedHandJoint.cs
+++ b/org.mixedrealitytoolkit.core/Utilities/TrackedHandJoint.cs
@@ -142,7 +142,7 @@ namespace MixedReality.Toolkit
         LittleTip,
 
         /// <summary>
-        /// Number of joints total (not counting None).
+        /// Number of joints total.
         /// </summary>
         TotalJoints = LittleTip + 1
     }

--- a/org.mixedrealitytoolkit.core/Utilities/XRSubsystemHelpers.cs
+++ b/org.mixedrealitytoolkit.core/Utilities/XRSubsystemHelpers.cs
@@ -96,8 +96,7 @@ namespace MixedReality.Toolkit
             }
 
             List<T> cache = scratchCaches[typeof(T)] as List<T>;
-            SubsystemManager.GetSubsystems<T>(cache);
-
+            SubsystemManager.GetSubsystems(cache);
             return cache;
         }
 

--- a/org.mixedrealitytoolkit.core/package.json
+++ b/org.mixedrealitytoolkit.core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "org.mixedrealitytoolkit.core",
-  "version": "3.0.1-development",
+  "version": "3.0.2-development",
   "description": "A limited collection of common interfaces and utilities that most MRTK packages share. Most implementations of these interfaces are contained in other packages in the MRTK ecosystem.",
   "displayName": "MRTK Core Definitions",
   "msftFeatureCategory": "MRTK3",

--- a/org.mixedrealitytoolkit.input/Subsystems/Hands/HandsProvider.cs
+++ b/org.mixedrealitytoolkit.input/Subsystems/Hands/HandsProvider.cs
@@ -13,9 +13,11 @@ namespace MixedReality.Toolkit.Input
 {
     /// <summary>
     /// Provides a generic, base hands provider for subsystem use.
+    /// </summary>
+    /// <remarks>
     /// Extends the <see cref="MixedReality.Toolkit.Subsystems.HandsSubsystem.Provider">Provider</see> class and
     /// obtains hand joint poses from a <see cref="MixedReality.Toolkit.Input.HandDataContainer">HandDataContainer</see> class.
-    /// </summary>
+    /// </remarks>
     /// <typeparam name="T">
     /// The type of <see cref="MixedReality.Toolkit.Input.HandDataContainer">HandDataContainer</see> to query hand data from.
     /// </typeparam>

--- a/org.mixedrealitytoolkit.input/Subsystems/Hands/HandsProvider.cs
+++ b/org.mixedrealitytoolkit.input/Subsystems/Hands/HandsProvider.cs
@@ -1,0 +1,70 @@
+using MixedReality.Toolkit.Subsystems;
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.InputSystem;
+using UnityEngine.Scripting;
+using UnityEngine.XR;
+
+namespace MixedReality.Toolkit.Input
+{
+    /// <summary>
+    /// Provides a generic, base hands provider for subsystem use.
+    /// Extends the <see cref="MixedReality.Toolkit.Subsystems.HandsSubsystem.Provider">Provider</see> class, and
+    /// obtains hand joint poses from a <see cref="MixedReality.Toolkit.Input.HandDataContainer">HandDataContainer</see> class.
+    /// </summary>
+    /// <typeparam name="T">
+    /// The type of <see cref="MixedReality.Toolkit.Input.HandDataContainer">HandDataContainer</see> to query hand data from.
+    /// </typeparam>
+    [Preserve]
+    internal class HandsProvider<T> : HandsSubsystem.Provider where T : HandDataContainer
+    {
+        private Dictionary<XRNode, T> hands = null;
+
+        /// <inheritdoc/>
+        public override void Start()
+        {
+            base.Start();
+
+            hands ??= new Dictionary<XRNode, T>
+            {
+                { XRNode.LeftHand, Activator.CreateInstance(typeof(T), XRNode.LeftHand) as T },
+                { XRNode.RightHand, Activator.CreateInstance(typeof(T), XRNode.RightHand) as T }
+            };
+
+            InputSystem.onBeforeUpdate += ResetHands;
+        }
+
+        /// <inheritdoc/>
+        public override void Stop()
+        {
+            ResetHands();
+            InputSystem.onBeforeUpdate -= ResetHands;
+            base.Stop();
+        }
+
+        private void ResetHands()
+        {
+            hands[XRNode.LeftHand].Reset();
+            hands[XRNode.RightHand].Reset();
+        }
+
+        #region IHandsSubsystem implementation
+
+        /// <inheritdoc/>
+        public override bool TryGetEntireHand(XRNode handNode, out IReadOnlyList<HandJointPose> jointPoses)
+        {
+            Debug.Assert(handNode == XRNode.LeftHand || handNode == XRNode.RightHand, "Non-hand XRNode used in TryGetEntireHand query.");
+            return hands[handNode].TryGetEntireHand(out jointPoses);
+        }
+
+        /// <inheritdoc/>
+        public override bool TryGetJoint(TrackedHandJoint joint, XRNode handNode, out HandJointPose jointPose)
+        {
+            Debug.Assert(handNode == XRNode.LeftHand || handNode == XRNode.RightHand, "Non-hand XRNode used in TryGetJoint query.");
+            return hands[handNode].TryGetJoint(joint, out jointPose);
+        }
+
+        #endregion IHandsSubsystem implementation
+    }
+}

--- a/org.mixedrealitytoolkit.input/Subsystems/Hands/HandsProvider.cs
+++ b/org.mixedrealitytoolkit.input/Subsystems/Hands/HandsProvider.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Mixed Reality Toolkit Contributors
+// Licensed under the BSD 3-Clause
+
 using MixedReality.Toolkit.Subsystems;
 using System;
 using System.Collections.Generic;
@@ -10,7 +13,7 @@ namespace MixedReality.Toolkit.Input
 {
     /// <summary>
     /// Provides a generic, base hands provider for subsystem use.
-    /// Extends the <see cref="MixedReality.Toolkit.Subsystems.HandsSubsystem.Provider">Provider</see> class, and
+    /// Extends the <see cref="MixedReality.Toolkit.Subsystems.HandsSubsystem.Provider">Provider</see> class and
     /// obtains hand joint poses from a <see cref="MixedReality.Toolkit.Input.HandDataContainer">HandDataContainer</see> class.
     /// </summary>
     /// <typeparam name="T">

--- a/org.mixedrealitytoolkit.input/Subsystems/Hands/HandsProvider.cs.meta
+++ b/org.mixedrealitytoolkit.input/Subsystems/Hands/HandsProvider.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 88778fc1359453f4fb37efd9a1d6139c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/org.mixedrealitytoolkit.input/Subsystems/Hands/OpenXRHandsSubsystem.cs
+++ b/org.mixedrealitytoolkit.input/Subsystems/Hands/OpenXRHandsSubsystem.cs
@@ -111,8 +111,7 @@ namespace MixedReality.Toolkit.Input
                             return false;
                         }
 
-                        var jointLocation = HandJointLocations[HandJointIndexFromTrackedHandJointIndex[index]];
-                        UpdateJoint(index, jointLocation, origin);
+                        UpdateJoint(index, HandJointLocations[HandJointIndexFromTrackedHandJointIndex[index]], origin);
                         thisQueryValid = true;
                     }
                     else

--- a/org.mixedrealitytoolkit.input/Subsystems/Hands/XRSDKHandsSubsystem.cs
+++ b/org.mixedrealitytoolkit.input/Subsystems/Hands/XRSDKHandsSubsystem.cs
@@ -232,8 +232,9 @@ namespace MixedReality.Toolkit.Input
                     }
 
                     // Write root bone into HandJoints as palm joint.
-                    handDevice.Value.TryGetRootBone(out Bone rootBone);
-                    FullQueryValid &= TryUpdateJoint(HandsUtils.ConvertToIndex(TrackedHandJoint.Palm), rootBone, origin);
+                    FullQueryValid &=
+                        handDevice.Value.TryGetRootBone(out Bone rootBone)
+                        && TryUpdateJoint(HandsUtils.ConvertToIndex(TrackedHandJoint.Palm), rootBone, origin);
 
                     // Mark this hand as having been fully queried this frame.
                     // If any joint is queried again this frame, we'll reuse the

--- a/org.mixedrealitytoolkit.input/Subsystems/Hands/XRSDKHandsSubsystem.cs
+++ b/org.mixedrealitytoolkit.input/Subsystems/Hands/XRSDKHandsSubsystem.cs
@@ -85,7 +85,6 @@ namespace MixedReality.Toolkit.Input
                 using (TryGetJointPerfMarker.Auto())
                 {
                     bool thisQueryValid = false;
-                    int index = HandsUtils.ConvertToIndex(joint);
 
                     // If we happened to have already queried the entire
                     // hand data this frame, we don't need to re-query for
@@ -99,7 +98,7 @@ namespace MixedReality.Toolkit.Input
                         // and return immediately.
                         if (!handDevice.HasValue)
                         {
-                            pose = HandJoints[index];
+                            pose = HandJoints[HandsUtils.ConvertToIndex(joint)];
                             return false;
                         }
 
@@ -107,7 +106,7 @@ namespace MixedReality.Toolkit.Input
                         Transform origin = PlayspaceUtilities.XROrigin.CameraFloorOffsetObject.transform;
                         if (origin == null)
                         {
-                            pose = HandJoints[index];
+                            pose = HandJoints[HandsUtils.ConvertToIndex(joint)];
                             return false;
                         }
 
@@ -116,7 +115,7 @@ namespace MixedReality.Toolkit.Input
                         {
                             if (handDevice.Value.TryGetRootBone(out Bone rootBone))
                             {
-                                thisQueryValid |= TryUpdateJoint(index, rootBone, origin);
+                                thisQueryValid |= TryUpdateJoint(joint, rootBone, origin);
                             }
                         }
                         else
@@ -125,7 +124,7 @@ namespace MixedReality.Toolkit.Input
                             if (handDevice.Value.TryGetFingerBones(finger, fingerBones))
                             {
                                 Bone bone = fingerBones[HandsUtils.GetOffsetFromBase(joint)];
-                                thisQueryValid |= TryUpdateJoint(index, bone, origin);
+                                thisQueryValid |= TryUpdateJoint(joint, bone, origin);
                             }
                         }
                     }
@@ -136,7 +135,7 @@ namespace MixedReality.Toolkit.Input
                         thisQueryValid = FullQueryValid;
                     }
 
-                    pose = HandJoints[index];
+                    pose = HandJoints[HandsUtils.ConvertToIndex(joint)];
                     return thisQueryValid;
                 }
             }
@@ -226,7 +225,7 @@ namespace MixedReality.Toolkit.Input
                         {
                             for (int i = 0; i < fingerBones.Count; i++)
                             {
-                                FullQueryValid &= TryUpdateJoint(HandsUtils.ConvertToIndex(HandsUtils.ConvertToTrackedHandJoint(finger, i)), fingerBones[i], origin);
+                                FullQueryValid &= TryUpdateJoint(HandsUtils.ConvertToTrackedHandJoint(finger, i), fingerBones[i], origin);
                             }
                         }
                     }
@@ -234,7 +233,7 @@ namespace MixedReality.Toolkit.Input
                     // Write root bone into HandJoints as palm joint.
                     FullQueryValid &=
                         handDevice.Value.TryGetRootBone(out Bone rootBone)
-                        && TryUpdateJoint(HandsUtils.ConvertToIndex(TrackedHandJoint.Palm), rootBone, origin);
+                        && TryUpdateJoint(TrackedHandJoint.Palm, rootBone, origin);
 
                     // Mark this hand as having been fully queried this frame.
                     // If any joint is queried again this frame, we'll reuse the
@@ -250,7 +249,7 @@ namespace MixedReality.Toolkit.Input
             /// Given a destination jointID, apply the Bone info to the correct struct
             /// in the HandJoints collection.
             /// </summary>
-            private bool TryUpdateJoint(int jointIndex, Bone bone, Transform playspaceTransform)
+            private bool TryUpdateJoint(TrackedHandJoint jointID, Bone bone, Transform playspaceTransform)
             {
                 using (TryUpdateJointPerfMarker.Auto())
                 {
@@ -260,7 +259,7 @@ namespace MixedReality.Toolkit.Input
                     }
 
                     // XRSDK does not return joint radius. 0.5cm default.
-                    HandJoints[jointIndex] = new HandJointPose(
+                    HandJoints[HandsUtils.ConvertToIndex(jointID)] = new HandJointPose(
                         playspaceTransform.TransformPoint(position),
                         playspaceTransform.rotation * rotation,
                         HandsUtils.DefaultHandJointRadius);

--- a/org.mixedrealitytoolkit.input/Subsystems/Hands/XRSDKHandsSubsystem.cs
+++ b/org.mixedrealitytoolkit.input/Subsystems/Hands/XRSDKHandsSubsystem.cs
@@ -262,7 +262,7 @@ namespace MixedReality.Toolkit.Input
                     HandJoints[HandsUtils.ConvertToIndex(jointID)] = new HandJointPose(
                         playspaceTransform.TransformPoint(position),
                         playspaceTransform.rotation * rotation,
-                        0.005f);
+                        HandsUtils.DefaultHandJointRadius);
 
                     return true;
                 }

--- a/org.mixedrealitytoolkit.input/Subsystems/HandsAggregator/MRTKHandsAggregatorSubsystem.cs
+++ b/org.mixedrealitytoolkit.input/Subsystems/HandsAggregator/MRTKHandsAggregatorSubsystem.cs
@@ -119,7 +119,7 @@ namespace MixedReality.Toolkit.Input
                         foreach (var sys in handsSubsystems)
                         {
                             // Don't scrape subsystems that aren't running.
-                            if (sys.running == false) { continue; }
+                            if (!sys.running) { continue; }
 
                             if (sys.TryGetJoint(joint, HandNode, out HandJointPose data))
                             {

--- a/org.mixedrealitytoolkit.input/package.json
+++ b/org.mixedrealitytoolkit.input/package.json
@@ -1,6 +1,6 @@
 {
   "name": "org.mixedrealitytoolkit.input",
-  "version": "3.0.0-development",
+  "version": "3.0.1-development",
   "description": "This package contains custom interactors and controllers that build on the foundation established by Unity's XR Interaction Toolkit. In addition, it contains hand joint aggregation and simulation subsystems, which allows for a single API for both real, device-driven hands and simulated hands. \n\nThe vast majority of actual input processing is not done by this package; instead, MRTK builds on the input data and interaction fundamentals already provided by the Unity Input System and XR Interaction Toolkit. \n\nWhen using MRTK Input in a project, it is not strictly necessary to have your package take a dependency on MRTK Input; the custom interactors in this package are fully compatible with the vanilla XRI APIs, and will both parse and generate all the same events and interactions that other XRI interactors will.",
   "displayName": "MRTK Input",
   "msftFeatureCategory": "MRTK3",
@@ -16,7 +16,7 @@
   "unity": "2021.3",
   "dependencies": {
     "com.microsoft.mrtk.graphicstools.unity": "0.5.12",
-    "org.mixedrealitytoolkit.core": "3.0.0",
+    "org.mixedrealitytoolkit.core": "3.0.1",
     "com.unity.inputsystem": "1.6.1",
     "com.unity.xr.arfoundation": "5.0.5",
     "com.unity.xr.interaction.toolkit": "2.3.0",

--- a/org.mixedrealitytoolkit.input/package.json
+++ b/org.mixedrealitytoolkit.input/package.json
@@ -16,7 +16,7 @@
   "unity": "2021.3",
   "dependencies": {
     "com.microsoft.mrtk.graphicstools.unity": "0.5.12",
-    "org.mixedrealitytoolkit.core": "3.0.1",
+    "org.mixedrealitytoolkit.core": "3.0.2",
     "com.unity.inputsystem": "1.6.1",
     "com.unity.xr.arfoundation": "5.0.5",
     "com.unity.xr.interaction.toolkit": "2.3.0",


### PR DESCRIPTION
First step of https://github.com/MixedRealityToolkit/MixedRealityToolkit-Unity/issues/66, to reduce the boilerplate code needed to spin up a new hands provider.

Also refactors out `DefaultHandJointRadius`, as `0.005f` was used in a couple places.

Also, some assorted formatting and slight perf updates.