### PR TITLE
Unity XR Hands provider

### DIFF
--- a/DEPENDS.md
+++ b/DEPENDS.md
@@ -78,6 +78,14 @@ Required by org.mixedrealitytoolkit.core, and org.mixedrealitytoolkit.input.
 |-------------|-------------|---------------|-----------------|--------------------------------------|
 | 2.1.0       |             | Sep. 20, 2023 | @AMollis        | Initial version                      |
 
+## com.unity.xr.hands
+
+Required by org.mixedrealitytoolkit.input.
+
+| Min Version | Max Version | Date          | Author          | Change Reason                           |
+|-------------|-------------|---------------|-----------------|-----------------------------------------|
+| 1.3.0       |             | Oct. 6, 2023  | @keveleigh      | Added support for Unity's XR Hands API. |
+
 ## com.unity.xr.interaction.toolkit
 
 Required by org.mixedrealitytoolkit.core, org.mixedrealitytoolkit.input, org.mixedrealitytoolkit.spatialmanipulation, org.mixedrealitytoolkit.uxcomponents, and org.mixedrealitytoolkit.uxcore.

--- a/UnityProjects/MRTKDevTemplate/Assets/XR/Settings/OpenXR Package Settings.asset
+++ b/UnityProjects/MRTKDevTemplate/Assets/XR/Settings/OpenXR Package Settings.asset
@@ -120,6 +120,26 @@ MonoBehaviour:
   company: Microsoft
   priority: 0
   required: 0
+--- !u!114 &-6535441690950590841
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e314dfef9af0904e80129bcc0a79361, type: 3}
+  m_Name: HandTracking WSA
+  m_EditorClassIdentifier: 
+  m_enabled: 0
+  nameUi: Hand Tracking Subsystem
+  version: 0.0.1
+  featureIdInternal: com.unity.openxr.feature.input.handtracking
+  openxrExtensionStrings: XR_EXT_hand_tracking
+  company: Unity
+  priority: -100
+  required: 0
 --- !u!114 &-6365806483391335959
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -181,6 +201,26 @@ MonoBehaviour:
   priority: 0
   required: 0
   ignoreValidationErrors: 0
+--- !u!114 &-6284616687731864893
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b3aced3429e5911458f4da2dac9d0f29, type: 3}
+  m_Name: MetaHandTrackingAim Android
+  m_EditorClassIdentifier: 
+  m_enabled: 0
+  nameUi: Meta Hand Tracking Aim
+  version: 0.0.1
+  featureIdInternal: com.unity.openxr.feature.input.metahandtrackingaim
+  openxrExtensionStrings: XR_FB_hand_tracking_aim
+  company: Unity
+  priority: 0
+  required: 0
 --- !u!114 &-6240091031804019219
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -218,6 +258,26 @@ MonoBehaviour:
   version: 0.0.1
   featureIdInternal: com.unity.openxr.feature.input.metaquestpro
   openxrExtensionStrings: XR_FB_touch_controller_pro
+  company: Unity
+  priority: 0
+  required: 0
+--- !u!114 &-5297537421338403838
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b3aced3429e5911458f4da2dac9d0f29, type: 3}
+  m_Name: MetaHandTrackingAim Standalone
+  m_EditorClassIdentifier: 
+  m_enabled: 0
+  nameUi: Meta Hand Tracking Aim
+  version: 0.0.1
+  featureIdInternal: com.unity.openxr.feature.input.metahandtrackingaim
+  openxrExtensionStrings: XR_FB_hand_tracking_aim
   company: Unity
   priority: 0
   required: 0
@@ -327,6 +387,7 @@ MonoBehaviour:
   - {fileID: -6365806483391335959}
   - {fileID: 2345388348882096190}
   - {fileID: -4980378866309187382}
+  - {fileID: -6535441690950590841}
   - {fileID: -4740256116611402092}
   - {fileID: 8809846650566260409}
   - {fileID: 8830336202024584476}
@@ -363,6 +424,46 @@ MonoBehaviour:
   required: 0
   cacheSize: 1048576
   perThreadCacheSize: 51200
+--- !u!114 &-3540660573686832417
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e314dfef9af0904e80129bcc0a79361, type: 3}
+  m_Name: HandTracking Android
+  m_EditorClassIdentifier: 
+  m_enabled: 1
+  nameUi: Hand Tracking Subsystem
+  version: 0.0.1
+  featureIdInternal: com.unity.openxr.feature.input.handtracking
+  openxrExtensionStrings: XR_EXT_hand_tracking
+  company: Unity
+  priority: -100
+  required: 0
+--- !u!114 &-3267254719211769934
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e314dfef9af0904e80129bcc0a79361, type: 3}
+  m_Name: HandTracking Standalone
+  m_EditorClassIdentifier: 
+  m_enabled: 1
+  nameUi: Hand Tracking Subsystem
+  version: 0.0.1
+  featureIdInternal: com.unity.openxr.feature.input.handtracking
+  openxrExtensionStrings: XR_EXT_hand_tracking
+  company: Unity
+  priority: -100
+  required: 0
 --- !u!114 &-2659505044388052374
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -508,8 +609,10 @@ MonoBehaviour:
   features:
   - {fileID: 5800620048986908060}
   - {fileID: 474827142986614695}
+  - {fileID: -3540660573686832417}
   - {fileID: 5420324578598372024}
   - {fileID: -4630134788987129440}
+  - {fileID: -6284616687731864893}
   - {fileID: 559627786289991748}
   - {fileID: 2700408812308480614}
   - {fileID: 8477975974732598692}
@@ -519,7 +622,7 @@ MonoBehaviour:
   - {fileID: 7949034004747903996}
   - {fileID: -4085893827450681117}
   m_renderMode: 1
-  m_depthSubmissionMode: 0
+  m_depthSubmissionMode: 1
 --- !u!114 &2140832713855989735
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -563,10 +666,12 @@ MonoBehaviour:
   - {fileID: -8136130855646488046}
   - {fileID: -6240091031804019219}
   - {fileID: 7857441528894569134}
+  - {fileID: -3267254719211769934}
   - {fileID: 4294374462335302092}
   - {fileID: -7104108163923222141}
   - {fileID: -2659505044388052374}
   - {fileID: 4938325070181230207}
+  - {fileID: -5297537421338403838}
   - {fileID: 6102079508090334006}
   - {fileID: 4835167900761102818}
   - {fileID: -7321926629275167846}
@@ -736,7 +841,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c79c911b38743a649b1c1eddb5097202, type: 3}
   m_Name: HandTrackingFeaturePlugin Standalone
   m_EditorClassIdentifier: 
-  m_enabled: 0
+  m_enabled: 1
   nameUi: Hand Tracking
   version: 1.7.0
   featureIdInternal: com.microsoft.openxr.feature.handtracking
@@ -801,7 +906,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c79c911b38743a649b1c1eddb5097202, type: 3}
   m_Name: HandTrackingFeaturePlugin Android
   m_EditorClassIdentifier: 
-  m_enabled: 0
+  m_enabled: 1
   nameUi: Hand Tracking
   version: 1.7.0
   featureIdInternal: com.microsoft.openxr.feature.handtracking

--- a/UnityProjects/MRTKDevTemplate/Packages/packages-lock.json
+++ b/UnityProjects/MRTKDevTemplate/Packages/packages-lock.json
@@ -233,6 +233,18 @@
       },
       "url": "https://packages.unity.com"
     },
+    "com.unity.xr.hands": {
+      "version": "1.3.0",
+      "depth": 1,
+      "source": "registry",
+      "dependencies": {
+        "com.unity.inputsystem": "1.3.0",
+        "com.unity.modules.xr": "1.0.0",
+        "com.unity.xr.core-utils": "2.2.0",
+        "com.unity.xr.management": "4.0.1"
+      },
+      "url": "https://packages.unity.com"
+    },
     "com.unity.xr.interaction.toolkit": {
       "version": "2.3.0",
       "depth": 0,
@@ -344,11 +356,12 @@
       "source": "local",
       "dependencies": {
         "com.microsoft.mrtk.graphicstools.unity": "0.5.12",
-        "org.mixedrealitytoolkit.core": "3.0.2",
         "com.unity.inputsystem": "1.6.1",
         "com.unity.xr.arfoundation": "5.0.5",
+        "com.unity.xr.core-utils": "2.1.0",
+        "com.unity.xr.hands": "1.3.0",
         "com.unity.xr.interaction.toolkit": "2.3.0",
-        "com.unity.xr.core-utils": "2.1.0"
+        "org.mixedrealitytoolkit.core": "3.0.2"
       }
     },
     "org.mixedrealitytoolkit.spatialmanipulation": {

--- a/org.mixedrealitytoolkit.input/MRTK.Input.asmdef
+++ b/org.mixedrealitytoolkit.input/MRTK.Input.asmdef
@@ -2,14 +2,14 @@
     "name": "MixedReality.Toolkit.Input",
     "rootNamespace": "MixedReality.Toolkit.Input",
     "references": [
+        "glTFast",
         "Microsoft.MixedReality.OpenXR",
         "MixedReality.Toolkit.Core",
         "Unity.InputSystem",
         "Unity.XR.CoreUtils",
+        "Unity.XR.Hands",
         "Unity.XR.Interaction.Toolkit",
-        "Unity.XR.Management",
-        "glTFast",
-        "Ktx"
+        "Unity.XR.Management"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/org.mixedrealitytoolkit.input/Subsystems/Hands/OpenXRHandsSubsystem.cs
+++ b/org.mixedrealitytoolkit.input/Subsystems/Hands/OpenXRHandsSubsystem.cs
@@ -131,7 +131,7 @@ namespace MixedReality.Toolkit.Input
 
             /// <summary>
             /// For a certain hand, query every Bone in the hand, and write all results to the
-            /// HandJoints collection. This will also mark handsQueriedThisFrame[handNode] = true.
+            /// HandJoints collection.
             /// </summary>
             private void TryCalculateEntireHand()
             {
@@ -172,7 +172,7 @@ namespace MixedReality.Toolkit.Input
                 new ProfilerMarker("[MRTK] OpenXRHandContainer.UpdateJoint");
 
             /// <summary>
-            /// Given a destination jointID, apply the Bone info to the correct struct
+            /// Given a destination jointIndex, apply the HandJointLocation info to the correct struct
             /// in the HandJoints collection.
             /// </summary>
             private void UpdateJoint(int jointIndex, in HandJointLocation handJointLocation, Transform playspaceTransform)

--- a/org.mixedrealitytoolkit.input/Subsystems/Hands/OpenXRHandsSubsystem.cs
+++ b/org.mixedrealitytoolkit.input/Subsystems/Hands/OpenXRHandsSubsystem.cs
@@ -15,7 +15,7 @@ using UnityEngine.XR;
 namespace MixedReality.Toolkit.Input
 {
     /// <summary>
-    /// A Unity subsystem that extends <see cref="MixedReality.Toolkit.Subsystems.HandsSubsystem">HandsSubsystem</see>, and 
+    /// A Unity subsystem that extends <see cref="MixedReality.Toolkit.Subsystems.HandsSubsystem">HandsSubsystem</see> and
     /// obtains hand joint poses from the Microsoft.MixedReality.OpenXR.HandTracker class.
     /// </summary>
 #if MROPENXR_PRESENT && (UNITY_EDITOR_WIN || UNITY_WSA || UNITY_STANDALONE_WIN || UNITY_ANDROID)

--- a/org.mixedrealitytoolkit.input/Subsystems/Hands/UnityHandsSubsystem.cs
+++ b/org.mixedrealitytoolkit.input/Subsystems/Hands/UnityHandsSubsystem.cs
@@ -13,8 +13,8 @@ namespace MixedReality.Toolkit.Input
 {
     [Preserve]
     [MRTKSubsystem(
-        Name = "org.mixedrealitytoolkit.unityhands",
-        DisplayName = "Subsystem for Unity Hands API",
+        Name = "org.mixedrealitytoolkit.unityxrhands",
+        DisplayName = "Subsystem for Unity XR Hands API",
         Author = "Mixed Reality Toolkit Contributors",
         ProviderType = typeof(HandsProvider<UnityHandContainer>),
         SubsystemTypeOverride = typeof(UnityHandsSubsystem),

--- a/org.mixedrealitytoolkit.input/Subsystems/Hands/UnityHandsSubsystem.cs
+++ b/org.mixedrealitytoolkit.input/Subsystems/Hands/UnityHandsSubsystem.cs
@@ -118,7 +118,7 @@ namespace MixedReality.Toolkit.Input
 
             /// <summary/>
             /// For a certain hand, query every Bone in the hand, and write all results to the
-            /// handJoints collection. This will also mark handsQueriedThisFrame[handNode] = true.
+            /// HandJoints collection.
             /// </summary>
             private void TryCalculateEntireHand()
             {
@@ -162,8 +162,8 @@ namespace MixedReality.Toolkit.Input
                 new ProfilerMarker("[MRTK] UnityHandContainer.TryUpdateJoint");
 
             /// <summary/>
-            /// Given a destination jointID, apply the Bone info to the correct struct
-            /// in the handJoints collection.
+            /// Given a destination jointIndex, apply the pose and radius to the correct struct
+            /// in the HandJoints collection.
             /// </summary>
             private bool TryUpdateJoint(int jointIndex, XRHandJoint xrHandJoint, Transform playspaceTransform)
             {
@@ -195,7 +195,7 @@ namespace MixedReality.Toolkit.Input
 
             /// <summary>
             /// Obtains a reference to the actual XRHand object representing the tracked hand
-            /// functionality present on HandNode. Returns null if no Hand reference available.
+            /// functionality present on HandNode. Returns null if no XRHand reference is available.
             /// </summary>
             private XRHand? GetTrackedHand()
             {
@@ -217,6 +217,10 @@ namespace MixedReality.Toolkit.Input
                 }
             }
 
+            /// <summary>
+            /// Cached mapping of <see cref="MixedReality.Toolkit.TrackedHandJoint"/> index to <see cref="UnityEngine.XR.Hands.XRHandJointID"/>
+            /// to ease calculation each frame, since the mapping doesn't change.
+            /// </summary>
             private static readonly XRHandJointID[] TrackedHandJointIndexToXRHandJointID = new XRHandJointID[]
             {
                 XRHandJointID.Palm,

--- a/org.mixedrealitytoolkit.input/Subsystems/Hands/UnityHandsSubsystem.cs
+++ b/org.mixedrealitytoolkit.input/Subsystems/Hands/UnityHandsSubsystem.cs
@@ -1,7 +1,7 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Copyright (c) Mixed Reality Toolkit Contributors
+// Licensed under the BSD 3-Clause
 
-using Microsoft.MixedReality.Toolkit.Subsystems;
+using MixedReality.Toolkit.Subsystems;
 using System.Collections.Generic;
 using Unity.Profiling;
 using UnityEngine;
@@ -9,13 +9,13 @@ using UnityEngine.Scripting;
 using UnityEngine.XR;
 using UnityEngine.XR.Hands;
 
-namespace Microsoft.MixedReality.Toolkit.Input
+namespace MixedReality.Toolkit.Input
 {
     [Preserve]
     [MRTKSubsystem(
-        Name = "com.qualcomm.mixedreality.unityhands",
+        Name = "org.mixedrealitytoolkit.unityhands",
         DisplayName = "Subsystem for Unity Hands API",
-        Author = "Qualcomm",
+        Author = "Mixed Reality Toolkit Contributors",
         ProviderType = typeof(HandsProvider<UnityHandContainer>),
         SubsystemTypeOverride = typeof(UnityHandsSubsystem),
         ConfigType = typeof(BaseSubsystemConfig))]
@@ -59,7 +59,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
                         TryCalculateEntireHand();
                     }
 
-                    result = handJoints;
+                    result = HandJoints;
                     return FullQueryValid;
                 }
             }
@@ -87,7 +87,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
                         // and return immediately.
                         if (!hand.HasValue)
                         {
-                            pose = handJoints[index];
+                            pose = HandJoints[index];
                             return false;
                         }
 
@@ -95,7 +95,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
                         Transform origin = PlayspaceUtilities.XROrigin.CameraFloorOffsetObject.transform;
                         if (origin == null)
                         {
-                            pose = handJoints[index];
+                            pose = HandJoints[index];
                             return false;
                         }
 
@@ -108,7 +108,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
                         thisQueryValid = FullQueryValid;
                     }
 
-                    pose = handJoints[index];
+                    pose = HandJoints[index];
                     return thisQueryValid;
                 }
             }
@@ -208,7 +208,7 @@ namespace Microsoft.MixedReality.Toolkit.Input
                         radius = HandsUtils.DefaultHandJointRadius;
                     }
 
-                    handJoints[jointIndex] = new HandJointPose(
+                    HandJoints[jointIndex] = new HandJointPose(
                         playspaceTransform.TransformPoint(pose.position),
                         playspaceTransform.rotation * pose.rotation,
                         radius);

--- a/org.mixedrealitytoolkit.input/Subsystems/Hands/UnityHandsSubsystem.cs
+++ b/org.mixedrealitytoolkit.input/Subsystems/Hands/UnityHandsSubsystem.cs
@@ -1,0 +1,256 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Microsoft.MixedReality.Toolkit.Subsystems;
+using System.Collections.Generic;
+using Unity.Profiling;
+using UnityEngine;
+using UnityEngine.Scripting;
+using UnityEngine.XR;
+using UnityEngine.XR.Hands;
+
+namespace Microsoft.MixedReality.Toolkit.Input
+{
+    [Preserve]
+    [MRTKSubsystem(
+        Name = "com.qualcomm.mixedreality.unityhands",
+        DisplayName = "Subsystem for Unity Hands API",
+        Author = "Qualcomm",
+        ProviderType = typeof(HandsProvider<UnityHandContainer>),
+        SubsystemTypeOverride = typeof(UnityHandsSubsystem),
+        ConfigType = typeof(BaseSubsystemConfig))]
+    public class UnityHandsSubsystem : HandsSubsystem
+    {
+        [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.SubsystemRegistration)]
+        private static void Register()
+        {
+            // Fetch subsystem metadata from the attribute.
+            var cinfo = XRSubsystemHelpers.ConstructCinfo<UnityHandsSubsystem, HandsSubsystemCinfo>();
+
+            // Populate remaining cinfo field.
+            cinfo.IsPhysicalData = true;
+
+            if (!Register(cinfo))
+            {
+                Debug.LogError($"Failed to register the {cinfo.Name} subsystem.");
+            }
+        }
+
+        private class UnityHandContainer : HandDataContainer
+        {
+            private XRHand? hand;
+            private XRHandSubsystem xrHandSubsystem;
+
+            public UnityHandContainer(XRNode handNode) : base(handNode)
+            {
+                hand = GetTrackedHand();
+            }
+
+            private static readonly ProfilerMarker TryGetEntireHandPerfMarker =
+                new ProfilerMarker("[MRTK] UnityHandContainer.TryGetEntireHand");
+
+            /// <inheritdoc/>
+            public override bool TryGetEntireHand(out IReadOnlyList<HandJointPose> result)
+            {
+                using (TryGetEntireHandPerfMarker.Auto())
+                {
+                    if (!AlreadyFullQueried)
+                    {
+                        TryCalculateEntireHand();
+                    }
+
+                    result = handJoints;
+                    return FullQueryValid;
+                }
+            }
+
+            private static readonly ProfilerMarker TryGetJointPerfMarker =
+                new ProfilerMarker("[MRTK] UnityHandContainer.TryGetJoint");
+
+            /// <inheritdoc/>
+            public override bool TryGetJoint(TrackedHandJoint joint, out HandJointPose pose)
+            {
+                using (TryGetJointPerfMarker.Auto())
+                {
+                    bool thisQueryValid = false;
+                    int index = HandsUtils.ConvertToIndex(joint);
+
+                    // If we happened to have already queried the entire
+                    // hand data this frame, we don't need to re-query for
+                    // just the joint. If we haven't, we do still need to
+                    // query for the single joint.
+                    if (!AlreadyFullQueried)
+                    {
+                        hand = GetTrackedHand();
+
+                        // If the tracked hand is null, we obviously have no data,
+                        // and return immediately.
+                        if (!hand.HasValue)
+                        {
+                            pose = handJoints[index];
+                            return false;
+                        }
+
+                        // Joints are relative to the camera floor offset object.
+                        Transform origin = PlayspaceUtilities.XROrigin.CameraFloorOffsetObject.transform;
+                        if (origin == null)
+                        {
+                            pose = handJoints[index];
+                            return false;
+                        }
+
+                        thisQueryValid |= TryUpdateJoint(index, hand.Value.GetJoint(TrackedHandJointIndexToXRHandJointID[index]), origin);
+                    }
+                    else
+                    {
+                        // If we've already run a full-hand query, this single joint query
+                        // is just as valid as the full query.
+                        thisQueryValid = FullQueryValid;
+                    }
+
+                    pose = handJoints[index];
+                    return thisQueryValid;
+                }
+            }
+
+            private static readonly ProfilerMarker GetTrackedHandPerfMarker =
+                new ProfilerMarker("[MRTK] UnityHandContainer.GetTrackedHand");
+
+            /// <summary>
+            /// Obtains a reference to the actual Hand object representing the tracked hand
+            /// functionality present on handNode. Returns null if no Hand reference available.
+            /// </summary>
+            private XRHand? GetTrackedHand()
+            {
+                using (GetTrackedHandPerfMarker.Auto())
+                {
+                    if (xrHandSubsystem == null || !xrHandSubsystem.running)
+                    {
+                        xrHandSubsystem = XRSubsystemHelpers.GetFirstRunningSubsystem<XRHandSubsystem>();
+
+                        if (xrHandSubsystem == null)
+                        {
+                            // No hand subsystem running this frame.
+                            return null;
+                        }
+                    }
+
+                    XRHand hand = HandNode == XRNode.LeftHand ? xrHandSubsystem.leftHand : xrHandSubsystem.rightHand;
+                    return hand.isTracked ? hand : null;
+                }
+            }
+
+            private static readonly ProfilerMarker TryCalculateEntireHandPerfMarker =
+                new ProfilerMarker("[MRTK] UnityHandContainer.TryCalculateEntireHand");
+
+            /// <summary/>
+            /// For a certain hand, query every Bone in the hand, and write all results to the
+            /// handJoints collection. This will also mark handsQueriedThisFrame[handNode] = true.
+            /// </summary>
+            private void TryCalculateEntireHand()
+            {
+                using (TryCalculateEntireHandPerfMarker.Auto())
+                {
+                    hand = GetTrackedHand();
+
+                    if (!hand.HasValue)
+                    {
+                        // No articulated hand device available this frame.
+                        FullQueryValid = false;
+                        AlreadyFullQueried = true;
+                        return;
+                    }
+
+                    // Null checks against Unity objects can be expensive, especially when you do
+                    // it 52 times per frame (26 hand joints across 2 hands). Instead, we manage
+                    // the playspace transformation internally for hand joints.
+                    // Joints are relative to the camera floor offset object.
+                    Transform origin = PlayspaceUtilities.XROrigin.CameraFloorOffsetObject.transform;
+                    if (origin == null)
+                    {
+                        return;
+                    }
+
+                    FullQueryValid = true;
+
+                    for (int i = 0; i < (int)TrackedHandJoint.TotalJoints; i++)
+                    {
+                        FullQueryValid &= TryUpdateJoint(i, hand.Value.GetJoint(TrackedHandJointIndexToXRHandJointID[i]), origin);
+                    }
+
+                    // Mark this hand as having been fully queried this frame.
+                    // If any joint is queried again this frame, we'll reuse the
+                    // information to avoid extra work.
+                    AlreadyFullQueried = true;
+                }
+            }
+
+            private static readonly ProfilerMarker TryUpdateJointPerfMarker =
+                new ProfilerMarker("[MRTK] UnityHandContainer.TryUpdateJoint");
+
+            /// <summary/>
+            /// Given a destination jointID, apply the Bone info to the correct struct
+            /// in the handJoints collection.
+            /// </summary>
+            private bool TryUpdateJoint(int jointIndex, XRHandJoint xrHandJoint, Transform playspaceTransform)
+            {
+                using (TryUpdateJointPerfMarker.Auto())
+                {
+                    // Not obtaining a pose is a failure state...
+                    if (!xrHandJoint.TryGetPose(out Pose pose))
+                    {
+                        return false;
+                    }
+
+                    // ...but not obtaining a radius has a built-in fallback.
+                    if (!xrHandJoint.TryGetRadius(out float radius))
+                    {
+                        radius = HandsUtils.DefaultHandJointRadius;
+                    }
+
+                    handJoints[jointIndex] = new HandJointPose(
+                        playspaceTransform.TransformPoint(pose.position),
+                        playspaceTransform.rotation * pose.rotation,
+                        radius);
+
+                    return true;
+                }
+            }
+
+            private static readonly XRHandJointID[] TrackedHandJointIndexToXRHandJointID = new XRHandJointID[]
+            {
+                XRHandJointID.Palm,
+                XRHandJointID.Wrist,
+
+                XRHandJointID.ThumbMetacarpal,
+                XRHandJointID.ThumbProximal,
+                XRHandJointID.ThumbDistal,
+                XRHandJointID.ThumbTip,
+
+                XRHandJointID.IndexMetacarpal,
+                XRHandJointID.IndexProximal,
+                XRHandJointID.IndexIntermediate,
+                XRHandJointID.IndexDistal,
+                XRHandJointID.IndexTip,
+
+                XRHandJointID.MiddleMetacarpal,
+                XRHandJointID.MiddleProximal,
+                XRHandJointID.MiddleIntermediate,
+                XRHandJointID.MiddleDistal,
+                XRHandJointID.MiddleTip,
+
+                XRHandJointID.RingMetacarpal,
+                XRHandJointID.RingProximal,
+                XRHandJointID.RingIntermediate,
+                XRHandJointID.RingDistal,
+                XRHandJointID.RingTip,
+
+                XRHandJointID.LittleMetacarpal,
+                XRHandJointID.LittleProximal,
+                XRHandJointID.LittleIntermediate,
+                XRHandJointID.LittleDistal,
+                XRHandJointID.LittleTip,
+            };
+        }
+    }
+}

--- a/org.mixedrealitytoolkit.input/Subsystems/Hands/UnityHandsSubsystem.cs
+++ b/org.mixedrealitytoolkit.input/Subsystems/Hands/UnityHandsSubsystem.cs
@@ -38,7 +38,7 @@ namespace MixedReality.Toolkit.Input
 
         private class UnityHandContainer : HandDataContainer
         {
-            private XRHand? hand;
+            private XRHand hand;
             private XRHandSubsystem xrHandSubsystem;
 
             public UnityHandContainer(XRNode handNode) : base(handNode)
@@ -83,9 +83,9 @@ namespace MixedReality.Toolkit.Input
                     {
                         hand = GetTrackedHand();
 
-                        // If the tracked hand is null, we obviously have no data,
+                        // If the hand is not tracked, we obviously have no data,
                         // and return immediately.
-                        if (!hand.HasValue)
+                        if (!hand.isTracked)
                         {
                             pose = HandJoints[index];
                             return false;
@@ -99,7 +99,7 @@ namespace MixedReality.Toolkit.Input
                             return false;
                         }
 
-                        thisQueryValid |= TryUpdateJoint(index, hand.Value.GetJoint(TrackedHandJointIndexToXRHandJointID[index]), origin);
+                        thisQueryValid |= TryUpdateJoint(index, hand.GetJoint(TrackedHandJointIndexToXRHandJointID[index]), origin);
                     }
                     else
                     {
@@ -126,7 +126,7 @@ namespace MixedReality.Toolkit.Input
                 {
                     hand = GetTrackedHand();
 
-                    if (!hand.HasValue)
+                    if (!hand.isTracked)
                     {
                         // No articulated hand device available this frame.
                         FullQueryValid = false;
@@ -148,7 +148,7 @@ namespace MixedReality.Toolkit.Input
 
                     for (int i = 0; i < (int)TrackedHandJoint.TotalJoints; i++)
                     {
-                        FullQueryValid &= TryUpdateJoint(i, hand.Value.GetJoint(TrackedHandJointIndexToXRHandJointID[i]), origin);
+                        FullQueryValid &= TryUpdateJoint(i, hand.GetJoint(TrackedHandJointIndexToXRHandJointID[i]), origin);
                     }
 
                     // Mark this hand as having been fully queried this frame.
@@ -195,9 +195,9 @@ namespace MixedReality.Toolkit.Input
 
             /// <summary>
             /// Obtains a reference to the actual XRHand object representing the tracked hand
-            /// functionality present on HandNode. Returns null if no XRHand reference is available.
+            /// functionality present on HandNode.
             /// </summary>
-            private XRHand? GetTrackedHand()
+            private XRHand GetTrackedHand()
             {
                 using (GetTrackedHandPerfMarker.Auto())
                 {
@@ -208,12 +208,12 @@ namespace MixedReality.Toolkit.Input
                         if (xrHandSubsystem == null)
                         {
                             // No hand subsystem running this frame.
-                            return null;
+                            return default;
                         }
                     }
 
                     XRHand hand = HandNode == XRNode.LeftHand ? xrHandSubsystem.leftHand : xrHandSubsystem.rightHand;
-                    return hand.isTracked ? hand : null;
+                    return hand;
                 }
             }
 

--- a/org.mixedrealitytoolkit.input/Subsystems/Hands/UnityHandsSubsystem.cs
+++ b/org.mixedrealitytoolkit.input/Subsystems/Hands/UnityHandsSubsystem.cs
@@ -17,8 +17,7 @@ namespace MixedReality.Toolkit.Input
         DisplayName = "Subsystem for Unity XR Hands API",
         Author = "Mixed Reality Toolkit Contributors",
         ProviderType = typeof(HandsProvider<UnityHandContainer>),
-        SubsystemTypeOverride = typeof(UnityHandsSubsystem),
-        ConfigType = typeof(BaseSubsystemConfig))]
+        SubsystemTypeOverride = typeof(UnityHandsSubsystem))]
     public class UnityHandsSubsystem : HandsSubsystem
     {
         [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.SubsystemRegistration)]

--- a/org.mixedrealitytoolkit.input/Subsystems/Hands/UnityHandsSubsystem.cs
+++ b/org.mixedrealitytoolkit.input/Subsystems/Hands/UnityHandsSubsystem.cs
@@ -113,33 +113,6 @@ namespace MixedReality.Toolkit.Input
                 }
             }
 
-            private static readonly ProfilerMarker GetTrackedHandPerfMarker =
-                new ProfilerMarker("[MRTK] UnityHandContainer.GetTrackedHand");
-
-            /// <summary>
-            /// Obtains a reference to the actual Hand object representing the tracked hand
-            /// functionality present on handNode. Returns null if no Hand reference available.
-            /// </summary>
-            private XRHand? GetTrackedHand()
-            {
-                using (GetTrackedHandPerfMarker.Auto())
-                {
-                    if (xrHandSubsystem == null || !xrHandSubsystem.running)
-                    {
-                        xrHandSubsystem = XRSubsystemHelpers.GetFirstRunningSubsystem<XRHandSubsystem>();
-
-                        if (xrHandSubsystem == null)
-                        {
-                            // No hand subsystem running this frame.
-                            return null;
-                        }
-                    }
-
-                    XRHand hand = HandNode == XRNode.LeftHand ? xrHandSubsystem.leftHand : xrHandSubsystem.rightHand;
-                    return hand.isTracked ? hand : null;
-                }
-            }
-
             private static readonly ProfilerMarker TryCalculateEntireHandPerfMarker =
                 new ProfilerMarker("[MRTK] UnityHandContainer.TryCalculateEntireHand");
 
@@ -214,6 +187,33 @@ namespace MixedReality.Toolkit.Input
                         radius);
 
                     return true;
+                }
+            }
+
+            private static readonly ProfilerMarker GetTrackedHandPerfMarker =
+                new ProfilerMarker("[MRTK] UnityHandContainer.GetTrackedHand");
+
+            /// <summary>
+            /// Obtains a reference to the actual XRHand object representing the tracked hand
+            /// functionality present on HandNode. Returns null if no Hand reference available.
+            /// </summary>
+            private XRHand? GetTrackedHand()
+            {
+                using (GetTrackedHandPerfMarker.Auto())
+                {
+                    if (xrHandSubsystem == null || !xrHandSubsystem.running)
+                    {
+                        xrHandSubsystem = XRSubsystemHelpers.GetFirstRunningSubsystem<XRHandSubsystem>();
+
+                        if (xrHandSubsystem == null)
+                        {
+                            // No hand subsystem running this frame.
+                            return null;
+                        }
+                    }
+
+                    XRHand hand = HandNode == XRNode.LeftHand ? xrHandSubsystem.leftHand : xrHandSubsystem.rightHand;
+                    return hand.isTracked ? hand : null;
                 }
             }
 

--- a/org.mixedrealitytoolkit.input/Subsystems/Hands/UnityHandsSubsystem.cs
+++ b/org.mixedrealitytoolkit.input/Subsystems/Hands/UnityHandsSubsystem.cs
@@ -11,6 +11,10 @@ using UnityEngine.XR.Hands;
 
 namespace MixedReality.Toolkit.Input
 {
+    /// <summary>
+    /// A Unity subsystem that extends <see cref="MixedReality.Toolkit.Subsystems.HandsSubsystem">HandsSubsystem</see> and
+    /// obtains hand joint poses from Unity's <see href="https://docs.unity3d.com/Packages/com.unity.xr.hands@1.3">XR Hands package</see>.
+    /// </summary>
     [Preserve]
     [MRTKSubsystem(
         Name = "org.mixedrealitytoolkit.unityxrhands",

--- a/org.mixedrealitytoolkit.input/Subsystems/Hands/UnityHandsSubsystem.cs.meta
+++ b/org.mixedrealitytoolkit.input/Subsystems/Hands/UnityHandsSubsystem.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9fff9276cf83ba945a5872b7ad2f370e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/org.mixedrealitytoolkit.input/Subsystems/Hands/XRSDKHandsSubsystem.cs
+++ b/org.mixedrealitytoolkit.input/Subsystems/Hands/XRSDKHandsSubsystem.cs
@@ -14,7 +14,7 @@ namespace MixedReality.Toolkit.Input
 {
     /// <summary>
     /// A Unity subsystem that extends <see cref="MixedReality.Toolkit.Subsystems.HandsSubsystem">HandsSubsystem</see>, and 
-    /// obtains hand joint poses from the Unity Engine's XR <see href="https://docs.unity3d.com/ScriptReference/XR.Hand.html">Hand</see> class.
+    /// obtains hand joint poses from the Unity engine's XR <see href="https://docs.unity3d.com/ScriptReference/XR.Hand.html">Hand</see> class.
     /// </summary>
     [Preserve]
     [MRTKSubsystem(

--- a/org.mixedrealitytoolkit.input/Subsystems/Hands/XRSDKHandsSubsystem.cs
+++ b/org.mixedrealitytoolkit.input/Subsystems/Hands/XRSDKHandsSubsystem.cs
@@ -191,7 +191,7 @@ namespace MixedReality.Toolkit.Input
 
             /// <summary>
             /// For a certain hand, query every Bone in the hand, and write all results to the
-            /// HandJoints collection. This will also mark handsQueriedThisFrame[handNode] = true.
+            /// HandJoints collection.
             /// </summary>
             private void TryCalculateEntireHand()
             {

--- a/org.mixedrealitytoolkit.input/Subsystems/Hands/XRSDKHandsSubsystem.cs
+++ b/org.mixedrealitytoolkit.input/Subsystems/Hands/XRSDKHandsSubsystem.cs
@@ -148,7 +148,7 @@ namespace MixedReality.Toolkit.Input
 
             /// <summary>
             /// Obtains a reference to the actual Hand object representing the tracked hand
-            /// functionality present on handNode. Returns null if no Hand reference available.
+            /// functionality present on HandNode. Returns null if no Hand reference available.
             /// </summary>
             private Hand? GetTrackedHand()
             {

--- a/org.mixedrealitytoolkit.input/Subsystems/SyntheticHands/SyntheticHandsSubsystem.cs
+++ b/org.mixedrealitytoolkit.input/Subsystems/SyntheticHands/SyntheticHandsSubsystem.cs
@@ -276,7 +276,7 @@ namespace MixedReality.Toolkit.Input
 
             /// <summary>
             /// For a certain hand, query every Bone in the hand, and write all results to the
-            /// HandJoints collection. This will also mark handsQueriedThisFrame[handNode] = true.
+            /// HandJoints collection.
             /// </summary>
             private void TryCalculateEntireHand()
             {

--- a/org.mixedrealitytoolkit.input/package.json
+++ b/org.mixedrealitytoolkit.input/package.json
@@ -1,6 +1,6 @@
 {
   "name": "org.mixedrealitytoolkit.input",
-  "version": "3.0.1-development",
+  "version": "3.1.0-development",
   "description": "This package contains custom interactors and controllers that build on the foundation established by Unity's XR Interaction Toolkit. In addition, it contains hand joint aggregation and simulation subsystems, which allows for a single API for both real, device-driven hands and simulated hands. \n\nThe vast majority of actual input processing is not done by this package; instead, MRTK builds on the input data and interaction fundamentals already provided by the Unity Input System and XR Interaction Toolkit. \n\nWhen using MRTK Input in a project, it is not strictly necessary to have your package take a dependency on MRTK Input; the custom interactors in this package are fully compatible with the vanilla XRI APIs, and will both parse and generate all the same events and interactions that other XRI interactors will.",
   "displayName": "MRTK Input",
   "msftFeatureCategory": "MRTK3",

--- a/org.mixedrealitytoolkit.input/package.json
+++ b/org.mixedrealitytoolkit.input/package.json
@@ -16,10 +16,11 @@
   "unity": "2021.3",
   "dependencies": {
     "com.microsoft.mrtk.graphicstools.unity": "0.5.12",
-    "org.mixedrealitytoolkit.core": "3.0.2",
     "com.unity.inputsystem": "1.6.1",
     "com.unity.xr.arfoundation": "5.0.5",
+    "com.unity.xr.core-utils": "2.1.0",
+    "com.unity.xr.hands": "1.3.0",
     "com.unity.xr.interaction.toolkit": "2.3.0",
-    "com.unity.xr.core-utils": "2.1.0"
+    "org.mixedrealitytoolkit.core": "3.0.2"
   }
 }


### PR DESCRIPTION
Next phase of #66: actually creating the hands provider wrapping Unity's XR Hands API.

1. Creates the `HandsSubsystem` implementation wrapping Unity's XR Hands API.
2. As a result, adds Unity's XR Hands package as a hard dependency to the Input package.
3. DOES NOT yet change any MRTK profiles or sample scenes. That will come in the next PR.

Does not complete https://github.com/MixedRealityToolkit/MixedRealityToolkit-Unity/issues/66 but is a major step along to completion.