### PR TITLE
Update SliderSounds to use one AudioSource instead of two (#495)

### DIFF
--- a/UnityProjects/MRTKDevTemplate/Packages/packages-lock.json
+++ b/UnityProjects/MRTKDevTemplate/Packages/packages-lock.json
@@ -384,7 +384,7 @@
       "source": "local",
       "dependencies": {
         "com.microsoft.mrtk.graphicstools.unity": "0.5.12",
-        "org.mixedrealitytoolkit.uxcore": "3.0.0",
+        "org.mixedrealitytoolkit.uxcore": "3.1.0",
         "org.mixedrealitytoolkit.spatialmanipulation": "3.0.0",
         "org.mixedrealitytoolkit.standardassets": "3.0.0",
         "com.unity.xr.interaction.toolkit": "2.3.0"
@@ -395,7 +395,7 @@
       "depth": 0,
       "source": "local",
       "dependencies": {
-        "org.mixedrealitytoolkit.uxcore": "3.0.0",
+        "org.mixedrealitytoolkit.uxcore": "3.1.0",
         "org.mixedrealitytoolkit.spatialmanipulation": "3.0.0",
         "org.mixedrealitytoolkit.standardassets": "3.0.0"
       }

--- a/org.mixedrealitytoolkit.uxcomponents.noncanvas/Slider/NonCanvasSliderBase.prefab
+++ b/org.mixedrealitytoolkit.uxcomponents.noncanvas/Slider/NonCanvasSliderBase.prefab
@@ -154,8 +154,8 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2624031095332604921}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0.000000012922101}
-  m_LocalScale: {x: 0.099999905, y: 0.002, z: 1}
+  m_LocalPosition: {x: -9.313226e-10, y: 0, z: 0}
+  m_LocalScale: {x: 0.1, y: 0.002, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 7661392059221250966}
@@ -300,7 +300,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 4713996577027406645}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0.000000012922101}
+  m_LocalPosition: {x: -9.313226e-10, y: 0, z: 0}
   m_LocalScale: {x: 0.004, y: 0.011999998, z: 0.062525995}
   m_ConstrainProportionsScale: 0
   m_Children:
@@ -334,6 +334,7 @@ GameObject:
   - component: {fileID: 7429095020531837141}
   - component: {fileID: 4552659453827628730}
   - component: {fileID: 5234196699703300340}
+  - component: {fileID: 3522167078609283624}
   m_Layer: 0
   m_Name: NonCanvasSliderBase
   m_TagString: Untagged
@@ -610,6 +611,7 @@ MonoBehaviour:
   startPitch: 0.75
   endPitch: 1.25
   minSecondsBetweenTicks: 0.01
+  audioSource: {fileID: 3522167078609283624}
 --- !u!114 &5234196699703300340
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -653,6 +655,102 @@ MonoBehaviour:
   m_TargetGraphic: {fileID: 0}
   movableAxes: 0
   onMoveDelta: 0.01
+--- !u!82 &3522167078609283624
+AudioSource:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7429095020531837142}
+  m_Enabled: 1
+  serializedVersion: 4
+  OutputAudioMixerGroup: {fileID: 0}
+  m_audioClip: {fileID: 0}
+  m_PlayOnAwake: 1
+  m_Volume: 1
+  m_Pitch: 1
+  Loop: 0
+  Mute: 0
+  Spatialize: 0
+  SpatializePostEffects: 0
+  Priority: 128
+  DopplerLevel: 1
+  MinDistance: 1
+  MaxDistance: 500
+  Pan2D: 0
+  rolloffMode: 0
+  BypassEffects: 0
+  BypassListenerEffects: 0
+  BypassReverbZones: 0
+  rolloffCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 1
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    - serializedVersion: 3
+      time: 1
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  panLevelCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  spreadCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  reverbZoneMixCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 1
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
 --- !u!1001 &4326098741687517490
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/org.mixedrealitytoolkit.uxcomponents.noncanvas/package.json
+++ b/org.mixedrealitytoolkit.uxcomponents.noncanvas/package.json
@@ -1,6 +1,6 @@
 {
   "name": "org.mixedrealitytoolkit.uxcomponents.noncanvas",
-  "version": "3.0.0-development",
+  "version": "3.1.0-development",
   "description": "MRTK non-Canvas UX component library, for building 3D UX without Canvas layout. For most production-grade UI, we recommend the dynamic hybrid Canvas-based UX systems, located in org.mixedrealitytoolkit.uxcomponents. However, in some circumstances, static/non-Canvas UI may offer improved performance and batching, and may be desirable in resource-constrained scenarios.",
   "displayName": "MRTK UX Components (Non-Canvas)",
   "msftFeatureCategory": "MRTK3",
@@ -15,7 +15,7 @@
   },
   "unity": "2021.3",
   "dependencies": {
-    "org.mixedrealitytoolkit.uxcore": "3.0.0",
+    "org.mixedrealitytoolkit.uxcore": "3.1.0",
     "org.mixedrealitytoolkit.spatialmanipulation": "3.0.0",
     "org.mixedrealitytoolkit.standardassets": "3.0.0"
   },

--- a/org.mixedrealitytoolkit.uxcomponents/Slider/CanvasSlider.prefab
+++ b/org.mixedrealitytoolkit.uxcomponents/Slider/CanvasSlider.prefab
@@ -102,6 +102,7 @@ MonoBehaviour:
   _Iridescent_Map_: {fileID: 0}
   _Frequency_: 1.89
   _Vertical_Offset_: 0
+  _Orthographic_Distance_: 400
   _Gradient_Disabled_: 0
   _Gradient_Color_: {r: 1, g: 1, b: 1, a: 1}
   _Top_Left_: {r: 0.90588236, g: 0.64705884, b: 0.9254902, a: 1}
@@ -118,6 +119,8 @@ MonoBehaviour:
   _GridScale: 0.02
   _SrcBlend: 1
   _DstBlend: 0
+  _SrcBlendAlpha: 1
+  _DstBlendAlpha: 1
   _StencilReference: 0
   _StencilComparison: 0
   _StencilOperation: 0
@@ -238,7 +241,7 @@ RectTransform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 5677198132670553563}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0.0000166893}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
@@ -248,7 +251,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0, y: 0}
+  m_AnchoredPosition: {x: -0.000017166138, y: -0.000002861023}
   m_SizeDelta: {x: 6, y: 6}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!65 &1197545758422362387
@@ -331,6 +334,7 @@ GameObject:
   - component: {fileID: 1304092318350955345}
   - component: {fileID: 4480812510405459949}
   - component: {fileID: 5856489340448090782}
+  - component: {fileID: 7149116039216951488}
   m_Layer: 5
   m_Name: CanvasSlider
   m_TagString: Untagged
@@ -615,6 +619,7 @@ MonoBehaviour:
   startPitch: 0.75
   endPitch: 1.25
   minSecondsBetweenTicks: 0.01
+  audioSource: {fileID: 7149116039216951488}
 --- !u!95 &1304092318350955345
 Animator:
   serializedVersion: 5
@@ -738,6 +743,102 @@ MonoBehaviour:
   m_TargetGraphic: {fileID: 0}
   movableAxes: 1
   onMoveDelta: 0.01
+--- !u!82 &7149116039216951488
+AudioSource:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5677198132984834579}
+  m_Enabled: 1
+  serializedVersion: 4
+  OutputAudioMixerGroup: {fileID: 0}
+  m_audioClip: {fileID: 0}
+  m_PlayOnAwake: 1
+  m_Volume: 1
+  m_Pitch: 1
+  Loop: 0
+  Mute: 0
+  Spatialize: 0
+  SpatializePostEffects: 0
+  Priority: 128
+  DopplerLevel: 1
+  MinDistance: 1
+  MaxDistance: 500
+  Pan2D: 0
+  rolloffMode: 0
+  BypassEffects: 0
+  BypassListenerEffects: 0
+  BypassReverbZones: 0
+  rolloffCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 1
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    - serializedVersion: 3
+      time: 1
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  panLevelCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  spreadCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  reverbZoneMixCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 1
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
 --- !u!1 &5677198133136054595
 GameObject:
   m_ObjectHideFlags: 0

--- a/org.mixedrealitytoolkit.uxcomponents/package.json
+++ b/org.mixedrealitytoolkit.uxcomponents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "org.mixedrealitytoolkit.uxcomponents",
-  "version": "3.0.0-development",
+  "version": "3.1.0-development",
   "description": "MRTK UX component library, leveraging RectTransform/Canvas for dynamic layout and presentation. Contains prefabs, visuals, pre-made controls, and everything to get started building 3D user interfaces for mixed reality.",
   "displayName": "MRTK UX Components",
   "msftFeatureCategory": "MRTK3",
@@ -16,7 +16,7 @@
   "unity": "2021.3",
   "dependencies": {
     "com.microsoft.mrtk.graphicstools.unity": "0.5.12",
-    "org.mixedrealitytoolkit.uxcore": "3.0.0",
+    "org.mixedrealitytoolkit.uxcore": "3.1.0",
     "org.mixedrealitytoolkit.spatialmanipulation": "3.0.0",
     "org.mixedrealitytoolkit.standardassets": "3.0.0",
     "com.unity.xr.interaction.toolkit": "2.3.0"


### PR DESCRIPTION
* unify slider audio sources, cache and restore the pitch shift value

* update package versionsto match slidersounds and prefab updates

* reserialize packages-lock with 2021.3.21f1

* remodify/serialize prefabs with 2021.3.21f1

* Update org.mixedrealitytoolkit.uxcore/Slider/SliderSounds.cs




* pr feedback: code improvements

---------