### PR TITLE
Fixing the clear color on MRTK's default rig (should be clearing with a 0 alpha)

### DIFF
--- a/org.mixedrealitytoolkit.input/Assets/Prefabs/MRTK XR Rig.prefab
+++ b/org.mixedrealitytoolkit.input/Assets/Prefabs/MRTK XR Rig.prefab
@@ -235,7 +235,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   opaqueDisplay:
     clearMode: 1
-    clearColor: {r: 0, g: 0, b: 0, a: 1}
+    clearColor: {r: 0, g: 0, b: 0, a: 0}
     nearPlaneDistance: 0.1
     farPlaneDistance: 1000
     adjustTrackingOrigin: 1
@@ -243,7 +243,7 @@ MonoBehaviour:
     qualityLevel: 5
   transparentDisplay:
     clearMode: 2
-    clearColor: {r: 0, g: 0, b: 0, a: 1}
+    clearColor: {r: 0, g: 0, b: 0, a: 0}
     nearPlaneDistance: 0.1
     farPlaneDistance: 50
     adjustTrackingOrigin: 1


### PR DESCRIPTION
A camera clear color with an alpha value of non-zero will show-up on HoloLens's Mixed Reality Capture videos.

Fixes:

- https://github.com/MixedRealityToolkit/MixedRealityToolkit-Unity/issues/497