### PR TITLE
Adding Rigidbody MovementType to ObjectManipulator

### DIFF
--- a/org.mixedrealitytoolkit.spatialmanipulation/Editor/ObjectManipulator/ObjectManipulatorEditor.cs
+++ b/org.mixedrealitytoolkit.spatialmanipulation/Editor/ObjectManipulator/ObjectManipulatorEditor.cs
@@ -4,6 +4,7 @@
 using MixedReality.Toolkit.Editor;
 using UnityEditor;
 using UnityEngine;
+using UnityEngine.XR.Interaction.Toolkit;
 
 namespace MixedReality.Toolkit.SpatialManipulation.Editor
 {
@@ -31,6 +32,7 @@ namespace MixedReality.Toolkit.SpatialManipulation.Editor
         private SerializedProperty manipulationLogicTypes;
 
         private SerializedProperty releaseBehavior;
+        private SerializedProperty rigidbodyMovementType;
 
         private SerializedProperty transformSmoothingLogicType;
         private SerializedProperty smoothingFar;
@@ -72,6 +74,7 @@ namespace MixedReality.Toolkit.SpatialManipulation.Editor
 
             // Physics
             releaseBehavior = serializedObject.FindProperty("releaseBehavior");
+            rigidbodyMovementType = serializedObject.FindProperty("rigidbodyMovementType");
             applyTorque = serializedObject.FindProperty("applyTorque");
             springForceSoftness = serializedObject.FindProperty("springForceSoftness");
             springTorqueSoftness = serializedObject.FindProperty("springTorqueSoftness");
@@ -119,6 +122,7 @@ namespace MixedReality.Toolkit.SpatialManipulation.Editor
 
             ObjectManipulator objectManipulator = (ObjectManipulator)target;
             Rigidbody rb = objectManipulator.HostTransform.GetComponent<Rigidbody>();
+            XRBaseInteractable.MovementType rbMovementType = objectManipulator.RigidbodyMovementType;
 
             constraintsFoldout = ConstraintManagerEditor.DrawConstraintManagerFoldout(objectManipulator.gameObject,
                                                                                         enableConstraints,
@@ -129,14 +133,21 @@ namespace MixedReality.Toolkit.SpatialManipulation.Editor
 
             if (physicsFoldout)
             {
-                if (rb != null && !rb.isKinematic)
+                if (rb != null)
                 {
-                    EditorGUILayout.PropertyField(releaseBehavior);
-                    EditorGUILayout.PropertyField(applyTorque);
-                    EditorGUILayout.PropertyField(springForceSoftness);
-                    EditorGUILayout.PropertyField(springTorqueSoftness);
-                    EditorGUILayout.PropertyField(springDamping);
-                    EditorGUILayout.PropertyField(springForceLimit);
+                    if (!rb.isKinematic)
+                    {
+                        EditorGUILayout.PropertyField(releaseBehavior);
+                    }
+                    EditorGUILayout.PropertyField(rigidbodyMovementType);
+                    if (rbMovementType == XRBaseInteractable.MovementType.VelocityTracking)
+                    {
+                        EditorGUILayout.PropertyField(applyTorque);
+                        EditorGUILayout.PropertyField(springForceSoftness);
+                        EditorGUILayout.PropertyField(springTorqueSoftness);
+                        EditorGUILayout.PropertyField(springDamping);
+                        EditorGUILayout.PropertyField(springForceLimit);
+                    }
                 }
                 else
                 {
@@ -148,7 +159,7 @@ namespace MixedReality.Toolkit.SpatialManipulation.Editor
 
             if (smoothingFoldout)
             {
-                if (rb == null || rb.isKinematic)
+                if (rb == null || rbMovementType != XRBaseInteractable.MovementType.VelocityTracking)
                 {
                     EditorGUILayout.PropertyField(moveLerpTime);
                     EditorGUILayout.PropertyField(rotateLerpTime);

--- a/org.mixedrealitytoolkit.spatialmanipulation/package.json
+++ b/org.mixedrealitytoolkit.spatialmanipulation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "org.mixedrealitytoolkit.spatialmanipulation",
-  "version": "3.0.1-development",
+  "version": "3.1.0-development",
   "description": "Spatial manipulation features, including ObjectManipulator, BoundsControl, and the Solvers/Constraints systems.",
   "displayName": "MRTK Spatial Manipulation",
   "msftFeatureCategory": "MRTK3",


### PR DESCRIPTION
This adds XRI's XRBaseInteractable.MovementType to ObjectManipulator so devs can specify the movement type of the rigid body during manipulation.

Currently the behavior always forces non-kinematic "Velocity Tracking" when a rigid body is attached, setting velocity and angular velocity to move the rigid body.  This would allow the dev to specify other types of movement, like kinematic, as is provided in XRI.  This also observes the XRBaseInteractor.selectedInteractableMovementTypeOverride when an interactor overrides the movement type.

Resolves:  #532 

Related to being more compatible with XRI #67 