### PR TITLE
Fix improper list item rotation in VirtualizedScrollRectList (#534)

### DIFF
--- a/org.mixedrealitytoolkit.uxcore/Experimental/List/VirtualizedScrollRectList.cs
+++ b/org.mixedrealitytoolkit.uxcore/Experimental/List/VirtualizedScrollRectList.cs
@@ -411,7 +411,7 @@ namespace MixedReality.Toolkit.UX.Experimental
             int poolSize = screenCount + layoutRowsOrColumns;
             for (int i = 0; i < poolSize; i++)
             {
-                GameObject go = Instantiate(prefab, ItemLocation(-(i + 1)), Quaternion.identity, scrollRect.content);
+                GameObject go = Instantiate(prefab, ItemLocation(-(i + 1)), scrollRect.content.rotation, scrollRect.content);
                 pool.Enqueue(go);
             }
         }

--- a/org.mixedrealitytoolkit.uxcore/package.json
+++ b/org.mixedrealitytoolkit.uxcore/package.json
@@ -1,6 +1,6 @@
 {
   "name": "org.mixedrealitytoolkit.uxcore",
-  "version": "3.1.0-development",
+  "version": "3.1.1-development",
   "description": "Core interaction and visualization scripts for building MR user interface components.\n\nNote: this is intended to be consumed in order to build UX libraries. To build MR interfaces with a pre-existing library of components, see org.mixedrealitytoolkit.uxcomponents.",
   "displayName": "MRTK UX Core Scripts",
   "msftFeatureCategory": "MRTK3",


### PR DESCRIPTION
Add fix for #534 

When using the VirtualizedScrollRectList, the pool item prefabs are spawned as children of scrollRect.content with an initial rotation of Quaternion.identity. If the ScollRect or content are rotated, this will spawn the pool items at an angle to the ScrollRect whereas the desired behaviour is probably to spawn them aligned.

This fix instantiates the list items with the parent's rotation.