### PR TITLE
Fix Canvas Slider Handle Positioning and Impose MinMax Limits to Slider Value

### DIFF
--- a/org.mixedrealitytoolkit.uxcomponents/Slider/CanvasSlider.prefab
+++ b/org.mixedrealitytoolkit.uxcomponents/Slider/CanvasSlider.prefab
@@ -317,7 +317,7 @@ RectTransform:
   m_AnchorMin: {x: 1, y: 0.5}
   m_AnchorMax: {x: 1, y: 0.5}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 617.13, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &5677198132984834579
 GameObject:

--- a/org.mixedrealitytoolkit.uxcore/Slider/Slider.cs
+++ b/org.mixedrealitytoolkit.uxcore/Slider/Slider.cs
@@ -155,7 +155,7 @@ namespace MixedReality.Toolkit.UX
                 {
                     if (value < minValue || value > maxValue)
                     {
-                        Debug.Log($"{this.value} is outside of the slider range.");
+                        Debug.Log($"{value} is outside of the slider range.");
                     }
                     else
                     {

--- a/org.mixedrealitytoolkit.uxcore/Slider/Slider.cs
+++ b/org.mixedrealitytoolkit.uxcore/Slider/Slider.cs
@@ -151,7 +151,11 @@ namespace MixedReality.Toolkit.UX
             get => value;
             set
             {
-                if (this.value != value)
+                if (value < minValue || value > maxValue)
+                {
+                    Debug.Log($"{this.value} is outside of the slider range.");
+                }
+                else
                 {
                     var oldSliderValue = this.value;
                     this.value = value;

--- a/org.mixedrealitytoolkit.uxcore/Slider/Slider.cs
+++ b/org.mixedrealitytoolkit.uxcore/Slider/Slider.cs
@@ -151,15 +151,18 @@ namespace MixedReality.Toolkit.UX
             get => value;
             set
             {
-                if (value < minValue || value > maxValue)
+                if (this.value != value)
                 {
-                    Debug.Log($"{this.value} is outside of the slider range.");
-                }
-                else
-                {
-                    var oldSliderValue = this.value;
-                    this.value = value;
-                    OnValueUpdated.Invoke(new SliderEventData(oldSliderValue, value));
+                    if (value < minValue || value > maxValue)
+                    {
+                        Debug.Log($"{this.value} is outside of the slider range.");
+                    }
+                    else
+                    {
+                        var oldSliderValue = this.value;
+                        this.value = value;
+                        OnValueUpdated.Invoke(new SliderEventData(oldSliderValue, value));
+                    }
                 }
             }
         }

--- a/org.mixedrealitytoolkit.uxcore/Slider/Slider.cs
+++ b/org.mixedrealitytoolkit.uxcore/Slider/Slider.cs
@@ -153,16 +153,10 @@ namespace MixedReality.Toolkit.UX
             {
                 if (this.value != value)
                 {
-                    if (value < minValue || value > maxValue)
-                    {
-                        Debug.Log($"{value} is outside of the slider range.");
-                    }
-                    else
-                    {
-                        var oldSliderValue = this.value;
-                        this.value = value;
-                        OnValueUpdated.Invoke(new SliderEventData(oldSliderValue, value));
-                    }
+                    value = Mathf.Clamp(value, minValue, maxValue);
+                    var oldSliderValue = this.value;
+                    this.value = value;
+                    OnValueUpdated.Invoke(new SliderEventData(oldSliderValue, value));
                 }
             }
         }

--- a/org.mixedrealitytoolkit.uxcore/Slider/Visuals/CanvasSliderVisuals.cs
+++ b/org.mixedrealitytoolkit.uxcore/Slider/Visuals/CanvasSliderVisuals.cs
@@ -199,23 +199,30 @@ namespace MixedReality.Toolkit.UX
         // Update the things that depend on the slider value.
         void UpdateHandle(float value)
         {
-            handle.position = SliderState.SliderStart.position + (value * SliderState.SliderTrackDirection);
-
             switch (SliderDirection)
             {
                 case Direction.LeftToRight:
                     fillVisual.anchorMax = new Vector2(value, 1.0f);
+                    handle.anchorMin = new Vector2(value, handle.anchorMin.y);
+                    handle.anchorMax = new Vector2(value, handle.anchorMax.y);
                     break;
                 case Direction.RightToLeft:
                     fillVisual.anchorMin = new Vector2(1.0f - value, 0.0f);
+                    handle.anchorMin = new Vector2(1.0f - value, handle.anchorMin.y);
+                    handle.anchorMax = new Vector2(1.0f - value, handle.anchorMax.y);
                     break;
                 case Direction.BottomToTop:
                     fillVisual.anchorMax = new Vector2(1.0f, value);
+                    handle.anchorMin = new Vector2(handle.anchorMin.x, value);
+                    handle.anchorMax = new Vector2(handle.anchorMax.x, value);
                     break;
                 case Direction.TopToBottom:
                     fillVisual.anchorMin = new Vector2(0.0f, 1.0f - value);
+                    handle.anchorMin = new Vector2(handle.anchorMin.x, 1.0f - value);
+                    handle.anchorMax = new Vector2(handle.anchorMax.x, 1.0f - value);
                     break;
             }
+            handle.anchoredPosition = Vector3.zero;
         }
 
         void SetLayout(Direction direction)


### PR DESCRIPTION
Implement fixes related to setting the slider value programmatically: canvas slider handle calculations now use canvas positioning, aligning with fillVisual. Issue and workaround reported by @anonymous2585, https://github.com/MixedRealityToolkit/MixedRealityToolkit-Unity/issues/523.

Also adds a check to limit Slider value within the range of min and max values, removes arbitrary prefab value.