### PR TITLE
ObjectManipulator's ManipulationLogic observes XRSocketInteractor

### DIFF
--- a/org.mixedrealitytoolkit.spatialmanipulation/ObjectManipulator/MoveLogics/ManipulationLogic.cs
+++ b/org.mixedrealitytoolkit.spatialmanipulation/ObjectManipulator/MoveLogics/ManipulationLogic.cs
@@ -23,6 +23,16 @@ namespace MixedReality.Toolkit.SpatialManipulation
         protected int NumInteractors { get; private set; }
 
         /// <summary>
+        /// Whether the object is selected by a singular <see cref="XRSocketInteractor"/>.
+        /// </summary>
+        protected bool SelectedBySocket { get; private set; }
+
+        /// <summary>
+        /// Whether the object is force grabbed by a singular <see cref="XRRayInteractor"/>.
+        /// </summary>
+        protected bool ForceGrabbed { get; private set; }
+
+        /// <summary>
         /// Setup the manipulation logic. Called automatically by Update if the number of interactor points has changed.
         /// </summary>
         /// <param name="interactors">
@@ -38,6 +48,8 @@ namespace MixedReality.Toolkit.SpatialManipulation
         public virtual void Setup(List<IXRSelectInteractor> interactors, IXRSelectInteractable interactable, MixedRealityTransform currentTarget)
         {
             NumInteractors = interactors.Count;
+            SelectedBySocket = NumInteractors == 1 && interactors[0] is XRSocketInteractor;
+            ForceGrabbed = NumInteractors == 1 && interactors[0] is XRRayInteractor rayInteractor && rayInteractor.useForceGrab;
         }
 
         /// <summary>

--- a/org.mixedrealitytoolkit.spatialmanipulation/ObjectManipulator/MoveLogics/RotateLogic.cs
+++ b/org.mixedrealitytoolkit.spatialmanipulation/ObjectManipulator/MoveLogics/RotateLogic.cs
@@ -22,6 +22,8 @@ namespace MixedReality.Toolkit.SpatialManipulation
         private Quaternion startInputRotation;
         private Quaternion startRotation;
 
+        private bool ShouldMatchAttachRotation => SelectedBySocket;
+
         /// <inheritdoc />
         public override void Setup(List<IXRSelectInteractor> interactors, IXRSelectInteractable interactable, MixedRealityTransform currentTarget)
         {
@@ -41,7 +43,11 @@ namespace MixedReality.Toolkit.SpatialManipulation
         {
             base.Update(interactors, interactable, currentTarget, centeredAnchor);
 
-            if (NumInteractors == 1)
+            if (ShouldMatchAttachRotation)
+            {
+                return interactors[0].GetAttachTransform(interactable).rotation;
+            }
+            else if (NumInteractors == 1)
             {
                 return interactors[0].GetAttachTransform(interactable).rotation * Quaternion.Inverse(startInputRotation) * startRotation;
             }

--- a/org.mixedrealitytoolkit.spatialmanipulation/ObjectManipulator/MoveLogics/UnifiedMoveLogic.cs
+++ b/org.mixedrealitytoolkit.spatialmanipulation/ObjectManipulator/MoveLogics/UnifiedMoveLogic.cs
@@ -20,6 +20,8 @@ namespace MixedReality.Toolkit.SpatialManipulation
         private Vector3 attachToObject;
         private Vector3 objectLocalAttachPoint;
 
+        private bool ShouldMatchAttachPosition => SelectedBySocket || ForceGrabbed;
+
         /// <inheritdoc />
         public override void Setup(List<IXRSelectInteractor> interactors, IXRSelectInteractable interactable, MixedRealityTransform currentTarget)
         {
@@ -39,7 +41,11 @@ namespace MixedReality.Toolkit.SpatialManipulation
 
             Vector3 attachCentroid = GetAttachCentroid(interactors, interactable);
 
-            if (centeredAnchor)
+            if (ShouldMatchAttachPosition)
+            {
+                return attachCentroid;
+            }
+            else if (centeredAnchor)
             {
                 return attachCentroid + attachToObject;
             }

--- a/org.mixedrealitytoolkit.spatialmanipulation/ObjectManipulator/ObjectManipulator.cs
+++ b/org.mixedrealitytoolkit.spatialmanipulation/ObjectManipulator/ObjectManipulator.cs
@@ -567,6 +567,8 @@ namespace MixedReality.Toolkit.SpatialManipulation
 
         private bool UseForces => rigidBody != null && !rigidBody.isKinematic;
 
+        private bool SelectedBySocket => interactorsSelecting.Count == 1 && interactorsSelecting[0] is XRSocketInteractor;
+
         private Rigidbody rigidBody;
 
         private bool wasGravity = false;
@@ -987,7 +989,7 @@ namespace MixedReality.Toolkit.SpatialManipulation
         {
             // TODO: Elastics. Compute elastics here and apply to modifiedTransformFlags.
 
-            bool applySmoothing = ShouldSmooth && smoothingLogic != null;
+            bool applySmoothing = ShouldSmooth && smoothingLogic != null && !SelectedBySocket;
 
             targetPose.Position = (applySmoothing && !UseForces) ? smoothingLogic.SmoothPosition(HostTransform.position, targetPose.Position, moveLerpTime, Time.deltaTime) : targetPose.Position;
             targetPose.Rotation = (applySmoothing && !UseForces) ? smoothingLogic.SmoothRotation(HostTransform.rotation, targetPose.Rotation, rotateLerpTime, Time.deltaTime) : targetPose.Rotation;


### PR DESCRIPTION
* Modifies ManipulationLogic for position and rotation to properly observe XRSocketInteractor.
* Turns off object smoothing when selected by XRSocketInteractor.
* Also observes XRRayInteractor forceGrab property for position, moving the object to the ray interactor's force grab attach transform.

Resolves #492 