### PR TITLE
Allow Variable Bounding Box Handle Sizes

### DIFF
--- a/UnityProjects/MRTKDevTemplate/Assets/Prefabs/BoundsControl/ScaledBoundingBoxWithTraditionalHandles.prefab
+++ b/UnityProjects/MRTKDevTemplate/Assets/Prefabs/BoundsControl/ScaledBoundingBoxWithTraditionalHandles.prefab
@@ -1,0 +1,379 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &1106921549130465469
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 189245729653895548, guid: ecbf05ce2121a744cb893e82377ba3cd, type: 3}
+      propertyPath: maintainGlobalSize
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 267191481337050457, guid: ecbf05ce2121a744cb893e82377ba3cd, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 267191481337050457, guid: ecbf05ce2121a744cb893e82377ba3cd, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 267191481337050457, guid: ecbf05ce2121a744cb893e82377ba3cd, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 317209344881906958, guid: ecbf05ce2121a744cb893e82377ba3cd, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 317209344881906958, guid: ecbf05ce2121a744cb893e82377ba3cd, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 317209344881906958, guid: ecbf05ce2121a744cb893e82377ba3cd, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 820712312052533931, guid: ecbf05ce2121a744cb893e82377ba3cd, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 820712312052533931, guid: ecbf05ce2121a744cb893e82377ba3cd, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 820712312052533931, guid: ecbf05ce2121a744cb893e82377ba3cd, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 838235203131453643, guid: ecbf05ce2121a744cb893e82377ba3cd, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 838235203131453643, guid: ecbf05ce2121a744cb893e82377ba3cd, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 838235203131453643, guid: ecbf05ce2121a744cb893e82377ba3cd, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 1205344286066329862, guid: ecbf05ce2121a744cb893e82377ba3cd, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 1205344286066329862, guid: ecbf05ce2121a744cb893e82377ba3cd, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 1205344286066329862, guid: ecbf05ce2121a744cb893e82377ba3cd, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 1383653277728269118, guid: ecbf05ce2121a744cb893e82377ba3cd, type: 3}
+      propertyPath: maintainGlobalSize
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1547771033818799799, guid: ecbf05ce2121a744cb893e82377ba3cd, type: 3}
+      propertyPath: maintainGlobalSize
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2788359083835903198, guid: ecbf05ce2121a744cb893e82377ba3cd, type: 3}
+      propertyPath: maintainGlobalSize
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2920836690631141696, guid: ecbf05ce2121a744cb893e82377ba3cd, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 2920836690631141696, guid: ecbf05ce2121a744cb893e82377ba3cd, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 2920836690631141696, guid: ecbf05ce2121a744cb893e82377ba3cd, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 2950414707919917693, guid: ecbf05ce2121a744cb893e82377ba3cd, type: 3}
+      propertyPath: maintainGlobalSize
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3023444588432002058, guid: ecbf05ce2121a744cb893e82377ba3cd, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 3023444588432002058, guid: ecbf05ce2121a744cb893e82377ba3cd, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 3023444588432002058, guid: ecbf05ce2121a744cb893e82377ba3cd, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 3229878193932362468, guid: ecbf05ce2121a744cb893e82377ba3cd, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 3229878193932362468, guid: ecbf05ce2121a744cb893e82377ba3cd, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 3229878193932362468, guid: ecbf05ce2121a744cb893e82377ba3cd, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 3526394353919841268, guid: ecbf05ce2121a744cb893e82377ba3cd, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 3526394353919841268, guid: ecbf05ce2121a744cb893e82377ba3cd, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 3526394353919841268, guid: ecbf05ce2121a744cb893e82377ba3cd, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 3618957461922352420, guid: ecbf05ce2121a744cb893e82377ba3cd, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 3618957461922352420, guid: ecbf05ce2121a744cb893e82377ba3cd, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 3618957461922352420, guid: ecbf05ce2121a744cb893e82377ba3cd, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 3686202657192415696, guid: ecbf05ce2121a744cb893e82377ba3cd, type: 3}
+      propertyPath: maintainGlobalSize
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3802085631340061212, guid: ecbf05ce2121a744cb893e82377ba3cd, type: 3}
+      propertyPath: maintainGlobalSize
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4336175348979764853, guid: ecbf05ce2121a744cb893e82377ba3cd, type: 3}
+      propertyPath: maintainGlobalSize
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4618306618419526986, guid: ecbf05ce2121a744cb893e82377ba3cd, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 4618306618419526986, guid: ecbf05ce2121a744cb893e82377ba3cd, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 4618306618419526986, guid: ecbf05ce2121a744cb893e82377ba3cd, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 4729807749527318333, guid: ecbf05ce2121a744cb893e82377ba3cd, type: 3}
+      propertyPath: maintainGlobalSize
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5365878068246254448, guid: ecbf05ce2121a744cb893e82377ba3cd, type: 3}
+      propertyPath: maintainGlobalSize
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5569167572273935438, guid: ecbf05ce2121a744cb893e82377ba3cd, type: 3}
+      propertyPath: maintainGlobalSize
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5633261822938306772, guid: ecbf05ce2121a744cb893e82377ba3cd, type: 3}
+      propertyPath: maintainGlobalSize
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5671351296789090341, guid: ecbf05ce2121a744cb893e82377ba3cd, type: 3}
+      propertyPath: m_Name
+      value: ScaledBoundingBoxWithTraditionalHandles
+      objectReference: {fileID: 0}
+    - target: {fileID: 5671351296789090343, guid: ecbf05ce2121a744cb893e82377ba3cd, type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5671351296789090343, guid: ecbf05ce2121a744cb893e82377ba3cd, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5671351296789090343, guid: ecbf05ce2121a744cb893e82377ba3cd, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5671351296789090343, guid: ecbf05ce2121a744cb893e82377ba3cd, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5671351296789090343, guid: ecbf05ce2121a744cb893e82377ba3cd, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5671351296789090343, guid: ecbf05ce2121a744cb893e82377ba3cd, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5671351296789090343, guid: ecbf05ce2121a744cb893e82377ba3cd, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5671351296789090343, guid: ecbf05ce2121a744cb893e82377ba3cd, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5671351296789090343, guid: ecbf05ce2121a744cb893e82377ba3cd, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5671351296789090343, guid: ecbf05ce2121a744cb893e82377ba3cd, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5671351296789090343, guid: ecbf05ce2121a744cb893e82377ba3cd, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5715303648484916638, guid: ecbf05ce2121a744cb893e82377ba3cd, type: 3}
+      propertyPath: maintainGlobalSize
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5937433203586028424, guid: ecbf05ce2121a744cb893e82377ba3cd, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 5937433203586028424, guid: ecbf05ce2121a744cb893e82377ba3cd, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 5937433203586028424, guid: ecbf05ce2121a744cb893e82377ba3cd, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 6096930606889794736, guid: ecbf05ce2121a744cb893e82377ba3cd, type: 3}
+      propertyPath: maintainGlobalSize
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6178803803868470422, guid: ecbf05ce2121a744cb893e82377ba3cd, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 6178803803868470422, guid: ecbf05ce2121a744cb893e82377ba3cd, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 6178803803868470422, guid: ecbf05ce2121a744cb893e82377ba3cd, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 6221155870201029216, guid: ecbf05ce2121a744cb893e82377ba3cd, type: 3}
+      propertyPath: maintainGlobalSize
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6388838889849711093, guid: ecbf05ce2121a744cb893e82377ba3cd, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 6388838889849711093, guid: ecbf05ce2121a744cb893e82377ba3cd, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 6388838889849711093, guid: ecbf05ce2121a744cb893e82377ba3cd, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 6612435286814206603, guid: ecbf05ce2121a744cb893e82377ba3cd, type: 3}
+      propertyPath: maintainGlobalSize
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6981269539414684302, guid: ecbf05ce2121a744cb893e82377ba3cd, type: 3}
+      propertyPath: maintainGlobalSize
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7174184099105599984, guid: ecbf05ce2121a744cb893e82377ba3cd, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 7174184099105599984, guid: ecbf05ce2121a744cb893e82377ba3cd, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 7174184099105599984, guid: ecbf05ce2121a744cb893e82377ba3cd, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 7207427688271266024, guid: ecbf05ce2121a744cb893e82377ba3cd, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 7207427688271266024, guid: ecbf05ce2121a744cb893e82377ba3cd, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 7207427688271266024, guid: ecbf05ce2121a744cb893e82377ba3cd, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 7282594969110709453, guid: ecbf05ce2121a744cb893e82377ba3cd, type: 3}
+      propertyPath: maintainGlobalSize
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7856453474603385183, guid: ecbf05ce2121a744cb893e82377ba3cd, type: 3}
+      propertyPath: maintainGlobalSize
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7923030092577097709, guid: ecbf05ce2121a744cb893e82377ba3cd, type: 3}
+      propertyPath: maintainGlobalSize
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8349516722664271651, guid: ecbf05ce2121a744cb893e82377ba3cd, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 8349516722664271651, guid: ecbf05ce2121a744cb893e82377ba3cd, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 8349516722664271651, guid: ecbf05ce2121a744cb893e82377ba3cd, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 8431421097137893173, guid: ecbf05ce2121a744cb893e82377ba3cd, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 8431421097137893173, guid: ecbf05ce2121a744cb893e82377ba3cd, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 8431421097137893173, guid: ecbf05ce2121a744cb893e82377ba3cd, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 8472961834347041450, guid: ecbf05ce2121a744cb893e82377ba3cd, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 8472961834347041450, guid: ecbf05ce2121a744cb893e82377ba3cd, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 8472961834347041450, guid: ecbf05ce2121a744cb893e82377ba3cd, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 8784380612583060550, guid: ecbf05ce2121a744cb893e82377ba3cd, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 8784380612583060550, guid: ecbf05ce2121a744cb893e82377ba3cd, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 8784380612583060550, guid: ecbf05ce2121a744cb893e82377ba3cd, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 3
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: ecbf05ce2121a744cb893e82377ba3cd, type: 3}

--- a/UnityProjects/MRTKDevTemplate/Assets/Prefabs/BoundsControl/ScaledBoundingBoxWithTraditionalHandles.prefab.meta
+++ b/UnityProjects/MRTKDevTemplate/Assets/Prefabs/BoundsControl/ScaledBoundingBoxWithTraditionalHandles.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 728f720d1417fae41a8c8a820e4523fa
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProjects/MRTKDevTemplate/Assets/Scenes/BoundsControlRuntimeExample.unity
+++ b/UnityProjects/MRTKDevTemplate/Assets/Scenes/BoundsControlRuntimeExample.unity
@@ -1485,9 +1485,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   statusText: {fileID: 414943981}
   darkGrayMaterial: {fileID: 2100000, guid: 4b78d3a2e1ab7c0499ce81ca8d18e7b5, type: 2}
-  redMaterial: {fileID: 2100000, guid: db61b94b23e5fb444b86c231d13e46ef, type: 2}
-  cyanMaterial: {fileID: 2100000, guid: 0c3570eeff29ef44e9fed596a4cc3ffd, type: 2}
-  boundsVisualsPrefab: {fileID: 5671351296789090341, guid: ecbf05ce2121a744cb893e82377ba3cd, type: 3}
+  boundsVisualsPrefab: {fileID: 4749112585544339608, guid: 728f720d1417fae41a8c8a820e4523fa, type: 3}
   cubeParent: {fileID: 1321897323}
 --- !u!4 &1886794917
 Transform:

--- a/UnityProjects/MRTKDevTemplate/Assets/Scripts/BoundsControlRuntimeExample.cs
+++ b/UnityProjects/MRTKDevTemplate/Assets/Scripts/BoundsControlRuntimeExample.cs
@@ -25,12 +25,6 @@ namespace MixedReality.Toolkit.Examples.Demos
         private Material darkGrayMaterial;
 
         [SerializeField]
-        private Material redMaterial;
-
-        [SerializeField]
-        private Material cyanMaterial;
-
-        [SerializeField]
         private GameObject boundsVisualsPrefab;
 
         [SerializeField]

--- a/org.mixedrealitytoolkit.spatialmanipulation/BoundsControl/BoundsHandleInteractable.cs
+++ b/org.mixedrealitytoolkit.spatialmanipulation/BoundsControl/BoundsHandleInteractable.cs
@@ -91,7 +91,7 @@ namespace MixedReality.Toolkit.SpatialManipulation
 
         private float initialParentScale;
 
-        private float initialHandleScale;
+        private float initialLocalScale;
 
         /// <inheritdoc/>
         protected override void Awake()
@@ -112,7 +112,7 @@ namespace MixedReality.Toolkit.SpatialManipulation
             // Record initial values at Start(), so that we
             // capture the bounds sizing, etc.
             initialParentScale = MaxComponent(transform.parent.lossyScale);
-            initialHandleScale = MaxComponent(transform.localScale);
+            initialLocalScale = MaxComponent(transform.localScale);
         }
 
         /// <summary>
@@ -132,12 +132,12 @@ namespace MixedReality.Toolkit.SpatialManipulation
             }
 
             // Maintain the aspect ratio/proportion of the handles, globally.
-            // Setting localScale to ensure that lossyScale remains equal to initialHandleScale across all axes. 
+            // Setting localScale to ensure that lossyScale remains equal to initialLocalScale across all axes. 
             transform.localScale = Vector3.one;
             transform.localScale = new Vector3(
-                transform.lossyScale.x == 0 ? transform.localScale.x : (initialHandleScale / transform.lossyScale.x),
-                transform.lossyScale.y == 0 ? transform.localScale.y : (initialHandleScale / transform.lossyScale.y),
-                transform.lossyScale.z == 0 ? transform.localScale.z : (initialHandleScale / transform.lossyScale.z));
+                transform.lossyScale.x == 0 ? transform.localScale.x : (initialLocalScale / transform.lossyScale.x),
+                transform.lossyScale.y == 0 ? transform.localScale.y : (initialLocalScale / transform.lossyScale.y),
+                transform.lossyScale.z == 0 ? transform.localScale.z : (initialLocalScale / transform.lossyScale.z));
 
             // If we don't want to maintain the overall *size*, we scale
             // by the maximum component of the box so that the handles grow/shrink

--- a/org.mixedrealitytoolkit.spatialmanipulation/BoundsControl/BoundsHandleInteractable.cs
+++ b/org.mixedrealitytoolkit.spatialmanipulation/BoundsControl/BoundsHandleInteractable.cs
@@ -91,6 +91,8 @@ namespace MixedReality.Toolkit.SpatialManipulation
 
         private float initialParentScale;
 
+        private float initialHandleScale;
+
         /// <inheritdoc/>
         protected override void Awake()
         {
@@ -110,6 +112,7 @@ namespace MixedReality.Toolkit.SpatialManipulation
             // Record initial values at Start(), so that we
             // capture the bounds sizing, etc.
             initialParentScale = MaxComponent(transform.parent.lossyScale);
+            initialHandleScale = MaxComponent(transform.localScale);
         }
 
         /// <summary>
@@ -129,11 +132,12 @@ namespace MixedReality.Toolkit.SpatialManipulation
             }
 
             // Maintain the aspect ratio/proportion of the handles, globally.
+            // Setting localScale to ensure that lossyScale remains equal to initialHandleScale across all axes. 
             transform.localScale = Vector3.one;
             transform.localScale = new Vector3(
-                transform.lossyScale.x == 0 ? transform.localScale.x : (1.0f / transform.lossyScale.x),
-                transform.lossyScale.y == 0 ? transform.localScale.y : (1.0f / transform.lossyScale.y),
-                transform.lossyScale.z == 0 ? transform.localScale.z : (1.0f / transform.lossyScale.z));
+                transform.lossyScale.x == 0 ? transform.localScale.x : (initialHandleScale / transform.lossyScale.x),
+                transform.lossyScale.y == 0 ? transform.localScale.y : (initialHandleScale / transform.lossyScale.y),
+                transform.lossyScale.z == 0 ? transform.localScale.z : (initialHandleScale / transform.lossyScale.z));
 
             // If we don't want to maintain the overall *size*, we scale
             // by the maximum component of the box so that the handles grow/shrink

--- a/org.mixedrealitytoolkit.spatialmanipulation/BoundsControl/Prefabs/BoundingBoxWithHandles.prefab
+++ b/org.mixedrealitytoolkit.spatialmanipulation/BoundsControl/Prefabs/BoundingBoxWithHandles.prefab
@@ -64,15 +64,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1881740777175929026, guid: 45938efb25451774cad2262df8ebeef2, type: 3}
       propertyPath: m_LocalScale.x
-      value: 10
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 1881740777175929026, guid: 45938efb25451774cad2262df8ebeef2, type: 3}
       propertyPath: m_LocalScale.y
-      value: 10
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 1881740777175929026, guid: 45938efb25451774cad2262df8ebeef2, type: 3}
       propertyPath: m_LocalScale.z
-      value: 10
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 1881740777175929026, guid: 45938efb25451774cad2262df8ebeef2, type: 3}
       propertyPath: m_LocalPosition.x
@@ -157,15 +157,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1881740777175929026, guid: 45938efb25451774cad2262df8ebeef2, type: 3}
       propertyPath: m_LocalScale.x
-      value: 10
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 1881740777175929026, guid: 45938efb25451774cad2262df8ebeef2, type: 3}
       propertyPath: m_LocalScale.y
-      value: 10
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 1881740777175929026, guid: 45938efb25451774cad2262df8ebeef2, type: 3}
       propertyPath: m_LocalScale.z
-      value: 10
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 1881740777175929026, guid: 45938efb25451774cad2262df8ebeef2, type: 3}
       propertyPath: m_LocalPosition.x
@@ -262,15 +262,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1881740777175929026, guid: b475f5cfd3a24ff4dadda4a9f34acd4b, type: 3}
       propertyPath: m_LocalScale.x
-      value: 10
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 1881740777175929026, guid: b475f5cfd3a24ff4dadda4a9f34acd4b, type: 3}
       propertyPath: m_LocalScale.y
-      value: 10
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 1881740777175929026, guid: b475f5cfd3a24ff4dadda4a9f34acd4b, type: 3}
       propertyPath: m_LocalScale.z
-      value: 10
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 1881740777175929026, guid: b475f5cfd3a24ff4dadda4a9f34acd4b, type: 3}
       propertyPath: m_LocalPosition.x
@@ -352,15 +352,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1881740777175929026, guid: b475f5cfd3a24ff4dadda4a9f34acd4b, type: 3}
       propertyPath: m_LocalScale.x
-      value: 10
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 1881740777175929026, guid: b475f5cfd3a24ff4dadda4a9f34acd4b, type: 3}
       propertyPath: m_LocalScale.y
-      value: 10
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 1881740777175929026, guid: b475f5cfd3a24ff4dadda4a9f34acd4b, type: 3}
       propertyPath: m_LocalScale.z
-      value: 10
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 1881740777175929026, guid: b475f5cfd3a24ff4dadda4a9f34acd4b, type: 3}
       propertyPath: m_LocalPosition.x
@@ -434,15 +434,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1881740777175929026, guid: 45938efb25451774cad2262df8ebeef2, type: 3}
       propertyPath: m_LocalScale.x
-      value: 10
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 1881740777175929026, guid: 45938efb25451774cad2262df8ebeef2, type: 3}
       propertyPath: m_LocalScale.y
-      value: 10
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 1881740777175929026, guid: 45938efb25451774cad2262df8ebeef2, type: 3}
       propertyPath: m_LocalScale.z
-      value: 10
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 1881740777175929026, guid: 45938efb25451774cad2262df8ebeef2, type: 3}
       propertyPath: m_LocalPosition.x
@@ -539,15 +539,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1881740777175929026, guid: b475f5cfd3a24ff4dadda4a9f34acd4b, type: 3}
       propertyPath: m_LocalScale.x
-      value: 10
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 1881740777175929026, guid: b475f5cfd3a24ff4dadda4a9f34acd4b, type: 3}
       propertyPath: m_LocalScale.y
-      value: 10
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 1881740777175929026, guid: b475f5cfd3a24ff4dadda4a9f34acd4b, type: 3}
       propertyPath: m_LocalScale.z
-      value: 10
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 1881740777175929026, guid: b475f5cfd3a24ff4dadda4a9f34acd4b, type: 3}
       propertyPath: m_LocalPosition.x
@@ -633,15 +633,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1881740777175929026, guid: b475f5cfd3a24ff4dadda4a9f34acd4b, type: 3}
       propertyPath: m_LocalScale.x
-      value: 10
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 1881740777175929026, guid: b475f5cfd3a24ff4dadda4a9f34acd4b, type: 3}
       propertyPath: m_LocalScale.y
-      value: 10
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 1881740777175929026, guid: b475f5cfd3a24ff4dadda4a9f34acd4b, type: 3}
       propertyPath: m_LocalScale.z
-      value: 10
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 1881740777175929026, guid: b475f5cfd3a24ff4dadda4a9f34acd4b, type: 3}
       propertyPath: m_LocalPosition.x
@@ -723,15 +723,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1881740777175929026, guid: b475f5cfd3a24ff4dadda4a9f34acd4b, type: 3}
       propertyPath: m_LocalScale.x
-      value: 10
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 1881740777175929026, guid: b475f5cfd3a24ff4dadda4a9f34acd4b, type: 3}
       propertyPath: m_LocalScale.y
-      value: 10
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 1881740777175929026, guid: b475f5cfd3a24ff4dadda4a9f34acd4b, type: 3}
       propertyPath: m_LocalScale.z
-      value: 10
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 1881740777175929026, guid: b475f5cfd3a24ff4dadda4a9f34acd4b, type: 3}
       propertyPath: m_LocalPosition.x
@@ -817,15 +817,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1881740777175929026, guid: b475f5cfd3a24ff4dadda4a9f34acd4b, type: 3}
       propertyPath: m_LocalScale.x
-      value: 10
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 1881740777175929026, guid: b475f5cfd3a24ff4dadda4a9f34acd4b, type: 3}
       propertyPath: m_LocalScale.y
-      value: 10
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 1881740777175929026, guid: b475f5cfd3a24ff4dadda4a9f34acd4b, type: 3}
       propertyPath: m_LocalScale.z
-      value: 10
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 1881740777175929026, guid: b475f5cfd3a24ff4dadda4a9f34acd4b, type: 3}
       propertyPath: m_LocalPosition.x
@@ -903,15 +903,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1881740777175929026, guid: b475f5cfd3a24ff4dadda4a9f34acd4b, type: 3}
       propertyPath: m_LocalScale.x
-      value: 10
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 1881740777175929026, guid: b475f5cfd3a24ff4dadda4a9f34acd4b, type: 3}
       propertyPath: m_LocalScale.y
-      value: 10
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 1881740777175929026, guid: b475f5cfd3a24ff4dadda4a9f34acd4b, type: 3}
       propertyPath: m_LocalScale.z
-      value: 10
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 1881740777175929026, guid: b475f5cfd3a24ff4dadda4a9f34acd4b, type: 3}
       propertyPath: m_LocalPosition.x
@@ -985,15 +985,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1881740777175929026, guid: 45938efb25451774cad2262df8ebeef2, type: 3}
       propertyPath: m_LocalScale.x
-      value: 10
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 1881740777175929026, guid: 45938efb25451774cad2262df8ebeef2, type: 3}
       propertyPath: m_LocalScale.y
-      value: 10
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 1881740777175929026, guid: 45938efb25451774cad2262df8ebeef2, type: 3}
       propertyPath: m_LocalScale.z
-      value: 10
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 1881740777175929026, guid: 45938efb25451774cad2262df8ebeef2, type: 3}
       propertyPath: m_LocalPosition.x
@@ -1090,15 +1090,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1881740777175929026, guid: b475f5cfd3a24ff4dadda4a9f34acd4b, type: 3}
       propertyPath: m_LocalScale.x
-      value: 10
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 1881740777175929026, guid: b475f5cfd3a24ff4dadda4a9f34acd4b, type: 3}
       propertyPath: m_LocalScale.y
-      value: 10
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 1881740777175929026, guid: b475f5cfd3a24ff4dadda4a9f34acd4b, type: 3}
       propertyPath: m_LocalScale.z
-      value: 10
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 1881740777175929026, guid: b475f5cfd3a24ff4dadda4a9f34acd4b, type: 3}
       propertyPath: m_LocalPosition.x
@@ -1176,15 +1176,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1881740777175929026, guid: 45938efb25451774cad2262df8ebeef2, type: 3}
       propertyPath: m_LocalScale.x
-      value: 10
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 1881740777175929026, guid: 45938efb25451774cad2262df8ebeef2, type: 3}
       propertyPath: m_LocalScale.y
-      value: 10
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 1881740777175929026, guid: 45938efb25451774cad2262df8ebeef2, type: 3}
       propertyPath: m_LocalScale.z
-      value: 10
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 1881740777175929026, guid: 45938efb25451774cad2262df8ebeef2, type: 3}
       propertyPath: m_LocalPosition.x
@@ -1281,15 +1281,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1881740777175929026, guid: b475f5cfd3a24ff4dadda4a9f34acd4b, type: 3}
       propertyPath: m_LocalScale.x
-      value: 10
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 1881740777175929026, guid: b475f5cfd3a24ff4dadda4a9f34acd4b, type: 3}
       propertyPath: m_LocalScale.y
-      value: 10
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 1881740777175929026, guid: b475f5cfd3a24ff4dadda4a9f34acd4b, type: 3}
       propertyPath: m_LocalScale.z
-      value: 10
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 1881740777175929026, guid: b475f5cfd3a24ff4dadda4a9f34acd4b, type: 3}
       propertyPath: m_LocalPosition.x
@@ -1429,15 +1429,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1881740777175929026, guid: 45938efb25451774cad2262df8ebeef2, type: 3}
       propertyPath: m_LocalScale.x
-      value: 10
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 1881740777175929026, guid: 45938efb25451774cad2262df8ebeef2, type: 3}
       propertyPath: m_LocalScale.y
-      value: 10
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 1881740777175929026, guid: 45938efb25451774cad2262df8ebeef2, type: 3}
       propertyPath: m_LocalScale.z
-      value: 10
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 1881740777175929026, guid: 45938efb25451774cad2262df8ebeef2, type: 3}
       propertyPath: m_LocalPosition.x
@@ -1534,15 +1534,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1881740777175929026, guid: b475f5cfd3a24ff4dadda4a9f34acd4b, type: 3}
       propertyPath: m_LocalScale.x
-      value: 10
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 1881740777175929026, guid: b475f5cfd3a24ff4dadda4a9f34acd4b, type: 3}
       propertyPath: m_LocalScale.y
-      value: 10
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 1881740777175929026, guid: b475f5cfd3a24ff4dadda4a9f34acd4b, type: 3}
       propertyPath: m_LocalScale.z
-      value: 10
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 1881740777175929026, guid: b475f5cfd3a24ff4dadda4a9f34acd4b, type: 3}
       propertyPath: m_LocalPosition.x
@@ -1612,15 +1612,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1881740777175929026, guid: 45938efb25451774cad2262df8ebeef2, type: 3}
       propertyPath: m_LocalScale.x
-      value: 10
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 1881740777175929026, guid: 45938efb25451774cad2262df8ebeef2, type: 3}
       propertyPath: m_LocalScale.y
-      value: 10
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 1881740777175929026, guid: 45938efb25451774cad2262df8ebeef2, type: 3}
       propertyPath: m_LocalScale.z
-      value: 10
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 1881740777175929026, guid: 45938efb25451774cad2262df8ebeef2, type: 3}
       propertyPath: m_LocalPosition.x
@@ -1717,15 +1717,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1881740777175929026, guid: b475f5cfd3a24ff4dadda4a9f34acd4b, type: 3}
       propertyPath: m_LocalScale.x
-      value: 10
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 1881740777175929026, guid: b475f5cfd3a24ff4dadda4a9f34acd4b, type: 3}
       propertyPath: m_LocalScale.y
-      value: 10
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 1881740777175929026, guid: b475f5cfd3a24ff4dadda4a9f34acd4b, type: 3}
       propertyPath: m_LocalScale.z
-      value: 10
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 1881740777175929026, guid: b475f5cfd3a24ff4dadda4a9f34acd4b, type: 3}
       propertyPath: m_LocalPosition.x
@@ -1799,15 +1799,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1881740777175929026, guid: 45938efb25451774cad2262df8ebeef2, type: 3}
       propertyPath: m_LocalScale.x
-      value: 10
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 1881740777175929026, guid: 45938efb25451774cad2262df8ebeef2, type: 3}
       propertyPath: m_LocalScale.y
-      value: 10
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 1881740777175929026, guid: 45938efb25451774cad2262df8ebeef2, type: 3}
       propertyPath: m_LocalScale.z
-      value: 10
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 1881740777175929026, guid: 45938efb25451774cad2262df8ebeef2, type: 3}
       propertyPath: m_LocalPosition.x
@@ -1904,15 +1904,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1881740777175929026, guid: b475f5cfd3a24ff4dadda4a9f34acd4b, type: 3}
       propertyPath: m_LocalScale.x
-      value: 10
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 1881740777175929026, guid: b475f5cfd3a24ff4dadda4a9f34acd4b, type: 3}
       propertyPath: m_LocalScale.y
-      value: 10
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 1881740777175929026, guid: b475f5cfd3a24ff4dadda4a9f34acd4b, type: 3}
       propertyPath: m_LocalScale.z
-      value: 10
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 1881740777175929026, guid: b475f5cfd3a24ff4dadda4a9f34acd4b, type: 3}
       propertyPath: m_LocalPosition.x

--- a/org.mixedrealitytoolkit.spatialmanipulation/BoundsControl/Prefabs/BoundingBoxWithTraditionalHandles.prefab
+++ b/org.mixedrealitytoolkit.spatialmanipulation/BoundsControl/Prefabs/BoundingBoxWithTraditionalHandles.prefab
@@ -64,15 +64,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1881740777175929026, guid: c1859d1d3f5090248a08125171b6fbe8, type: 3}
       propertyPath: m_LocalScale.x
-      value: 10
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 1881740777175929026, guid: c1859d1d3f5090248a08125171b6fbe8, type: 3}
       propertyPath: m_LocalScale.y
-      value: 10
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 1881740777175929026, guid: c1859d1d3f5090248a08125171b6fbe8, type: 3}
       propertyPath: m_LocalScale.z
-      value: 10
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 1881740777175929026, guid: c1859d1d3f5090248a08125171b6fbe8, type: 3}
       propertyPath: m_LocalPosition.x
@@ -146,15 +146,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1881740777175929026, guid: c1859d1d3f5090248a08125171b6fbe8, type: 3}
       propertyPath: m_LocalScale.x
-      value: 10
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 1881740777175929026, guid: c1859d1d3f5090248a08125171b6fbe8, type: 3}
       propertyPath: m_LocalScale.y
-      value: 10
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 1881740777175929026, guid: c1859d1d3f5090248a08125171b6fbe8, type: 3}
       propertyPath: m_LocalScale.z
-      value: 10
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 1881740777175929026, guid: c1859d1d3f5090248a08125171b6fbe8, type: 3}
       propertyPath: m_LocalPosition.x
@@ -240,15 +240,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1881740777175929026, guid: b475f5cfd3a24ff4dadda4a9f34acd4b, type: 3}
       propertyPath: m_LocalScale.x
-      value: 10
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 1881740777175929026, guid: b475f5cfd3a24ff4dadda4a9f34acd4b, type: 3}
       propertyPath: m_LocalScale.y
-      value: 10
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 1881740777175929026, guid: b475f5cfd3a24ff4dadda4a9f34acd4b, type: 3}
       propertyPath: m_LocalScale.z
-      value: 10
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 1881740777175929026, guid: b475f5cfd3a24ff4dadda4a9f34acd4b, type: 3}
       propertyPath: m_LocalPosition.x
@@ -330,15 +330,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1881740777175929026, guid: b475f5cfd3a24ff4dadda4a9f34acd4b, type: 3}
       propertyPath: m_LocalScale.x
-      value: 10
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 1881740777175929026, guid: b475f5cfd3a24ff4dadda4a9f34acd4b, type: 3}
       propertyPath: m_LocalScale.y
-      value: 10
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 1881740777175929026, guid: b475f5cfd3a24ff4dadda4a9f34acd4b, type: 3}
       propertyPath: m_LocalScale.z
-      value: 10
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 1881740777175929026, guid: b475f5cfd3a24ff4dadda4a9f34acd4b, type: 3}
       propertyPath: m_LocalPosition.x
@@ -412,15 +412,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1881740777175929026, guid: c1859d1d3f5090248a08125171b6fbe8, type: 3}
       propertyPath: m_LocalScale.x
-      value: 10
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 1881740777175929026, guid: c1859d1d3f5090248a08125171b6fbe8, type: 3}
       propertyPath: m_LocalScale.y
-      value: 10
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 1881740777175929026, guid: c1859d1d3f5090248a08125171b6fbe8, type: 3}
       propertyPath: m_LocalScale.z
-      value: 10
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 1881740777175929026, guid: c1859d1d3f5090248a08125171b6fbe8, type: 3}
       propertyPath: m_LocalPosition.x
@@ -506,15 +506,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1881740777175929026, guid: b475f5cfd3a24ff4dadda4a9f34acd4b, type: 3}
       propertyPath: m_LocalScale.x
-      value: 10
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 1881740777175929026, guid: b475f5cfd3a24ff4dadda4a9f34acd4b, type: 3}
       propertyPath: m_LocalScale.y
-      value: 10
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 1881740777175929026, guid: b475f5cfd3a24ff4dadda4a9f34acd4b, type: 3}
       propertyPath: m_LocalScale.z
-      value: 10
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 1881740777175929026, guid: b475f5cfd3a24ff4dadda4a9f34acd4b, type: 3}
       propertyPath: m_LocalPosition.x
@@ -600,15 +600,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1881740777175929026, guid: b475f5cfd3a24ff4dadda4a9f34acd4b, type: 3}
       propertyPath: m_LocalScale.x
-      value: 10
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 1881740777175929026, guid: b475f5cfd3a24ff4dadda4a9f34acd4b, type: 3}
       propertyPath: m_LocalScale.y
-      value: 10
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 1881740777175929026, guid: b475f5cfd3a24ff4dadda4a9f34acd4b, type: 3}
       propertyPath: m_LocalScale.z
-      value: 10
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 1881740777175929026, guid: b475f5cfd3a24ff4dadda4a9f34acd4b, type: 3}
       propertyPath: m_LocalPosition.x
@@ -690,15 +690,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1881740777175929026, guid: b475f5cfd3a24ff4dadda4a9f34acd4b, type: 3}
       propertyPath: m_LocalScale.x
-      value: 10
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 1881740777175929026, guid: b475f5cfd3a24ff4dadda4a9f34acd4b, type: 3}
       propertyPath: m_LocalScale.y
-      value: 10
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 1881740777175929026, guid: b475f5cfd3a24ff4dadda4a9f34acd4b, type: 3}
       propertyPath: m_LocalScale.z
-      value: 10
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 1881740777175929026, guid: b475f5cfd3a24ff4dadda4a9f34acd4b, type: 3}
       propertyPath: m_LocalPosition.x
@@ -784,15 +784,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1881740777175929026, guid: b475f5cfd3a24ff4dadda4a9f34acd4b, type: 3}
       propertyPath: m_LocalScale.x
-      value: 10
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 1881740777175929026, guid: b475f5cfd3a24ff4dadda4a9f34acd4b, type: 3}
       propertyPath: m_LocalScale.y
-      value: 10
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 1881740777175929026, guid: b475f5cfd3a24ff4dadda4a9f34acd4b, type: 3}
       propertyPath: m_LocalScale.z
-      value: 10
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 1881740777175929026, guid: b475f5cfd3a24ff4dadda4a9f34acd4b, type: 3}
       propertyPath: m_LocalPosition.x
@@ -870,15 +870,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1881740777175929026, guid: b475f5cfd3a24ff4dadda4a9f34acd4b, type: 3}
       propertyPath: m_LocalScale.x
-      value: 10
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 1881740777175929026, guid: b475f5cfd3a24ff4dadda4a9f34acd4b, type: 3}
       propertyPath: m_LocalScale.y
-      value: 10
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 1881740777175929026, guid: b475f5cfd3a24ff4dadda4a9f34acd4b, type: 3}
       propertyPath: m_LocalScale.z
-      value: 10
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 1881740777175929026, guid: b475f5cfd3a24ff4dadda4a9f34acd4b, type: 3}
       propertyPath: m_LocalPosition.x
@@ -952,15 +952,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1881740777175929026, guid: c1859d1d3f5090248a08125171b6fbe8, type: 3}
       propertyPath: m_LocalScale.x
-      value: 10
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 1881740777175929026, guid: c1859d1d3f5090248a08125171b6fbe8, type: 3}
       propertyPath: m_LocalScale.y
-      value: 10
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 1881740777175929026, guid: c1859d1d3f5090248a08125171b6fbe8, type: 3}
       propertyPath: m_LocalScale.z
-      value: 10
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 1881740777175929026, guid: c1859d1d3f5090248a08125171b6fbe8, type: 3}
       propertyPath: m_LocalPosition.x
@@ -1046,15 +1046,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1881740777175929026, guid: b475f5cfd3a24ff4dadda4a9f34acd4b, type: 3}
       propertyPath: m_LocalScale.x
-      value: 10
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 1881740777175929026, guid: b475f5cfd3a24ff4dadda4a9f34acd4b, type: 3}
       propertyPath: m_LocalScale.y
-      value: 10
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 1881740777175929026, guid: b475f5cfd3a24ff4dadda4a9f34acd4b, type: 3}
       propertyPath: m_LocalScale.z
-      value: 10
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 1881740777175929026, guid: b475f5cfd3a24ff4dadda4a9f34acd4b, type: 3}
       propertyPath: m_LocalPosition.x
@@ -1132,15 +1132,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1881740777175929026, guid: c1859d1d3f5090248a08125171b6fbe8, type: 3}
       propertyPath: m_LocalScale.x
-      value: 10
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 1881740777175929026, guid: c1859d1d3f5090248a08125171b6fbe8, type: 3}
       propertyPath: m_LocalScale.y
-      value: 10
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 1881740777175929026, guid: c1859d1d3f5090248a08125171b6fbe8, type: 3}
       propertyPath: m_LocalScale.z
-      value: 10
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 1881740777175929026, guid: c1859d1d3f5090248a08125171b6fbe8, type: 3}
       propertyPath: m_LocalPosition.x
@@ -1226,15 +1226,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1881740777175929026, guid: b475f5cfd3a24ff4dadda4a9f34acd4b, type: 3}
       propertyPath: m_LocalScale.x
-      value: 10
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 1881740777175929026, guid: b475f5cfd3a24ff4dadda4a9f34acd4b, type: 3}
       propertyPath: m_LocalScale.y
-      value: 10
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 1881740777175929026, guid: b475f5cfd3a24ff4dadda4a9f34acd4b, type: 3}
       propertyPath: m_LocalScale.z
-      value: 10
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 1881740777175929026, guid: b475f5cfd3a24ff4dadda4a9f34acd4b, type: 3}
       propertyPath: m_LocalPosition.x
@@ -1382,15 +1382,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1881740777175929026, guid: c1859d1d3f5090248a08125171b6fbe8, type: 3}
       propertyPath: m_LocalScale.x
-      value: 10
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 1881740777175929026, guid: c1859d1d3f5090248a08125171b6fbe8, type: 3}
       propertyPath: m_LocalScale.y
-      value: 10
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 1881740777175929026, guid: c1859d1d3f5090248a08125171b6fbe8, type: 3}
       propertyPath: m_LocalScale.z
-      value: 10
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 1881740777175929026, guid: c1859d1d3f5090248a08125171b6fbe8, type: 3}
       propertyPath: m_LocalPosition.x
@@ -1476,15 +1476,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1881740777175929026, guid: b475f5cfd3a24ff4dadda4a9f34acd4b, type: 3}
       propertyPath: m_LocalScale.x
-      value: 10
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 1881740777175929026, guid: b475f5cfd3a24ff4dadda4a9f34acd4b, type: 3}
       propertyPath: m_LocalScale.y
-      value: 10
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 1881740777175929026, guid: b475f5cfd3a24ff4dadda4a9f34acd4b, type: 3}
       propertyPath: m_LocalScale.z
-      value: 10
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 1881740777175929026, guid: b475f5cfd3a24ff4dadda4a9f34acd4b, type: 3}
       propertyPath: m_LocalPosition.x
@@ -1554,15 +1554,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1881740777175929026, guid: c1859d1d3f5090248a08125171b6fbe8, type: 3}
       propertyPath: m_LocalScale.x
-      value: 10
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 1881740777175929026, guid: c1859d1d3f5090248a08125171b6fbe8, type: 3}
       propertyPath: m_LocalScale.y
-      value: 10
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 1881740777175929026, guid: c1859d1d3f5090248a08125171b6fbe8, type: 3}
       propertyPath: m_LocalScale.z
-      value: 10
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 1881740777175929026, guid: c1859d1d3f5090248a08125171b6fbe8, type: 3}
       propertyPath: m_LocalPosition.x
@@ -1648,15 +1648,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1881740777175929026, guid: b475f5cfd3a24ff4dadda4a9f34acd4b, type: 3}
       propertyPath: m_LocalScale.x
-      value: 10
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 1881740777175929026, guid: b475f5cfd3a24ff4dadda4a9f34acd4b, type: 3}
       propertyPath: m_LocalScale.y
-      value: 10
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 1881740777175929026, guid: b475f5cfd3a24ff4dadda4a9f34acd4b, type: 3}
       propertyPath: m_LocalScale.z
-      value: 10
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 1881740777175929026, guid: b475f5cfd3a24ff4dadda4a9f34acd4b, type: 3}
       propertyPath: m_LocalPosition.x
@@ -1730,15 +1730,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1881740777175929026, guid: c1859d1d3f5090248a08125171b6fbe8, type: 3}
       propertyPath: m_LocalScale.x
-      value: 10
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 1881740777175929026, guid: c1859d1d3f5090248a08125171b6fbe8, type: 3}
       propertyPath: m_LocalScale.y
-      value: 10
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 1881740777175929026, guid: c1859d1d3f5090248a08125171b6fbe8, type: 3}
       propertyPath: m_LocalScale.z
-      value: 10
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 1881740777175929026, guid: c1859d1d3f5090248a08125171b6fbe8, type: 3}
       propertyPath: m_LocalPosition.x
@@ -1824,15 +1824,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1881740777175929026, guid: b475f5cfd3a24ff4dadda4a9f34acd4b, type: 3}
       propertyPath: m_LocalScale.x
-      value: 10
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 1881740777175929026, guid: b475f5cfd3a24ff4dadda4a9f34acd4b, type: 3}
       propertyPath: m_LocalScale.y
-      value: 10
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 1881740777175929026, guid: b475f5cfd3a24ff4dadda4a9f34acd4b, type: 3}
       propertyPath: m_LocalScale.z
-      value: 10
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 1881740777175929026, guid: b475f5cfd3a24ff4dadda4a9f34acd4b, type: 3}
       propertyPath: m_LocalPosition.x


### PR DESCRIPTION
Currently, all BoundsHandleInteractables are set to a global scale of 1x1x1 at runtime (and may then scale with the bounding box if MaintainGlobalSize is unselected). The initial scale of BoundsHandleInteractable is never taken into account when scaling the handles. This change sets the global scale to the max(x,y,z) of the initial BoundsHandleInteractable scale, instead of 1, so a user may now change the size of the handles in the prefab in order to make bounding boxes with larger or smaller handles. PR also makes changes to the BoundsControlRuntimeExample scene to give an example of this.

<img width="277" alt="image" src="https://github.com/MixedRealityToolkit/MixedRealityToolkit-Unity/assets/125413876/f86a67e7-1904-47e3-a873-cb7798583d0b">

[3x3x3 Handles Scaled Prefab from Sample Scene]

Addresses https://github.com/MixedRealityToolkit/MixedRealityToolkit-Unity/issues/572

Spatial Manipulation package version number has already been bumped since last release, so no update is needed.