### PR TITLE
Updating maintainer rules

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,6 +1,6 @@
 # Governance Policy
 
-This document provides the governance policy for the Mixed Reality Toolkit for Unity Project. Maintainers agree to this policy and to abide by all Project polices, including the [code of conduct](../org-docs/CODE-OF-CONDUCT.md), [trademark policy](../org-docs/TRADEMARKS.md), and [antitrust policy](../org-docs/ANTITRUST.md) by adding their name to the [maintainers.md file](./MAINTAINERS.md).
+This document provides the governance policy for the Mixed Reality Toolkit for Unity Project. Maintainers agree to this policy and to abide by all Project polices, including the [code of conduct](../org-docs/CODE-OF-CONDUCT.md), [trademark policy](../org-docs/TRADEMARKS.md), and [antitrust policy](../org-docs/ANTITRUST.md) by adding their name to the [MAINTAINERS.md](./MAINTAINERS.md) file.
 
 ## 1. Roles
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -6,7 +6,7 @@ This document provides the governance policy for the Mixed Reality Toolkit for U
 
 This project may include the following roles. Additional roles may be adopted and documented by the Project.
 
-**1.1. Maintainers**. Maintainers are responsible for organizing activities around developing, maintaining, and updating the Project. Maintainers are also responsible for determining consensus. This Project may add or remove Maintainers with the approval of the current Maintainers. Maintainers must be part of an Affiliated Organization as listed in the [steering-committee.md](https://github.com/MixedRealityToolkit/MixedRealityToolkit-MVG/blob/main/org-docs/STEERING-COMMITTEE.md) organization file.
+**1.1. Maintainers**. Maintainers are responsible for organizing activities around developing, maintaining, and updating the Project. Maintainers are also responsible for determining consensus. This Project may add or remove Maintainers with the approval of the current Maintainers. Approved Maintainers and their Affiliated Organization must be listed in the [MAINTAINERS.md](./MAINTAINERS.md) file.
 
 **1.2. Contributors**. Contributors are those that have made contributions to the Project.
 


### PR DESCRIPTION
# Description 

Updating maintainer rules, so that a maintainer's affiliated organization doesn't need representation on the steering committee.

Existing maintainers should approve this change.

Note, changes to these rules were already approved by the MRTK Steering Committee.