### PR TITLE
Make GazePinchInteractor.DependentInteractor a XRBaseInteractor (Fix #605)

### DIFF
--- a/org.mixedrealitytoolkit.input/Interactors/GazePinch/GazePinchInteractor.cs
+++ b/org.mixedrealitytoolkit.input/Interactors/GazePinch/GazePinchInteractor.cs
@@ -70,12 +70,12 @@ namespace MixedReality.Toolkit.Input
 
         [SerializeField]
         [Tooltip("The interactor we're using to query potential gaze pinch targets")]
-        private XRBaseControllerInteractor dependentInteractor;
+        private XRBaseInteractor dependentInteractor;
 
         /// <summary>
         /// The pose source representing the ray this interactor uses for aiming and positioning.
         /// </summary>
-        protected XRBaseControllerInteractor DependentInteractor { get => dependentInteractor; set => dependentInteractor = value; }
+        protected XRBaseInteractor DependentInteractor { get => dependentInteractor; set => dependentInteractor = value; }
 
         [SerializeField]
         [Range(0, 1)]


### PR DESCRIPTION
Fixes #605
XRI 3 deprecates `XRBaseControllerInteractor` in favor `XRBaseInputInteractor`. This breaks `GazePointInteractor` as  `GazePinchInteractor.DependentInteractor` is a `XRBaseControllerInteractor`. This PR makes this variable an `XRBaseInteractor`. This shouldn't cause any conflicts as only its `IXRInteractor` interface implementations are used.