### PR TITLE
Add alternative LOSAngularOffsetHandRayPoseSource

### DIFF
--- a/UnityProjects/MRTKDevTemplate/Packages/packages-lock.json
+++ b/UnityProjects/MRTKDevTemplate/Packages/packages-lock.json
@@ -361,7 +361,7 @@
         "com.unity.xr.core-utils": "2.1.0",
         "com.unity.xr.hands": "1.3.0",
         "com.unity.xr.interaction.toolkit": "2.3.0",
-        "org.mixedrealitytoolkit.core": "3.1.0"
+        "org.mixedrealitytoolkit.core": "3.2.0"
       }
     },
     "org.mixedrealitytoolkit.spatialmanipulation": {

--- a/org.mixedrealitytoolkit.core/Utilities/StabilizedRay.cs
+++ b/org.mixedrealitytoolkit.core/Utilities/StabilizedRay.cs
@@ -53,6 +53,18 @@ namespace MixedReality.Toolkit
         }
 
         /// <summary>
+        /// StabilizedRay with distinct position and direction half life values.
+        /// HalfLife closer to zero means lerp closer to one.
+        /// </summary>
+        /// <param name="positionHalfLife">The half life used for position decay calculations.</param>
+        /// <param name="directionHalfLife">The half life used for direction decay calculations.</param>
+        public StabilizedRay(float positionHalfLife, float directionHalfLife)
+        {
+            HalfLifePosition = positionHalfLife;
+            HalfLifeDirection = directionHalfLife;
+        }
+
+        /// <summary>
         /// Add sample to ray stabilizer.
         /// </summary>
         /// <param name="ray">New Sample used to update stabilized ray.</param>

--- a/org.mixedrealitytoolkit.core/package.json
+++ b/org.mixedrealitytoolkit.core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "org.mixedrealitytoolkit.core",
-  "version": "3.1.1-development",
+  "version": "3.2.0-development",
   "description": "A limited collection of common interfaces and utilities that most MRTK packages share. Most implementations of these interfaces are contained in other packages in the MRTK ecosystem.",
   "displayName": "MRTK Core Definitions",
   "msftFeatureCategory": "MRTK3",

--- a/org.mixedrealitytoolkit.input/Utilities/PoseSource/LOSAngularOffsetHandRayPoseSource.cs
+++ b/org.mixedrealitytoolkit.input/Utilities/PoseSource/LOSAngularOffsetHandRayPoseSource.cs
@@ -1,0 +1,96 @@
+// Copyright (c) Mixed Reality Toolkit Contributors
+// Licensed under the BSD 3-Clause
+
+using System;
+using UnityEngine;
+using UnityEngine.XR;
+
+namespace MixedReality.Toolkit.Input
+{
+    /// <summary>
+    /// A pose source which represents a hand ray. This hand ray is constructed by deriving it from a
+    /// line of sight (LOS) head to knuckle vector with angular offset applied.
+    /// </summary>
+    [Serializable]
+    public class LOSAngularOffsetHandRayPoseSource : HandBasedPoseSource
+    {
+        [SerializeField]
+        [Tooltip("The half life used for the position of the StabilizedRay.  A value of 0 means no stabilization/smoothing.")]
+        private float stabilizedPositionHalfLife = .01f;
+
+        [SerializeField]
+        [Tooltip("The half life used for the direction of the StabilizedRay.  A value of 0 means no stabilization/smoothing.")]
+        private float stabilizedDirectionHalfLife = .05f;
+
+        /// <summary>
+        /// The StabilizedRay used in hand ray stabilization calculations.
+        /// </summary>
+        protected Lazy<StabilizedRay> StabilizedHandRay { get; private set; }
+
+        /// <summary>
+        /// A cache of the knuckle joint pose returned by the hands aggregator.
+        /// </summary>
+        private HandJointPose knuckle;
+
+        private const float HeadCenterOffset = .09f;
+        private readonly Vector2 MinMaxYawAngleOffset = new Vector2(-12f, -35f);
+        private readonly Vector2 MinMaxPitchAngleOffset = new Vector2(-24f, -85f);
+        private const float MinMaxAngleAdjustHandProximity = .5f;
+
+        public LOSAngularOffsetHandRayPoseSource()
+        {
+             StabilizedHandRay = new Lazy<StabilizedRay>(() =>
+             {
+                 return new StabilizedRay(stabilizedPositionHalfLife, stabilizedDirectionHalfLife);
+             });
+        }
+
+        /// <summary>
+        /// Tries to get the pose of the hand ray in world space by deriving it from a
+        /// line of sight head to knuckle vector with angular offset applied.
+        /// </summary>
+        public override bool TryGetPose(out Pose pose)
+        {
+            XRNode? handNode = Hand.ToXRNode();
+
+            bool poseRetrieved = handNode.HasValue;
+            poseRetrieved &= XRSubsystemHelpers.HandsAggregator?.TryGetJoint(TrackedHandJoint.IndexProximal, handNode.Value, out knuckle) ?? false;
+
+            if (poseRetrieved)
+            {
+                pose = CalculateHandRay(knuckle.Position, Camera.main.transform, Hand);
+            }
+            else
+            {
+                pose = Pose.identity;
+            }
+
+            return poseRetrieved;
+        }
+
+        private Pose CalculateHandRay(Vector3 handJointPosition, Transform headTransform, Handedness hand)
+        {
+            // Approximate head center to reduce the head rotation wobble effect on the hand ray.
+            Vector3 headCenter = headTransform.position - headTransform.forward * HeadCenterOffset;
+            Vector3 headToJoint = handJointPosition - headCenter;
+
+            // Adjust yaw and pitch angle offsets to more closely approximate the original hand ray orientation behavior affected by hand proximity.
+            float t = Mathf.InverseLerp(MinMaxAngleAdjustHandProximity, 0, headToJoint.magnitude);
+            float yawOffset = Mathf.Lerp(MinMaxYawAngleOffset.x, MinMaxYawAngleOffset.y, t) * (hand == Handedness.Right ? 1.0f : -1.0f);
+            float pitchOffset = Mathf.Lerp(MinMaxPitchAngleOffset.x, MinMaxPitchAngleOffset.y, t);
+
+            Quaternion rayRotation = Quaternion.LookRotation(headToJoint, headTransform.up) * Quaternion.Euler(pitchOffset, yawOffset, 0);
+
+            if (stabilizedPositionHalfLife > 0 || stabilizedDirectionHalfLife > 0)
+            {
+                StabilizedHandRay.Value.AddSample(new Ray(handJointPosition, rayRotation * Vector3.forward));
+
+                return new Pose(StabilizedHandRay.Value.StabilizedPosition, Quaternion.LookRotation(StabilizedHandRay.Value.StabilizedDirection, headTransform.up));
+            }
+            else
+            {
+                return new Pose(handJointPosition, rayRotation);
+            }
+        }
+    }
+}

--- a/org.mixedrealitytoolkit.input/Utilities/PoseSource/LOSAngularOffsetHandRayPoseSource.cs
+++ b/org.mixedrealitytoolkit.input/Utilities/PoseSource/LOSAngularOffsetHandRayPoseSource.cs
@@ -39,10 +39,10 @@ namespace MixedReality.Toolkit.Input
 
         public LOSAngularOffsetHandRayPoseSource()
         {
-             StabilizedHandRay = new Lazy<StabilizedRay>(() =>
-             {
-                 return new StabilizedRay(stabilizedPositionHalfLife, stabilizedDirectionHalfLife);
-             });
+            StabilizedHandRay = new Lazy<StabilizedRay>(() =>
+            {
+                return new StabilizedRay(stabilizedPositionHalfLife, stabilizedDirectionHalfLife);
+            });
         }
 
         /// <summary>
@@ -51,7 +51,15 @@ namespace MixedReality.Toolkit.Input
         /// </summary>
         public override bool TryGetPose(out Pose pose)
         {
+            Debug.Assert(Hand == Handedness.Left || Hand == Handedness.Right, $"The {GetType().Name} does not have a valid hand assigned.");
+
             XRNode? handNode = Hand.ToXRNode();
+
+            if (!handNode.HasValue)
+            {
+                pose = Pose.identity;
+                return false;
+            }
 
             bool poseRetrieved = handNode.HasValue;
             poseRetrieved &= XRSubsystemHelpers.HandsAggregator?.TryGetJoint(TrackedHandJoint.IndexProximal, handNode.Value, out knuckle) ?? false;

--- a/org.mixedrealitytoolkit.input/Utilities/PoseSource/LOSAngularOffsetHandRayPoseSource.cs.meta
+++ b/org.mixedrealitytoolkit.input/Utilities/PoseSource/LOSAngularOffsetHandRayPoseSource.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5be67dbc85da5dd47b082dfda3a680af
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/org.mixedrealitytoolkit.input/Utilities/PoseSource/PolyfillHandRayPoseSource.cs
+++ b/org.mixedrealitytoolkit.input/Utilities/PoseSource/PolyfillHandRayPoseSource.cs
@@ -34,7 +34,15 @@ namespace MixedReality.Toolkit.Input
         /// </summary>
         public override bool TryGetPose(out Pose pose)
         {
+            Debug.Assert(Hand == Handedness.Left || Hand == Handedness.Right, $"The {GetType().Name} does not have a valid hand assigned.");
+
             XRNode? handNode = Hand.ToXRNode();
+
+            if (!handNode.HasValue)
+            {
+                pose = Pose.identity;
+                return false;
+            }
 
             bool poseRetrieved = handNode.HasValue;
             poseRetrieved &= XRSubsystemHelpers.HandsAggregator?.TryGetJoint(TrackedHandJoint.IndexProximal, handNode.Value, out knuckle) ?? false;

--- a/org.mixedrealitytoolkit.input/package.json
+++ b/org.mixedrealitytoolkit.input/package.json
@@ -1,6 +1,6 @@
 {
   "name": "org.mixedrealitytoolkit.input",
-  "version": "3.1.0-development",
+  "version": "3.2.0-development",
   "description": "This package contains custom interactors and controllers that build on the foundation established by Unity's XR Interaction Toolkit. In addition, it contains hand joint aggregation and simulation subsystems, which allows for a single API for both real, device-driven hands and simulated hands. \n\nThe vast majority of actual input processing is not done by this package; instead, MRTK builds on the input data and interaction fundamentals already provided by the Unity Input System and XR Interaction Toolkit. \n\nWhen using MRTK Input in a project, it is not strictly necessary to have your package take a dependency on MRTK Input; the custom interactors in this package are fully compatible with the vanilla XRI APIs, and will both parse and generate all the same events and interactions that other XRI interactors will.",
   "displayName": "MRTK Input",
   "msftFeatureCategory": "MRTK3",

--- a/org.mixedrealitytoolkit.input/package.json
+++ b/org.mixedrealitytoolkit.input/package.json
@@ -21,6 +21,6 @@
     "com.unity.xr.core-utils": "2.1.0",
     "com.unity.xr.hands": "1.3.0",
     "com.unity.xr.interaction.toolkit": "2.3.0",
-    "org.mixedrealitytoolkit.core": "3.1.0"
+    "org.mixedrealitytoolkit.core": "3.2.0"
   }
 }


### PR DESCRIPTION
Fixes #548 
Likely also fixes #580 

Fixes the issue by adding an alternative hand ray pose source that can optionally be used that is much less affected by head rotations.  To utilize the new hand ray pose source, within the MRTK XR Rig, select the Far Ray of each hand:

![image](https://github.com/MixedRealityToolkit/MixedRealityToolkit-Unity/assets/58860572/db985877-3d50-4dc6-b1ee-36b542590a95)

Then in the Inspector for each Far Ray, add an Aim Pose Source and select the LOSAngularOffsetHandRayPoseSource.  Move the new pose source to the top of the list so it takes precedence, and set the hand:

![image](https://github.com/MixedRealityToolkit/MixedRealityToolkit-Unity/assets/58860572/21bf4491-1856-4a72-ae36-16e07efe3a33)

Example video demonstrating the change.  The white ray is the existing hand ray, the green ray is the new LOSAngularOffsetHandRayPoseSource:

https://github.com/MixedRealityToolkit/MixedRealityToolkit-Unity/assets/58860572/38b95fe7-1bfb-4d75-87ea-443d8e2ced91


