### PR TITLE
Auto disable button's colliders when `StatefulInteractable` is disabled

### DIFF
--- a/UnityProjects/MRTKDevTemplate/Packages/packages-lock.json
+++ b/UnityProjects/MRTKDevTemplate/Packages/packages-lock.json
@@ -397,7 +397,7 @@
       "source": "local",
       "dependencies": {
         "com.microsoft.mrtk.graphicstools.unity": "0.5.12",
-        "org.mixedrealitytoolkit.uxcore": "3.1.0",
+        "org.mixedrealitytoolkit.uxcore": "3.2.0",
         "org.mixedrealitytoolkit.spatialmanipulation": "3.0.0",
         "org.mixedrealitytoolkit.standardassets": "3.0.0",
         "com.unity.xr.interaction.toolkit": "2.3.0"

--- a/org.mixedrealitytoolkit.uxcomponents/Button/Prefabs/Empty Button.prefab
+++ b/org.mixedrealitytoolkit.uxcomponents/Button/Prefabs/Empty Button.prefab
@@ -341,6 +341,7 @@ GameObject:
   - component: {fileID: 3705378105823492763}
   - component: {fileID: 3705378105823492760}
   - component: {fileID: 3705378105823492761}
+  - component: {fileID: 7288588985133169393}
   - component: {fileID: 3705378105823492766}
   - component: {fileID: 3705378105823492764}
   - component: {fileID: 8714766618717182506}
@@ -684,6 +685,22 @@ MonoBehaviour:
   attachedRectTransform: {fileID: 3705378105823492765}
   padding: {x: 0, y: 0}
   forceUpdateEveryFrame: 0
+  canToggleCollider: 1
+--- !u!114 &7288588985133169393
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3705378105823492738}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c9d6a03b734049145b6eaf0d01bbd59b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  statefulInteractable: {fileID: 3705378105823492762}
+  thisCollider: {fileID: 3705378105823492760}
+  colliderFitter: {fileID: 3705378105823492761}
 --- !u!95 &3705378105823492766
 Animator:
   serializedVersion: 5

--- a/org.mixedrealitytoolkit.uxcomponents/package.json
+++ b/org.mixedrealitytoolkit.uxcomponents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "org.mixedrealitytoolkit.uxcomponents",
-  "version": "3.1.1-development",
+  "version": "3.2.0-development",
   "description": "MRTK UX component library, leveraging RectTransform/Canvas for dynamic layout and presentation. Contains prefabs, visuals, pre-made controls, and everything to get started building 3D user interfaces for mixed reality.",
   "displayName": "MRTK UX Components",
   "msftFeatureCategory": "MRTK3",
@@ -16,7 +16,7 @@
   "unity": "2021.3",
   "dependencies": {
     "com.microsoft.mrtk.graphicstools.unity": "0.5.12",
-    "org.mixedrealitytoolkit.uxcore": "3.1.0",
+    "org.mixedrealitytoolkit.uxcore": "3.2.0",
     "org.mixedrealitytoolkit.spatialmanipulation": "3.0.0",
     "org.mixedrealitytoolkit.standardassets": "3.0.0",
     "com.unity.xr.interaction.toolkit": "2.3.0"

--- a/org.mixedrealitytoolkit.uxcore/Button/RectTransformColliderFitter.cs
+++ b/org.mixedrealitytoolkit.uxcore/Button/RectTransformColliderFitter.cs
@@ -44,7 +44,17 @@ namespace MixedReality.Toolkit.UX
                 }
                 return thisCollider;
             }
-            set => thisCollider = value;
+            set
+            {
+                if (thisCollider != value)
+                {
+                    thisCollider = value;
+                    if (thisCollider != null)
+                    {
+                        Fit();
+                    }
+                }
+            }
         }
 
         [SerializeField]
@@ -81,6 +91,29 @@ namespace MixedReality.Toolkit.UX
                  "When false, this script will disable itself on startup." +
                  "To control this from code, simply use .enabled on the component.")]
         private bool forceUpdateEveryFrame;
+
+        [SerializeField]
+        [Tooltip("When true, the collider will be enabled/disabled based on whether or not the collider is visible.")]
+        private bool canToggleCollider = true;
+
+        /// <summary>
+        /// When true, <paramref name="thisCollider"/> will be enabled/disabled based on whether or not the collider is visible.
+        /// </summary>
+        public bool CanToggleCollider
+        {
+            get => canToggleCollider;
+            set
+            {
+                if (canToggleCollider != value)
+                {
+                    canToggleCollider = value;
+                    if (canToggleCollider)
+                    {
+                        Fit();
+                    }
+                }
+            }
+        }
 
         private Canvas canvas;
 
@@ -212,7 +245,7 @@ namespace MixedReality.Toolkit.UX
                     // Compute the intersection.
                     bool intersects = AttachedRectTransform.rect.Intersects(localClipRect, out computedRect);
 
-                    if (thisCollider != null)
+                    if (thisCollider != null && canToggleCollider)
                     {
                         // If no intersection at all, kill the collider.
                         if (!intersects)

--- a/org.mixedrealitytoolkit.uxcore/Button/StatefulInteractableColliderToggle.cs
+++ b/org.mixedrealitytoolkit.uxcore/Button/StatefulInteractableColliderToggle.cs
@@ -1,0 +1,106 @@
+// Copyright (c) Mixed Reality Toolkit Contributors
+// Licensed under the BSD 3-Clause
+
+using Unity.Profiling;
+using UnityEngine;
+using UnityEngine.EventSystems;
+using UnityEngine.Serialization;
+using UnityEngine.UI;
+
+namespace MixedReality.Toolkit.UX
+{
+    /// <summary>
+    /// The 'InteractableColliderToggle' class is responsible for managing the state of the collider 
+    /// associated with a StatefulInteractable in the Unity UI. It enables or disables the collider based on 
+    /// the state of the associated 'StatefulInteractable' object.
+    /// </summary>
+    [AddComponentMenu("MRTK/UX/Stateful Interactable Collider Toggle")]
+    public class StatefulInteractableColliderToggle : UIBehaviour
+    {       
+        [SerializeField]
+        [Tooltip("The StatefulInteractable to enable or disable the collider based on the Interactable's state.")]
+        private StatefulInteractable statefulInteractable;
+
+        /// <summary>
+        /// The StatefulInteractable to enable or disable the collider based on the Interactable's state.
+        /// </summary>
+        public StatefulInteractable StatefulInteractable
+        {
+            get => statefulInteractable;
+            set => statefulInteractable = value;
+        }
+        
+        [SerializeField]
+        [Tooltip("The collider to enable or disable based on the Interactable's state.")]
+        private BoxCollider thisCollider;
+
+        /// <summary>
+        /// The collider to enable or disable based on the Interactable's state.
+        /// </summary>
+        public BoxCollider ThisCollider
+        {
+            get => thisCollider;
+            set
+            {
+                if (thisCollider != value)
+                {
+                    thisCollider = value;
+                    UpdateCollider();
+                }
+            }
+        }
+
+        [SerializeField]
+        private RectTransformColliderFitter colliderFitter;
+
+        public RectTransformColliderFitter ColliderFitter
+        {
+            get => colliderFitter;
+            set 
+            {
+                if (colliderFitter != value)
+                {
+                    colliderFitter = value;
+                    UpdateCollider();
+                }
+            }
+        }
+
+        protected virtual void OnEnable()
+        {
+            if (statefulInteractable != null)
+            {
+                statefulInteractable.OnDisabled.AddListener(OnInteractableDisabled);
+                statefulInteractable.OnEnabled.AddListener(OnInteractableEnabled);
+            }
+
+            UpdateCollider();
+        }
+
+        protected virtual void OnDisable()
+        {
+            if (statefulInteractable != null)
+            {
+                statefulInteractable.OnDisabled.RemoveListener(OnInteractableDisabled);
+                statefulInteractable.OnEnabled.RemoveListener(OnInteractableEnabled);
+            }
+        }
+
+        protected virtual void OnInteractableDisabled() => UpdateCollider();
+
+        protected virtual void OnInteractableEnabled() => UpdateCollider();
+
+        private void UpdateCollider()
+        {
+            if (thisCollider != null)
+            {
+                thisCollider.enabled = statefulInteractable.enabled;
+
+                if (colliderFitter != null)
+                {
+                    colliderFitter.CanToggleCollider = statefulInteractable.enabled;
+                }
+            }
+        }
+    }
+}

--- a/org.mixedrealitytoolkit.uxcore/Button/StatefulInteractableColliderToggle.cs
+++ b/org.mixedrealitytoolkit.uxcore/Button/StatefulInteractableColliderToggle.cs
@@ -1,58 +1,45 @@
 // Copyright (c) Mixed Reality Toolkit Contributors
 // Licensed under the BSD 3-Clause
 
-using Unity.Profiling;
 using UnityEngine;
-using UnityEngine.EventSystems;
-using UnityEngine.Serialization;
-using UnityEngine.UI;
 
 namespace MixedReality.Toolkit.UX
 {
     /// <summary>
-    /// The 'InteractableColliderToggle' class is responsible for managing the state of the collider 
-    /// associated with a StatefulInteractable in the Unity UI. It enables or disables the collider based on 
-    /// the state of the associated 'StatefulInteractable' object.
+    /// The <see cref="StatefulInteractableColliderToggle"/> class is responsible for managing the state of the collider 
+    /// associated with a <see cref="StatefulInteractable"/>.
+    /// </summary>
+    /// <remarks>
+    /// This class will enables or disables the colliders associated with <see cref="StatefulInteractable"/> based on
+    /// the enabled state of <see cref="StatefulInteractable"/>.
     /// </summary>
     [AddComponentMenu("MRTK/UX/Stateful Interactable Collider Toggle")]
-    public class StatefulInteractableColliderToggle : UIBehaviour
+    public class StatefulInteractableColliderToggle : MonoBehaviour
     {       
         [SerializeField]
-        [Tooltip("The StatefulInteractable to enable or disable the collider based on the Interactable's state.")]
+        [Tooltip("The StatefulInteractable to enable or disable the collider based on the interactable's enabled state.")]
         private StatefulInteractable statefulInteractable;
 
         /// <summary>
-        /// The StatefulInteractable to enable or disable the collider based on the Interactable's state.
+        /// The <see cref="StatefulInteractable"/> to enable or disable the collider based on the interactable's enabled state.
         /// </summary>
         public StatefulInteractable StatefulInteractable
         {
             get => statefulInteractable;
             set => statefulInteractable = value;
         }
-        
-        [SerializeField]
-        [Tooltip("The collider to enable or disable based on the Interactable's state.")]
-        private BoxCollider thisCollider;
-
-        /// <summary>
-        /// The collider to enable or disable based on the Interactable's state.
-        /// </summary>
-        public BoxCollider ThisCollider
-        {
-            get => thisCollider;
-            set
-            {
-                if (thisCollider != value)
-                {
-                    thisCollider = value;
-                    UpdateCollider();
-                }
-            }
-        }
 
         [SerializeField]
+        [Tooltip("The RectTransformColliderFitter that automatically disables the interactable's colliders based visibility.")]
         private RectTransformColliderFitter colliderFitter;
 
+        /// <summary>
+        /// The <see cref="RectTransformColliderFitter"/> that automatically disables the interactable's colliders based visibility.
+        /// </summary>
+        /// <remarks>
+        /// The <see cref="StatefulInteractableColliderToggle"/> class will change <see cref="RectTransformColliderFitter.CanToggleCollider"/>
+        /// based on the enabled state of <see cref="StatefulInteractable"/>.
+        /// </remarks>
         public RectTransformColliderFitter ColliderFitter
         {
             get => colliderFitter;
@@ -66,6 +53,9 @@ namespace MixedReality.Toolkit.UX
             }
         }
 
+        /// <summary>
+        /// A Unity event function that is called when the script component has been enabled.
+        /// </summary> 
         protected virtual void OnEnable()
         {
             if (statefulInteractable != null)
@@ -77,6 +67,9 @@ namespace MixedReality.Toolkit.UX
             UpdateCollider();
         }
 
+        /// <summary>
+        /// A Unity event function that is called when the script component has been disabled.
+        /// </summary> 
         protected virtual void OnDisable()
         {
             if (statefulInteractable != null)
@@ -86,15 +79,29 @@ namespace MixedReality.Toolkit.UX
             }
         }
 
-        protected virtual void OnInteractableDisabled() => UpdateCollider();
+        /// <summary>
+        /// Function called when the interactable has been disabled.
+        /// </summary>
+        private void OnInteractableDisabled() => UpdateCollider();
 
-        protected virtual void OnInteractableEnabled() => UpdateCollider();
+        /// <summary>
+        /// Function called when the interactable has been enabled.
+        /// </summary>
+        private void OnInteractableEnabled() => UpdateCollider();
 
+        /// <summary>
+        /// Update the interactable's collider's and the filler's enablement based on the interactable's enabled state.
+        /// </summary>
         private void UpdateCollider()
         {
-            if (thisCollider != null)
+            if (statefulInteractable != null && statefulInteractable.colliders != null)
             {
-                thisCollider.enabled = statefulInteractable.enabled;
+                int colliderCount = statefulInteractable.colliders.Count;
+                for (int i = 0; i < colliderCount; i++)
+                {
+                    var collider = statefulInteractable.colliders[i];
+                    collider.enabled = statefulInteractable.enabled;
+                }
 
                 if (colliderFitter != null)
                 {

--- a/org.mixedrealitytoolkit.uxcore/Button/StatefulInteractableColliderToggle.cs
+++ b/org.mixedrealitytoolkit.uxcore/Button/StatefulInteractableColliderToggle.cs
@@ -26,7 +26,16 @@ namespace MixedReality.Toolkit.UX
         public StatefulInteractable StatefulInteractable
         {
             get => statefulInteractable;
-            set => statefulInteractable = value;
+            set
+            {
+                if (statefulInteractable != value)
+                {
+                    RemoveStatefulInteractableEventHandlers();
+                    statefulInteractable = value;
+                    AddStatefulInteractableEventHandlers();
+                    UpdateCollider();
+                }
+            }
         }
 
         [SerializeField]
@@ -58,12 +67,7 @@ namespace MixedReality.Toolkit.UX
         /// </summary> 
         protected virtual void OnEnable()
         {
-            if (statefulInteractable != null)
-            {
-                statefulInteractable.OnDisabled.AddListener(OnInteractableDisabled);
-                statefulInteractable.OnEnabled.AddListener(OnInteractableEnabled);
-            }
-
+            AddStatefulInteractableEventHandlers();
             UpdateCollider();
         }
 
@@ -71,6 +75,26 @@ namespace MixedReality.Toolkit.UX
         /// A Unity event function that is called when the script component has been disabled.
         /// </summary> 
         protected virtual void OnDisable()
+        {
+            RemoveStatefulInteractableEventHandlers();
+        }
+
+        /// <summary>
+        /// Add event handlers to the <see cref="StatefulInteractable"/> to enable or disable the collider based on the interactable's enabled state.
+        /// </summary>
+        private void AddStatefulInteractableEventHandlers()
+        {
+            if (statefulInteractable != null)
+            {
+                statefulInteractable.OnDisabled.AddListener(OnInteractableDisabled);
+                statefulInteractable.OnEnabled.AddListener(OnInteractableEnabled);
+            }
+        }
+
+        /// <summary>
+        /// Remove event handlers from the <see cref="StatefulInteractable"/> that enable or disable the collider based on the interactable's enabled state.
+        /// </summary>
+        private void RemoveStatefulInteractableEventHandlers()
         {
             if (statefulInteractable != null)
             {

--- a/org.mixedrealitytoolkit.uxcore/Button/StatefulInteractableColliderToggle.cs.meta
+++ b/org.mixedrealitytoolkit.uxcore/Button/StatefulInteractableColliderToggle.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c9d6a03b734049145b6eaf0d01bbd59b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/org.mixedrealitytoolkit.uxcore/package.json
+++ b/org.mixedrealitytoolkit.uxcore/package.json
@@ -1,6 +1,6 @@
 {
   "name": "org.mixedrealitytoolkit.uxcore",
-  "version": "3.1.1-development",
+  "version": "3.2.0-development",
   "description": "Core interaction and visualization scripts for building MR user interface components.\n\nNote: this is intended to be consumed in order to build UX libraries. To build MR interfaces with a pre-existing library of components, see org.mixedrealitytoolkit.uxcomponents.",
   "displayName": "MRTK UX Core Scripts",
   "msftFeatureCategory": "MRTK3",


### PR DESCRIPTION
# Overview

This pull request aims to make it easier to disable an interactable’s colliders when `StatefiulInteractable.IsInteractable` is false or when the `StatefiulInteractable.enabled` is false. This is because list scrolling would break if the user attempted to scroll the list while focusing the disabled interactable. This is because the interactable’s collider was still enabled and blocking ray casts to the list’s backplate.

To work around this, this change adds a new button component, `StatefulInteractableColliderToggle`, and new property, `RectTransformColliderFitter.CanToggleCollider`. The new `RectTransformColliderFitter` property, `CanToggleCollider`, will allow code to turn off the fitter’s automatic enabling/disabling when the collider's visibility changes. The new behavior class, `StatefulInteractableColliderToggle`, automatically disables or enables an interactable’s colliders based on this interactor’s enablement state. This component, to prevent visibility changes causing false collider enables, also sets the `RectTransformColliderFitter.CanToggleCollider` value.

Unit tests were added to validate this new functionality.

# Fixes
- https://github.com/MixedRealityToolkit/MixedRealityToolkit-Unity/issues/574

# Alternative Considerations

1. Adding auto-collider-disablement logic to the interactable itself was considered. However, in order to prevent the RectTransformColliderFitter from changing the collider’s enabled state as well, the interactable would introduce a reference to RectTransformColliderFitter. This would add additional complication to the interactable code that most scenarios don’t require. As such, it was opted to move logic to an isolated component that could be selectively added to the appropriate scenarios.

2. Adding auto-collider-disable logic to `RectTransformColliderFitter`. This would fit nicely into `RectTransformColliderFitter`, since `RectTransformColliderFitter` is already controlling collider's enablement.  However, for this to work correctly, `RectTransformColliderFitter` would need a reference to the interactable so it could query the interactor's enabled state. Leaking interactor knowledge into `RectTransformColliderFitter` was not desired, as `RectTransformColliderFitter`'s main purpose is to resize a collider to fitter a transform.  This resize logic can be useful for non-interactable components.  So leaking interactable knowledge into `RectTransformColliderFitter` would muddy its original intent, to resize colliders.