### PR TITLE
Fixing shaders of a couple of TMPro fonts

### DIFF
--- a/Pipelines/Config/settings.yaml
+++ b/Pipelines/Config/settings.yaml
@@ -5,5 +5,5 @@ variables:
   # ProjectSettings/ProjectSettings.asset:  bundleVersion: x.x.x
   # ProjectSettings/ProjectSettings.asset:  metroPackageVersion: x.x.x.0
   MRTKVersion: 3.0.0        # used for overall build number, but each package version is read from the package.json file in each package directory.
-  MRTKReleaseTag: 'pre.19'  # final version component, e.g. 'RC2.1' or empty string.
+  MRTKReleaseTag: 'pre.20'  # final version component, e.g. 'RC2.1' or empty string.
   ReleasePackages: '"org.mixedrealitytoolkit.audio,org.mixedrealitytoolkit.core,org.mixedrealitytoolkit.diagnostics,org.mixedrealitytoolkit.extendedassets,org.mixedrealitytoolkit.input,org.mixedrealitytoolkit.spatialmanipulation,org.mixedrealitytoolkit.standardassets,org.mixedrealitytoolkit.tools,org.mixedrealitytoolkit.uxcomponents,org.mixedrealitytoolkit.uxcomponents.noncanvas,org.mixedrealitytoolkit.uxcore,org.mixedrealitytoolkit.windowsspeech"'   # array of packages that shouldn't get the prerelease tag  e.g.  '"org.mixedrealitytoolkit.core,org.mixedrealitytoolkit.tools"'

--- a/UnityProjects/MRTKDevTemplate/Assets/Data Binding Example/Resources/Fonts & Materials/CooperHewitt-BoldItalic SDF.asset
+++ b/UnityProjects/MRTKDevTemplate/Assets/Data Binding Example/Resources/Fonts & Materials/CooperHewitt-BoldItalic SDF.asset
@@ -55,10 +55,10 @@ Material:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_Name: CooperHewitt-BoldItalic SDF Material
-  m_Shader: {fileID: 4800000, guid: 1c504b73bf66872479cd1215fb5ce0fe, type: 3}
-  m_ValidKeywords: []
-  m_InvalidKeywords:
+  m_Shader: {fileID: 4800000, guid: c5f3f59b19556b3479f929a84f25f776, type: 3}
+  m_ValidKeywords:
   - OUTLINE_ON
+  m_InvalidKeywords: []
   m_LightmapFlags: 4
   m_EnableInstancingVariants: 0
   m_DoubleSidedGI: 0
@@ -99,7 +99,10 @@ Material:
     - _BumpFace: 0
     - _BumpOutline: 0
     - _ColorMask: 15
+    - _CullMode: 0
     - _Diffuse: 0.5
+    - _DstBlend: 10
+    - _DstBlendAlpha: 1
     - _FaceDilate: 0
     - _FaceUVSpeedX: 0
     - _FaceUVSpeedY: 0
@@ -125,6 +128,8 @@ Material:
     - _ShaderFlags: 0
     - _Sharpness: 0
     - _SpecularPower: 2
+    - _SrcBlend: 1
+    - _SrcBlendAlpha: 1
     - _Stencil: 0
     - _StencilComp: 8
     - _StencilOp: 0
@@ -140,9 +145,11 @@ Material:
     - _VertexOffsetY: 0
     - _WeightBold: 0.75
     - _WeightNormal: 0
+    - _ZTest: 4
     - _ZWrite: 0
     m_Colors:
     - _ClipRect: {r: -32767, g: -32767, b: 32767, a: 32767}
+    - _ClipRectRadii: {r: 10, g: 10, b: 10, a: 10}
     - _EnvMatrixRotation: {r: 0, g: 0, b: 0, a: 0}
     - _FaceColor: {r: 1, g: 1, b: 1, a: 1}
     - _GlowColor: {r: 0, g: 1, b: 0, a: 0.5}

--- a/org.mixedrealitytoolkit.standardassets/Icons/MRTK_FluentIconSet SDF.asset
+++ b/org.mixedrealitytoolkit.standardassets/Icons/MRTK_FluentIconSet SDF.asset
@@ -3794,7 +3794,7 @@ Material:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_Name: MRTK_FluentIconSet SDF Material
-  m_Shader: {fileID: 4800000, guid: 68e6db2ebdc24f95958faec2be5558d6, type: 3}
+  m_Shader: {fileID: 4800000, guid: c5f3f59b19556b3479f929a84f25f776, type: 3}
   m_ValidKeywords: []
   m_InvalidKeywords: []
   m_LightmapFlags: 4
@@ -3839,6 +3839,8 @@ Material:
     - _ColorMask: 15
     - _CullMode: 0
     - _Diffuse: 0.5
+    - _DstBlend: 10
+    - _DstBlendAlpha: 1
     - _FaceDilate: 0
     - _FaceUVSpeedX: 0
     - _FaceUVSpeedY: 0
@@ -3864,6 +3866,8 @@ Material:
     - _ShaderFlags: 0
     - _Sharpness: 0
     - _SpecularPower: 2
+    - _SrcBlend: 1
+    - _SrcBlendAlpha: 1
     - _Stencil: 0
     - _StencilComp: 8
     - _StencilOp: 0
@@ -3879,8 +3883,11 @@ Material:
     - _VertexOffsetY: 0
     - _WeightBold: 0.75
     - _WeightNormal: 0
+    - _ZTest: 4
+    - _ZWrite: 0
     m_Colors:
     - _ClipRect: {r: -32767, g: -32767, b: 32767, a: 32767}
+    - _ClipRectRadii: {r: 10, g: 10, b: 10, a: 10}
     - _EnvMatrixRotation: {r: 0, g: 0, b: 0, a: 0}
     - _FaceColor: {r: 1, g: 1, b: 1, a: 1}
     - _GlowColor: {r: 0, g: 1, b: 0, a: 0.5}


### PR DESCRIPTION
# Overview 

Updating MRTK_FluentIconSet SDF's shader to a Graphic Tools TMPro shader, so the font works in UPM projects.

Also, setting the Data packages's CooperHewitt-BoldItalic SDK shader to the Graphic Tools TMPro shader, is its original shader is missing.

## Valid Version Number

- [x] Validate Standard Asset Package. The standard asset package's version has already been updated since last release.
- [x] Validate Data Package. The data package is still in preview, and use the "preview version tag".  I've updated this tag to "pre.20"

# Fixes

- https://github.com/MixedRealityToolkit/MixedRealityToolkit-Unity/issues/668
- https://github.com/MixedRealityToolkit/MixedRealityToolkit-Unity/issues/672