### PR TITLE
Add logic to account for a bound but untracked interaction profile

### DIFF
--- a/org.mixedrealitytoolkit.input/CHANGELOG.md
+++ b/org.mixedrealitytoolkit.input/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [3.2.1-development] - 2024-03-20
+
+### Fixed
+
+* Add logic to account for a bound but untracked interaction profile. [PR #704](https://github.com/MixedRealityToolkit/MixedRealityToolkit-Unity/pull/704)
+
 ## [3.2.0-development] - 2024-03-20
 
 ### Added

--- a/org.mixedrealitytoolkit.input/package.json
+++ b/org.mixedrealitytoolkit.input/package.json
@@ -1,6 +1,6 @@
 {
   "name": "org.mixedrealitytoolkit.input",
-  "version": "3.2.0-development",
+  "version": "3.2.1-development",
   "description": "This package contains custom interactors and controllers that build on the foundation established by Unity's XR Interaction Toolkit. In addition, it contains hand joint aggregation and simulation subsystems, which allows for a single API for both real, device-driven hands and simulated hands. \n\nThe vast majority of actual input processing is not done by this package; instead, MRTK builds on the input data and interaction fundamentals already provided by the Unity Input System and XR Interaction Toolkit. \n\nWhen using MRTK Input in a project, it is not strictly necessary to have your package take a dependency on MRTK Input; the custom interactors in this package are fully compatible with the vanilla XRI APIs, and will both parse and generate all the same events and interactions that other XRI interactors will.",
   "displayName": "MRTK Input",
   "msftFeatureCategory": "MRTK3",


### PR DESCRIPTION
This could show up on runtimes where a controller is disconnected, hand tracking spins up, but the interaction profile is not cleared. This is allowed, per-spec: "The runtime may return the last-known interaction profile in the event that no controllers are active."

If we have a bound but untracked interaction profile, we now make an attempt at polyfilling based on hand tracking data.

Fixes #703