### PR TITLE
Assigned XRI hover events for tripod center piece to enable outlines (Fixes #692)

### DIFF
--- a/UnityProjects/MRTKDevTemplate/Assets/Scenes/OutlineExamples.unity
+++ b/UnityProjects/MRTKDevTemplate/Assets/Scenes/OutlineExamples.unity
@@ -4144,7 +4144,7 @@ MonoBehaviour:
   m_HoverEntered:
     m_PersistentCalls:
       m_Calls:
-      - m_Target: {fileID: 0}
+      - m_Target: {fileID: 1686868139}
         m_TargetAssemblyTypeName: UnityEngine.Behaviour, UnityEngine
         m_MethodName: set_enabled
         m_Mode: 6
@@ -4171,7 +4171,7 @@ MonoBehaviour:
   m_HoverExited:
     m_PersistentCalls:
       m_Calls:
-      - m_Target: {fileID: 0}
+      - m_Target: {fileID: 1686868139}
         m_TargetAssemblyTypeName: UnityEngine.Behaviour, UnityEngine
         m_MethodName: set_enabled
         m_Mode: 6


### PR DESCRIPTION
Fixes #692

The XRI hover events on the center of the tripod object in the OutlineExample scene were not set, resulting in the outline not appearing when selecting, looking at or pointing at the object.