### PR TITLE
Updated ConstantViewSize solver to retain the initial scale and aspect ratio (Fixes #306)

### DIFF
--- a/org.mixedrealitytoolkit.spatialmanipulation/CHANGELOG.md
+++ b/org.mixedrealitytoolkit.spatialmanipulation/CHANGELOG.md
@@ -2,13 +2,17 @@
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
-## [3.3.0-development] - 2024-04-5
+## [3.3.0-development] - 2024-04-07
 
 ### Added
 
-* Made bounds control overridable for custom translation, scaling and rotation logic. PR #715
+* Made bounds control overridable for custom translation, scaling and rotation logic. [PR #715](https://github.com/MixedRealityToolkit/MixedRealityToolkit-Unity/pull/715)
 
-## [3.2.0-development] - 2024-03-20
+### Fixed
+
+* ConstantViewSize solver now retains the initial scale and aspect ratio [PR #719](https://github.com/MixedRealityToolkit/MixedRealityToolkit-Unity/pull/719)
+
+## [3.2.0] - 2024-03-20
 
 ### Added
 

--- a/org.mixedrealitytoolkit.spatialmanipulation/Solvers/ConstantViewSize.cs
+++ b/org.mixedrealitytoolkit.spatialmanipulation/Solvers/ConstantViewSize.cs
@@ -119,9 +119,9 @@ namespace MixedReality.Toolkit.SpatialManipulation
         /// Get the current scale progress on this <see cref="ConstantViewSize"/> object.
         /// </summary>
         /// <remarks>
-        /// This is a value between zero and one, representing progress between 
+        /// This is a value between zero and one, representing progress between
         /// <see cref="MinScale"/> and <see cref="MaxScale"/>. If current scale is less
-        /// than max,  then scaling is being applied. This value is subject to inaccuracies
+        /// than max, then scaling is being applied. This value is subject to inaccuracies
         /// due to smoothing, interpolation, and momentum.
         /// </remarks>
         public float CurrentScalePercent { get; private set; } = 1f;
@@ -130,9 +130,9 @@ namespace MixedReality.Toolkit.SpatialManipulation
         /// Get the current distance progress on this <see cref="ConstantViewSize"/> object.
         /// </summary>
         /// <remarks>
-        /// This is a value between zero and one, representing progress between  
+        /// This is a value between zero and one, representing progress between
         /// <see cref="MinDistance"/> and <see cref="MaxDistance"/>. If current is less than
-        /// max, object is potentially on a surface. This value is subject to inaccuracies due 
+        /// max, object is potentially on a surface. This value is subject to inaccuracies due
         /// to smoothing, interpolation, and momentum.
         /// </remarks>
         public float CurrentDistancePercent { get; private set; } = 1f;
@@ -183,13 +183,13 @@ namespace MixedReality.Toolkit.SpatialManipulation
 
                 if (SolverHandler.TransformTarget != null)
                 {
-                    // Get current fov each time instead of trying to cache it.  Can never count on init order these days
+                    // Get current fov each time instead of trying to cache it. Can never count on init order these days
                     fovScalar = FovScale;
 
                     // Set the linked alt scale ahead of our work. This is an attempt to minimize jittering by having solvers work with an interpolated scale.
                     SolverHandler.AltScale.SetGoal(transform.localScale);
 
-                    // Calculate scale based on distance from view.  Do not interpolate so we can appear at a constant size if possible.  Borrowed from greybox.
+                    // Calculate scale based on distance from view. Do not interpolate so we can appear at a constant size if possible. Borrowed from greybox.
                     Vector3 targetPosition = SolverHandler.TransformTarget.position;
                     float distance = Mathf.Clamp(Vector3.Distance(transform.position, targetPosition), minDistance, maxDistance);
                     float scale = Mathf.Clamp(fovScalar * distance, minScale, maxScale);

--- a/org.mixedrealitytoolkit.spatialmanipulation/Solvers/ConstantViewSize.cs
+++ b/org.mixedrealitytoolkit.spatialmanipulation/Solvers/ConstantViewSize.cs
@@ -153,8 +153,16 @@ namespace MixedReality.Toolkit.SpatialManipulation
 
         #endregion
 
+        private Vector3 originalScale;
         private float fovScalar = 1f;
         private float objectSize = 1f;
+
+        /// <inheritdoc/>
+        protected override void Awake()
+        {
+            base.Awake();
+            originalScale = GoalScale;
+        }
 
         /// <inheritdoc/>
         protected override void Start()
@@ -185,7 +193,7 @@ namespace MixedReality.Toolkit.SpatialManipulation
                     Vector3 targetPosition = SolverHandler.TransformTarget.position;
                     float distance = Mathf.Clamp(Vector3.Distance(transform.position, targetPosition), minDistance, maxDistance);
                     float scale = Mathf.Clamp(fovScalar * distance, minScale, maxScale);
-                    GoalScale = Vector3.one * scale;
+                    GoalScale = originalScale * scale;
 
                     // Save some state information for external use
                     CurrentDistancePercent = Mathf.InverseLerp(minDistance, maxDistance, distance);


### PR DESCRIPTION
Fixes #306 

The ConstantViewSize solver now retains the original scale and aspect ratio as set by the base class Solver instead of using Vector3.one as the base scale.