### PR TITLE
Added a way to modify scaling, translation, and rotation logic using manipulationlogic class

### DIFF
--- a/org.mixedrealitytoolkit.spatialmanipulation/BoundsControl/BoundsControl.cs
+++ b/org.mixedrealitytoolkit.spatialmanipulation/BoundsControl/BoundsControl.cs
@@ -895,10 +895,7 @@ namespace MixedReality.Toolkit.SpatialManipulation
                     }
                     else if (currentHandle.HandleType == HandleType.Translation)
                     {
-                        //Vector3 translateVectorAlongAxis = Vector3.Project(currentGrabPoint - initialGrabPoint, currentHandle.transform.forward);
-
-                        //var goal = initialTransformOnGrabStart.Position + translateVectorAlongAxis;
-                        var goal = ManipulationLogicImplementations.moveLogic.Update(currentHandle.interactorsSelecting, interactable, targetTransform, ScaleAnchor == ScaleAnchorType.BoundsCenter);
+                        var goal = ManipulationLogicImplementations.moveLogic.Update(currentHandle.interactorsSelecting, interactable, targetTransform, true);
 
                         MixedRealityTransform constraintTranslate = MixedRealityTransform.NewTranslate(goal);
                         if (EnableConstraints && constraintsManager != null)
@@ -937,16 +934,28 @@ namespace MixedReality.Toolkit.SpatialManipulation
 public class BoundsControlMoveLogic : ManipulationLogic<Vector3>
 {
     private BoundsControl boundsCont;
+    private BoundsHandleInteractable currentHandle;
+    private Vector3 initialGrabPoint;
+    private MixedRealityTransform initialTransformOnGrabStart;
+
     public override void Setup(List<IXRSelectInteractor> interactors, IXRSelectInteractable interactable, MixedRealityTransform currentTarget)
     {
         base.Setup(interactors, interactable, currentTarget);
-        boundsCont = interactable.transform.GetComponent<BoundsHandleInteractable>().BoundsControlRoot;
+        currentHandle = interactable.transform.GetComponent<BoundsHandleInteractable>();
+        boundsCont = currentHandle.BoundsControlRoot;
+        initialGrabPoint = currentHandle.interactorsSelecting[0].GetAttachTransform(currentHandle).position;
+        initialTransformOnGrabStart = new MixedRealityTransform(boundsCont.Target.transform);
     }
 
     /// <inheritdoc />
     public override Vector3 Update(List<IXRSelectInteractor> interactors, IXRSelectInteractable interactable, MixedRealityTransform currentTarget, bool centeredAnchor)
     {
-        return base.Update(interactors, interactable, currentTarget, centeredAnchor);
+        base.Update(interactors, interactable, currentTarget, centeredAnchor);
+
+        Vector3 currentGrabPoint = currentHandle.interactorsSelecting[0].GetAttachTransform(currentHandle).position;
+        Vector3 translateVectorAlongAxis = Vector3.Project(currentGrabPoint - initialGrabPoint, currentHandle.transform.forward);
+
+        return initialTransformOnGrabStart.Position + translateVectorAlongAxis;
     }
 }
 

--- a/org.mixedrealitytoolkit.spatialmanipulation/BoundsControl/BoundsControl.cs
+++ b/org.mixedrealitytoolkit.spatialmanipulation/BoundsControl/BoundsControl.cs
@@ -502,6 +502,7 @@ namespace MixedReality.Toolkit.SpatialManipulation
 
         // The corner opposite from the current scale handle (if a scale handle is being selected)
         private Vector3 oppositeCorner;
+        public Vector3 OppositeCorner => oppositeCorner;
 
         // Position of the anchor when manipulation started.
         private Vector3 initialAnchorOnGrabStart;
@@ -772,6 +773,7 @@ namespace MixedReality.Toolkit.SpatialManipulation
                 if (currentHandle.HandleType == HandleType.Scale)
                 {
                     // Will use this to scale the target relative to the opposite corner
+                    oppositeCorner = boxInstance.transform.TransformPoint(-currentHandle.transform.localPosition);
                     // ScaleStarted?.Invoke();
 
                     ManipulationLogicImplementations.scaleLogic.Setup(currentHandle.interactorsSelecting, args.interactableObject, initialTransformOnGrabStart);
@@ -954,7 +956,7 @@ public class BoundsControlScaleLogic : ManipulationLogic<Vector3>
     private Vector3 initialGrabPoint;
     private MixedRealityTransform initialTransformOnGrabStart;
     private Vector3 diagonalDir;
-    private Vector3 oppositeCorner;
+    //private Vector3 oppositeCorner;
 
     /// <inheritdoc />
     public override void Setup(List<IXRSelectInteractor> interactors, IXRSelectInteractable interactable, MixedRealityTransform currentTarget)
@@ -964,8 +966,8 @@ public class BoundsControlScaleLogic : ManipulationLogic<Vector3>
         boundsCont = currentHandle.BoundsControlRoot;
         initialGrabPoint = currentHandle.interactorsSelecting[0].GetAttachTransform(currentHandle).position;
         initialTransformOnGrabStart = new MixedRealityTransform(boundsCont.Target.transform);
-        oppositeCorner = boundsCont.BoxInstance.transform.TransformPoint(-currentHandle.transform.localPosition);
-        diagonalDir = (currentHandle.transform.position - oppositeCorner).normalized;
+        //oppositeCorner = boundsCont.BoxInstance.transform.TransformPoint(-currentHandle.transform.localPosition);
+        diagonalDir = (currentHandle.transform.position - boundsCont.OppositeCorner).normalized;
     }
 
     /// <inheritdoc />
@@ -973,7 +975,7 @@ public class BoundsControlScaleLogic : ManipulationLogic<Vector3>
     {
         base.Update(interactors, interactable, currentTarget, centeredAnchor);
 
-        Vector3 anchorPoint = centeredAnchor ? boundsCont.Target.transform.TransformPoint(boundsCont.CurrentBounds.center) : oppositeCorner;
+        Vector3 anchorPoint = centeredAnchor ? boundsCont.Target.transform.TransformPoint(boundsCont.CurrentBounds.center) : boundsCont.OppositeCorner;
         Vector3 scaleFactor = boundsCont.Target.transform.localScale;
         Vector3 currentGrabPoint = currentHandle.interactorsSelecting[0].GetAttachTransform(currentHandle).position;
 

--- a/org.mixedrealitytoolkit.spatialmanipulation/BoundsControl/BoundsControl.cs
+++ b/org.mixedrealitytoolkit.spatialmanipulation/BoundsControl/BoundsControl.cs
@@ -919,7 +919,9 @@ namespace MixedReality.Toolkit.SpatialManipulation
         }
     }
 }
-
+/*
+ * These are the three classes that define the default manipulation behavior for Moving, Scaling and Rotation respectively
+ */
 public class BoundsControlMoveLogic : ManipulationLogic<Vector3>
 {
     private BoundsControl boundsCont;

--- a/org.mixedrealitytoolkit.spatialmanipulation/BoundsControl/BoundsControl.cs
+++ b/org.mixedrealitytoolkit.spatialmanipulation/BoundsControl/BoundsControl.cs
@@ -819,24 +819,10 @@ namespace MixedReality.Toolkit.SpatialManipulation
                 if (currentHandle != null)
                 {
                     TransformFlags transformUpdated = 0;
-                    Vector3 currentGrabPoint = currentHandle.interactorsSelecting[0].GetAttachTransform(currentHandle).position;
                     MixedRealityTransform targetTransform = new MixedRealityTransform(target.transform);
 
                     if (currentHandle.HandleType == HandleType.Rotation)
                     {
-                        /*
-                        // Compute the anchor around which we will be rotating the object, based
-                        // on the desired RotateAnchorType.
-                        Vector3 anchorPoint = RotateAnchor == RotateAnchorType.BoundsCenter ? Target.transform.TransformPoint(currentBounds.center) : Target.transform.position;
-
-                        Vector3 initDir = Vector3.ProjectOnPlane(initialGrabPoint - anchorPoint, currentManipulationAxis).normalized;
-                        Vector3 currentDir = Vector3.ProjectOnPlane(currentGrabPoint - anchorPoint, currentManipulationAxis).normalized;
-                        Quaternion initQuat = Quaternion.LookRotation(initDir, currentManipulationAxis);
-                        Quaternion currentQuat = Quaternion.LookRotation(currentDir, currentManipulationAxis);
-                        Quaternion goalRotation = (currentQuat * Quaternion.Inverse(initQuat)) * initialTransformOnGrabStart.Rotation;
-
-                        */
-
                         var goalRotation = ManipulationLogicImplementations.rotateLogic.Update(currentHandle.interactorsSelecting, interactable, targetTransform, RotateAnchor == RotateAnchorType.BoundsCenter);
 
                         Quaternion rotationDelta = goalRotation * Quaternion.Inverse(initialTransformOnGrabStart.Rotation);
@@ -1017,40 +1003,39 @@ public class BoundsControlScaleLogic : ManipulationLogic<Vector3>
 public class BoundsControlRotateLogic : ManipulationLogic<Quaternion>
 {
     private BoundsControl boundsCont;
-    /*
     private BoundsHandleInteractable currentHandle;
     private Vector3 initialGrabPoint;
     private Vector3 currentManipulationAxis;
     private MixedRealityTransform initialTransformOnGrabStart;
-    */
+
     /// <inheritdoc />
     public override void Setup(List<IXRSelectInteractor> interactors, IXRSelectInteractable interactable, MixedRealityTransform currentTarget)
     {
         base.Setup(interactors, interactable, currentTarget);
 
-        //currentHandle = interactable.transform.GetComponent<BoundsHandleInteractable>();
-        boundsCont = interactable.transform.GetComponent<BoundsHandleInteractable>().BoundsControlRoot;
-        //initialGrabPoint = currentHandle.interactorsSelecting[0].GetAttachTransform(currentHandle).position;
-        //currentManipulationAxis = currentHandle.transform.forward;
-        //initialTransformOnGrabStart = new MixedRealityTransform(boundsCont.Target.transform);
+        currentHandle = interactable.transform.GetComponent<BoundsHandleInteractable>();
+        boundsCont = currentHandle.BoundsControlRoot;
+        initialGrabPoint = currentHandle.interactorsSelecting[0].GetAttachTransform(currentHandle).position;
+        currentManipulationAxis = currentHandle.transform.forward;
+        initialTransformOnGrabStart = new MixedRealityTransform(boundsCont.Target.transform);
     }
 
     /// <inheritdoc />
     public override Quaternion Update(List<IXRSelectInteractor> interactors, IXRSelectInteractable interactable, MixedRealityTransform currentTarget, bool centeredAnchor)
     {
-        return base.Update(interactors, interactable, currentTarget, centeredAnchor);
-        /*
+        base.Update(interactors, interactable, currentTarget, centeredAnchor);
+
         // Compute the anchor around which we will be rotating the object, based
         // on the desired RotateAnchorType.
         Vector3 anchorPoint = centeredAnchor ? boundsCont.Target.transform.TransformPoint(boundsCont.CurrentBounds.center) : boundsCont.Target.transform.position;
         Vector3 currentGrabPoint = currentHandle.interactorsSelecting[0].GetAttachTransform(currentHandle).position;
-
         Vector3 initDir = Vector3.ProjectOnPlane(initialGrabPoint - anchorPoint, currentManipulationAxis).normalized;
         Vector3 currentDir = Vector3.ProjectOnPlane(currentGrabPoint - anchorPoint, currentManipulationAxis).normalized;
+
         Quaternion initQuat = Quaternion.LookRotation(initDir, currentManipulationAxis);
         Quaternion currentQuat = Quaternion.LookRotation(currentDir, currentManipulationAxis);
         Quaternion goalRotation = (currentQuat * Quaternion.Inverse(initQuat)) * initialTransformOnGrabStart.Rotation;
+
         return goalRotation;
-        */
     }
 }

--- a/org.mixedrealitytoolkit.spatialmanipulation/BoundsControl/BoundsControl.cs
+++ b/org.mixedrealitytoolkit.spatialmanipulation/BoundsControl/BoundsControl.cs
@@ -483,8 +483,7 @@ namespace MixedReality.Toolkit.SpatialManipulation
 
         // The box visuals GameObject instantiated at Awake.
         private GameObject boxInstance;
-        public GameObject BoxInstance => boxInstance;
-
+       
         // Used to determine whether the associated interactable was moved between select/deselect,
         // which drives whether the handles get toggled on/off. If the interactable was moved less than a
         // certain threshold, we toggle the handles on/off. If the interactable was moved further than the
@@ -956,7 +955,6 @@ public class BoundsControlScaleLogic : ManipulationLogic<Vector3>
     private Vector3 initialGrabPoint;
     private MixedRealityTransform initialTransformOnGrabStart;
     private Vector3 diagonalDir;
-    //private Vector3 oppositeCorner;
 
     /// <inheritdoc />
     public override void Setup(List<IXRSelectInteractor> interactors, IXRSelectInteractable interactable, MixedRealityTransform currentTarget)
@@ -966,7 +964,6 @@ public class BoundsControlScaleLogic : ManipulationLogic<Vector3>
         boundsCont = currentHandle.BoundsControlRoot;
         initialGrabPoint = currentHandle.interactorsSelecting[0].GetAttachTransform(currentHandle).position;
         initialTransformOnGrabStart = new MixedRealityTransform(boundsCont.Target.transform);
-        //oppositeCorner = boundsCont.BoxInstance.transform.TransformPoint(-currentHandle.transform.localPosition);
         diagonalDir = (currentHandle.transform.position - boundsCont.OppositeCorner).normalized;
     }
 


### PR DESCRIPTION
Similar to objectmanipulator.cs, boundscontrol.cs now supports custom scaling, translation, and/or rotation logic.

Steps for creating custom logic:
1. Create your own class that inherits from manipulationlogic class
2. Add the manipulation logic in Setup() and Update()
3. Assign the new class for "manipulationLogicTypes" variable in the inspector for the boundscontrol script for whatever manipulation you wish to modify.
