### PR TITLE
Fixing package descriptions so they are 200 characters or less, so packages can meet Unity's UPM Store Guidelines.

### DIFF
--- a/UnityProjects/MRTKDevTemplate/Packages/manifest.json
+++ b/UnityProjects/MRTKDevTemplate/Packages/manifest.json
@@ -21,7 +21,7 @@
     "org.mixedrealitytoolkit.uxcomponents.noncanvas": "file:../../../org.mixedrealitytoolkit.uxcomponents.noncanvas",
     "org.mixedrealitytoolkit.uxcore": "file:../../../org.mixedrealitytoolkit.uxcore",
     "org.mixedrealitytoolkit.windowsspeech": "file:../../../org.mixedrealitytoolkit.windowsspeech",
-    "com.unity.asset-store-validation": "0.2.1",
+    "com.unity.asset-store-validation": "0.5.1",
     "com.unity.collab-proxy": "2.0.1",
     "com.unity.ide.rider": "3.0.18",
     "com.unity.ide.visualstudio": "2.0.17",

--- a/UnityProjects/MRTKDevTemplate/Packages/packages-lock.json
+++ b/UnityProjects/MRTKDevTemplate/Packages/packages-lock.json
@@ -60,7 +60,7 @@
       "dependencies": {}
     },
     "com.unity.asset-store-validation": {
-      "version": "0.2.1",
+      "version": "0.5.1",
       "depth": 0,
       "source": "registry",
       "dependencies": {

--- a/org.mixedrealitytoolkit.accessibility/CHANGELOG.md
+++ b/org.mixedrealitytoolkit.accessibility/CHANGELOG.md
@@ -2,7 +2,13 @@
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
-## [1.0.2-development] - 2024-03-20
+## [1.0.3-development] - 2024-04-17
+
+### Fixed
+
+* Reduced package description to support for UPM package publishing in the Unity Asset Store.
+
+## [1.0.2] - 2024-03-20
 
 ### Fixed
 

--- a/org.mixedrealitytoolkit.accessibility/package.json
+++ b/org.mixedrealitytoolkit.accessibility/package.json
@@ -1,7 +1,7 @@
 {
   "name": "org.mixedrealitytoolkit.accessibility",
-  "version": "1.0.2-development",
-  "description": "*** Please note ***\nThe MRTK3 accessibility features are in early preview and may not contain all planned features. Early preview releases also may undergo significant, breaking architectural changes before release.\n\nFeatures and subsystem to enable accessibility in mixed reality experiences.",
+  "version": "1.0.3-development",
+  "description": "Features and subsystem to enable accessibility in MR experiences.\n\nThis is in early preview and may undergo significant, breaking changes before release.",
   "displayName": "MRTK Accessibility Early Preview",
   "msftFeatureCategory": "MRTK3",
   "author": "Mixed Reality Toolkit Contributors",

--- a/org.mixedrealitytoolkit.audio/CHANGELOG.md
+++ b/org.mixedrealitytoolkit.audio/CHANGELOG.md
@@ -2,7 +2,14 @@
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
-## [3.0.2-development] - 2024-03-20
+## [3.0.3-development] - 2024-04-17
+
+### Fixed
+
+* Reduced package description to support for UPM package publishing in the Unity Asset Store.
+* Fixing .asmdef for Editor Unit Tests, so it now contains proper `defineConstraints`.
+
+## [3.0.2] - 2024-03-20
 
 ### Fixed
 

--- a/org.mixedrealitytoolkit.audio/Tests/Editor/MRTK.Audio.EditorTests.asmdef
+++ b/org.mixedrealitytoolkit.audio/Tests/Editor/MRTK.Audio.EditorTests.asmdef
@@ -16,7 +16,9 @@
         "nunit.framework.dll"
     ],
     "autoReferenced": false,
-    "defineConstraints": [],
+    "defineConstraints": [
+        "UNITY_INCLUDE_TESTS"
+    ],
     "versionDefines": [
         {
             "name": "com.unity.asset-store-validation",

--- a/org.mixedrealitytoolkit.audio/package.json
+++ b/org.mixedrealitytoolkit.audio/package.json
@@ -1,7 +1,7 @@
 {
   "name": "org.mixedrealitytoolkit.audio",
-  "version": "3.0.2-development",
-  "description": "Effects and features that enhance the audio in mixed reality experiences.\n\nIn order for the audio effects to be spatialized, an audio spatializer, such as the Microsoft Spatializer, plugin must be imported into the project.\n\nPlease note that audio spatializer plugins may be platform specific.",
+  "version": "3.0.3-development",
+  "description": "Features to enhance audio in xr experiences.\n\nFor the audio effects to be spatialized, a spatializer plugin must be imported into the project. Spatializer plugins may be platform specific.",
   "displayName": "MRTK Audio Effects",
   "msftFeatureCategory": "MRTK3",
   "author": "Mixed Reality Toolkit Contributors",

--- a/org.mixedrealitytoolkit.data/CHANGELOG.md
+++ b/org.mixedrealitytoolkit.data/CHANGELOG.md
@@ -2,7 +2,13 @@
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
-## [1.0.2-development] - 2024-03-20
+## [1.0.3-development] - 2024-04-17
+
+### Fixed
+
+* Reduced package description to support for UPM package publishing in the Unity Asset Store.
+
+## [1.0.2] - 2024-03-20
 
 ### Fixed
 

--- a/org.mixedrealitytoolkit.data/package.json
+++ b/org.mixedrealitytoolkit.data/package.json
@@ -1,7 +1,7 @@
 {
   "name": "org.mixedrealitytoolkit.data",
-  "version": "1.0.2-development",
-  "description": "*** Please note ***\nThe MRTK3 data binding and theming features contained within this package are experimental. They are not recommended for use in production applications and may be changed or removed.",
+  "version": "1.0.3-development",
+  "description": "Data binding and theming features contained within this package are experimental, and are not recommended for use in production applications and may be changed or removed.",
   "displayName": "MRTK3 Data Binding and Theming (Experimental)",
   "msftFeatureCategory": "Experimental",
   "author": "Mixed Reality Toolkit Contributors",

--- a/org.mixedrealitytoolkit.input/CHANGELOG.md
+++ b/org.mixedrealitytoolkit.input/CHANGELOG.md
@@ -2,13 +2,14 @@
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
-## [3.2.1-development] - 2024-03-20
+## [3.2.1-development] - 2024-4-17
 
 ### Fixed
 
 * Add logic to account for a bound but untracked interaction profile. [PR #704](https://github.com/MixedRealityToolkit/MixedRealityToolkit-Unity/pull/704)
+* Reduced package description to support for UPM package publishing in the Unity Asset Store.
 
-## [3.2.0-development] - 2024-03-20
+## [3.2.0] - 2024-03-20
 
 ### Added
 

--- a/org.mixedrealitytoolkit.input/package.json
+++ b/org.mixedrealitytoolkit.input/package.json
@@ -1,7 +1,7 @@
 {
   "name": "org.mixedrealitytoolkit.input",
   "version": "3.2.1-development",
-  "description": "This package contains custom interactors and controllers that build on the foundation established by Unity's XR Interaction Toolkit. In addition, it contains hand joint aggregation and simulation subsystems, which allows for a single API for both real, device-driven hands and simulated hands. \n\nThe vast majority of actual input processing is not done by this package; instead, MRTK builds on the input data and interaction fundamentals already provided by the Unity Input System and XR Interaction Toolkit. \n\nWhen using MRTK Input in a project, it is not strictly necessary to have your package take a dependency on MRTK Input; the custom interactors in this package are fully compatible with the vanilla XRI APIs, and will both parse and generate all the same events and interactions that other XRI interactors will.",
+  "description": "This package extends the XR Interaction Toolkit with custom interactors and controllers, hand-joint aggregation, and simulation subsystems. It seamlessly integrates with the Unity Input System.",
   "displayName": "MRTK Input",
   "msftFeatureCategory": "MRTK3",
   "author": "Mixed Reality Toolkit Contributors",

--- a/org.mixedrealitytoolkit.tools/CHANGELOG.md
+++ b/org.mixedrealitytoolkit.tools/CHANGELOG.md
@@ -2,7 +2,13 @@
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
-## [3.0.2-development] - 2024-03-20
+## [3.0.3-development] - 2024-04-17
+
+### Fixed
+
+* Fixing .asmdef for Editor Unit Tests, so it now contains proper `defineConstraints`.
+
+## [3.0.2] - 2024-03-20
 
 ### Fixed
 

--- a/org.mixedrealitytoolkit.tools/Tests/Editor/MRTK.Tools.EditorTests.asmdef
+++ b/org.mixedrealitytoolkit.tools/Tests/Editor/MRTK.Tools.EditorTests.asmdef
@@ -16,7 +16,9 @@
         "nunit.framework.dll"
     ],
     "autoReferenced": false,
-    "defineConstraints": [],
+    "defineConstraints": [
+        "UNITY_INCLUDE_TESTS"
+    ],
     "versionDefines": [
         {
             "name": "com.unity.asset-store-validation",

--- a/org.mixedrealitytoolkit.tools/package.json
+++ b/org.mixedrealitytoolkit.tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "org.mixedrealitytoolkit.tools",
-  "version": "3.0.2-development",
+  "version": "3.0.3-development",
   "description": "A collection of tools, utilities, and wizards that can be used to create and analyze components for use with MRTK3.",
   "displayName": "MRTK Tools",
   "msftFeatureCategory": "MRTK3",

--- a/org.mixedrealitytoolkit.uxcomponents.noncanvas/CHANGELOG.md
+++ b/org.mixedrealitytoolkit.uxcomponents.noncanvas/CHANGELOG.md
@@ -2,7 +2,13 @@
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
-## [3.1.2-development] - 2024-03-20
+## [3.1.3-development] - 2024-04-17
+
+### Fixed
+
+* Reduced package description to support for UPM package publishing in the Unity Asset Store.
+
+## [3.1.2] - 2024-03-20
 
 ### Fixed
 

--- a/org.mixedrealitytoolkit.uxcomponents.noncanvas/package.json
+++ b/org.mixedrealitytoolkit.uxcomponents.noncanvas/package.json
@@ -1,7 +1,7 @@
 {
   "name": "org.mixedrealitytoolkit.uxcomponents.noncanvas",
-  "version": "3.1.2-development",
-  "description": "MRTK non-Canvas UX component library, for building 3D UX without Canvas layout. For most production-grade UI, we recommend the dynamic hybrid Canvas-based UX systems, located in org.mixedrealitytoolkit.uxcomponents. However, in some circumstances, static/non-Canvas UI may offer improved performance and batching, and may be desirable in resource-constrained scenarios.",
+  "version": "3.1.3-development",
+  "description": "UX component library for 3D UX without Canvas layout. In some cases, non-Canvas UI may offer better performance.",
   "displayName": "MRTK UX Components (Non-Canvas)",
   "msftFeatureCategory": "MRTK3",
   "author": "Mixed Reality Toolkit Contributors",

--- a/org.mixedrealitytoolkit.uxcomponents/CHANGELOG.md
+++ b/org.mixedrealitytoolkit.uxcomponents/CHANGELOG.md
@@ -1,6 +1,16 @@
+# Changelog
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+
 ## [3.3.0-development] - 2024-03-22
 
+### Added
+
 * Added unified font atlas and updated corresponding fonts and their materials. [PR #700](https://github.com/MixedRealityToolkit/MixedRealityToolkit-Unity/pull/700)
+
+### Fixed
+
+* Reduced package description to support for UPM package publishing in the Unity Asset Store.
 
 ## [3.2.0] - 2024-03-20
 

--- a/org.mixedrealitytoolkit.uxcomponents/package.json
+++ b/org.mixedrealitytoolkit.uxcomponents/package.json
@@ -1,7 +1,7 @@
 {
   "name": "org.mixedrealitytoolkit.uxcomponents",
   "version": "3.3.0-development",
-  "description": "MRTK UX component library, leveraging RectTransform/Canvas for dynamic layout and presentation. Contains prefabs, visuals, pre-made controls, and everything to get started building 3D user interfaces for mixed reality.",
+  "description": "UX library leveraging RectTransform and Canvas for dynamic layout and presentation. Contains prefabs, visuals, controls, and everything to get started building 3D user interfaces for mixed reality.",
   "displayName": "MRTK UX Components",
   "msftFeatureCategory": "MRTK3",
   "author": "Mixed Reality Toolkit Contributors",

--- a/org.mixedrealitytoolkit.uxcore/CHANGELOG.md
+++ b/org.mixedrealitytoolkit.uxcore/CHANGELOG.md
@@ -2,7 +2,13 @@
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
-## [3.2.0-development] - 2024-03-20
+## [3.2.1-development] - 2024-04-17
+
+### Fixed
+
+* Reduced package description to support for UPM package publishing in the Unity Asset Store.
+
+## [3.2.0] - 2024-03-20
 
 ### Added
 

--- a/org.mixedrealitytoolkit.uxcore/package.json
+++ b/org.mixedrealitytoolkit.uxcore/package.json
@@ -1,7 +1,7 @@
 {
   "name": "org.mixedrealitytoolkit.uxcore",
-  "version": "3.2.0-development",
-  "description": "Core interaction and visualization scripts for building MR user interface components.\n\nNote: this is intended to be consumed in order to build UX libraries. To build MR interfaces with a pre-existing library of components, see org.mixedrealitytoolkit.uxcomponents.",
+  "version": "3.2.1-development",
+  "description": "Core interaction and visualization scripts for building MR UI components. Intended to be consumed when building UX libraries. For pre-existing library of components see the UX Components package.",
   "displayName": "MRTK UX Core Scripts",
   "msftFeatureCategory": "MRTK3",
   "author": "Mixed Reality Toolkit Contributors",

--- a/org.mixedrealitytoolkit.windowsspeech/CHANGELOG.md
+++ b/org.mixedrealitytoolkit.windowsspeech/CHANGELOG.md
@@ -2,7 +2,13 @@
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
-## [3.0.2-development] - 2024-03-20
+## [3.0.3-development] - 2024-04-17
+
+### Fixed
+
+* Reduced package description to support for UPM package publishing in the Unity Asset Store.
+
+## [3.0.2] - 2024-03-20
 
 ### Fixed
 

--- a/org.mixedrealitytoolkit.windowsspeech/package.json
+++ b/org.mixedrealitytoolkit.windowsspeech/package.json
@@ -1,7 +1,7 @@
 {
   "name": "org.mixedrealitytoolkit.windowsspeech",
-  "version": "3.0.2-development",
-  "description": "Speech subsystem implementation for native Windows speech APIs. Allows for the use of native Windows text to speech and speech recognition (keyword recognition and dictation) to fire events and drive XRI interactions.",
+  "version": "3.0.3-development",
+  "description": "Speech subsystem implementation for native Windows speech APIs enables native Windows text-to-speech and speech recognition features, producing events to drive XRI interactions using speech.",
   "displayName": "MRTK Windows Speech",
   "msftFeatureCategory": "MRTK3",
   "author": "Mixed Reality Toolkit Contributors",


### PR DESCRIPTION
# Description

The set of packages edited here had descriptions that were too long to meet Unity's requirements for publishing to Unity's UPM Asset Store.  The max character length is 200 characters.

I'm also updating the test project "validation" package to v0.5.1, which is the min validations package required when publishing to the asset store. Version 0.5.1 tests the 200 character limit.  So our unit tests should now catch this failure.

# Fixes
- https://github.com/MixedRealityToolkit/MixedRealityToolkit-Unity/issues/723