### PR TITLE
XRI3 migration step05

### DIFF
--- a/org.mixedrealitytoolkit.core/Utilities/Extensions/InteractorHandednessExtensions.cs
+++ b/org.mixedrealitytoolkit.core/Utilities/Extensions/InteractorHandednessExtensions.cs
@@ -47,7 +47,7 @@ namespace MixedReality.Toolkit
         /// which the <see cref="Handedness"/> is requested.</param>
         /// <see cref="Handedness"/> representing the specified <see cref="InteractorHandedness"/>.
         /// <returns></returns>
-        public static Handedness ToMRTKHandedness(this InteractorHandedness hand)
+        public static Handedness ToHandedness(this InteractorHandedness hand)
         {
             switch (hand)
             {

--- a/org.mixedrealitytoolkit.core/Utilities/Extensions/InteractorHandednessExtensions.cs
+++ b/org.mixedrealitytoolkit.core/Utilities/Extensions/InteractorHandednessExtensions.cs
@@ -38,5 +38,26 @@ namespace MixedReality.Toolkit
                     return defaultValue;
             }
         }
+
+        /// <summary>
+        /// Converts the <see cref="InteractorHandedness"/> to <see cref="Handedness"/>. If the <see cref="InteractorHandedness"/>
+        /// is other than InteractorHandedness.Left or InteractorHandedness.Right then it defaults to <see cref="Handedness"/>.None.
+        /// </summary>
+        /// <param name="hand">The <see cref="InteractorHandedness"/> value for
+        /// which the <see cref="Handedness"/> is requested.</param>
+        /// <see cref="Handedness"/> representing the specified <see cref="InteractorHandedness"/>.
+        /// <returns></returns>
+        public static Handedness ToMRTKHandedness(this InteractorHandedness hand)
+        {
+            switch (hand)
+            {
+                case InteractorHandedness.Left:
+                    return Handedness.Left;
+                case InteractorHandedness.Right:
+                    return Handedness.Right;
+                default:
+                    return Handedness.None;
+            }
+        }
     }
 }

--- a/org.mixedrealitytoolkit.input/Assets/Prefabs/Experimental-XRI3/MRTK LeftHand Controller.prefab
+++ b/org.mixedrealitytoolkit.input/Assets/Prefabs/Experimental-XRI3/MRTK LeftHand Controller.prefab
@@ -359,6 +359,7 @@ MonoBehaviour:
     m_InputActionReference: {fileID: 0}
     m_ObjectReferenceObject: {fileID: 0}
     m_ManualValue: 0
+  trackedPoseDriver: {fileID: 9028998875765828509}
   aimPoseSource:
     rid: 0
   devicePoseSource:

--- a/org.mixedrealitytoolkit.input/Interactors/Ray/MRTKRayInteractor.cs
+++ b/org.mixedrealitytoolkit.input/Interactors/Ray/MRTKRayInteractor.cs
@@ -125,7 +125,7 @@ namespace MixedReality.Toolkit.Input
 #pragma warning restore CS0618
                 else
                 {
-                    return handedness.ToMRTKHandedness();
+                    return handedness.ToHandedness();
                 }
             }
         }

--- a/org.mixedrealitytoolkit.input/Interactors/Ray/MRTKRayInteractor.cs
+++ b/org.mixedrealitytoolkit.input/Interactors/Ray/MRTKRayInteractor.cs
@@ -16,13 +16,13 @@ using UnityEngine.XR.Interaction.Toolkit.UI;
 namespace MixedReality.Toolkit.Input
 {
     /// <summary>
-    /// A wrapper for the XRRayInteractor which stores extra information for MRTK management/services
+    /// A wrapper for the <see cref="XRRayInteractor"/> which stores extra information for MRTK management/services
     /// </summary>
     [AddComponentMenu("MRTK/Input/MRTK Ray Interactor")]
     // This execution order ensures that the MRTKRayInteractor runs its update function right after the
-    // XRController. We do this because the MRTKRayInteractor needs to set its own pose after the parent controller transform,
+    // <see cref="XRController"/>. We do this because the <see cref="MRTKRayInteractor"/> needs to set its own pose after the parent controller transform,
     // but before any physics raycast calls are made to determine selection. The earliest a physics call can be made is within
-    // the UIInputModule, which has an update order much higher than XRControllers.
+    // the UIInputModule, which has an update order much higher than <see cref="XRController"/>s.
     // TODO: Examine the update order of other interactors in the future with respect to when their physics calls happen,
     // or create a system to keep ensure interactor poses aren't ever implicitly set via parenting.
     [DefaultExecutionOrder(XRInteractionUpdateOrder.k_Controllers + 1)]

--- a/org.mixedrealitytoolkit.input/Interactors/Ray/MRTKRayInteractor.cs
+++ b/org.mixedrealitytoolkit.input/Interactors/Ray/MRTKRayInteractor.cs
@@ -38,13 +38,13 @@ namespace MixedReality.Toolkit.Input
         /// Holds a reference to the deprecated <see cref="XRBaseController"/> associated to this interactor if it exists.  This
         /// will be removed when the XRI3 migration is completed and all *Controller* stuff is removed.
         /// </summary>
-        [Obsolete]
+        [Obsolete("Deprecated, please use trackedPoseDriver instead.")]
         private XRBaseController xrBaseController = null;
 
         /// <summary>
         /// Property for accessing xrBaseController, will be removed for XRI3 migration completion.
         /// </summary>
-        [Obsolete]
+        [Obsolete("Deprecated, please use TrackedPoseDriver instead.")]
         private XRBaseController XRBaseController
         {
             get
@@ -60,8 +60,8 @@ namespace MixedReality.Toolkit.Input
 
         /// <summary>
         /// Holds a reference to the <see cref="TrackedPoseDriver"/> associated to this interactor if it exists.  This field
-        /// is popualted the first time IsTracked property is accessed AND there is no <see cref="XRBaseController"/> component
-        /// associated to to interactor.
+        /// is populated the first time IsTracked property is accessed AND there is no <see cref="XRBaseController"/> component
+        /// associated to the interactor.
         /// </summary>
         private TrackedPoseDriver trackedPoseDriver = null;
 
@@ -72,7 +72,7 @@ namespace MixedReality.Toolkit.Input
 
         /// <summary>
         /// Is this ray currently selecting a UnityUI/Canvas element?
-        /// </summary> 
+        /// </summary>
         public bool HasUISelection => HasUIHover && isUISelectActive;
 
         /// <summary>
@@ -83,6 +83,7 @@ namespace MixedReality.Toolkit.Input
         {
             get
             {
+                #pragma warning disable CS0618 // Type or member is obsolete
                 if (XRBaseController == null) //If no XRController is associated with this interactor then try to get the TrackedPoseDriver component instead
                 {
                     trackedPoseDriver = GetComponentInParent<TrackedPoseDriver>();
@@ -96,6 +97,7 @@ namespace MixedReality.Toolkit.Input
 
                 //If the XRController has already been set then use it to check if the controller is tracked
                 return XRBaseController.currentControllerState.inputTrackingState.HasPositionAndRotation();
+                #pragma warning disable CS0618 // Type or member is obsolete
             }
         }
 

--- a/org.mixedrealitytoolkit.input/Interactors/Ray/MRTKRayInteractor.cs
+++ b/org.mixedrealitytoolkit.input/Interactors/Ray/MRTKRayInteractor.cs
@@ -138,7 +138,7 @@ namespace MixedReality.Toolkit.Input
             get
             {
 #pragma warning disable CS0618 // Type or member is obsolete
-                if (xrController != null)
+                if (forceDeprecatedInput)
                 {
                     return xrController.selectInteractionState.value;
                 }
@@ -149,7 +149,7 @@ namespace MixedReality.Toolkit.Input
                 }
                 else
                 {
-                    Debug.LogWarning($"Unable to determine SelectProgress of {name} because there is neither an XRBaseController nor the Input Configuration has Select Input Actions referenced to it.");
+                    Debug.LogWarning($"Unable to determine SelectProgress of {name} because there is no Select Input Configuration set for this interactor.");
                 }
                 return 0;
             }

--- a/org.mixedrealitytoolkit.input/Interactors/Ray/MRTKRayInteractor.cs
+++ b/org.mixedrealitytoolkit.input/Interactors/Ray/MRTKRayInteractor.cs
@@ -230,15 +230,11 @@ namespace MixedReality.Toolkit.Input
 
 #pragma warning disable CS0618 // Type or member is obsolete
 #pragma warning disable CS0612 // Type or member is obsolete
-                        if (forceDeprecatedInput)
+                        if (forceDeprecatedInput &&
+                            xrController is ArticulatedHandController handController &&
+                            (XRSubsystemHelpers.HandsAggregator?.TryGetPalmFacingAway(handController.HandNode, out isPalmFacingAway) ?? true))
                         {
-                            if (xrController is ArticulatedHandController handController)
-                            {
-                                if (XRSubsystemHelpers.HandsAggregator?.TryGetPalmFacingAway(handController.HandNode, out isPalmFacingAway) ?? true)
-                                {
-                                    hoverActive &= isPalmFacingAway;
-                                }
-                            }
+                                hoverActive &= isPalmFacingAway;
                         }
 #pragma warning restore CS0612
 #pragma warning restore CS0618

--- a/org.mixedrealitytoolkit.input/Interactors/Ray/MRTKRayInteractor.cs
+++ b/org.mixedrealitytoolkit.input/Interactors/Ray/MRTKRayInteractor.cs
@@ -61,7 +61,13 @@ namespace MixedReality.Toolkit.Input
             get
             {
 #pragma warning disable CS0618 // Type or member is obsolete
-                if (xrController == null) //If no XRController is associated with this interactor then try to get the TrackedPoseDriver component instead
+                if (forceDeprecatedInput) //If no XRController is associated with this interactor then try to get the TrackedPoseDriver component instead
+                {
+                    //If the XRController has already been set then use it to check if the controller is tracked
+                    return xrController.currentControllerState.inputTrackingState.HasPositionAndRotation();
+                }
+#pragma warning restore CS0618
+                else
                 {
                     if (TrackedPoseDriver == null) //If the interactor does not have a TrackedPoseDriver component then it is not tracked
                     {
@@ -71,10 +77,6 @@ namespace MixedReality.Toolkit.Input
                     //If this interactor has a TrackedPoseDriver then use it to check if this interactor is tracked
                     return ((InputTrackingState)TrackedPoseDriver.trackingStateInput.action.ReadValue<int>()).HasPositionAndRotation();
                 }
-
-                //If the XRController has already been set then use it to check if the controller is tracked
-                return xrController.currentControllerState.inputTrackingState.HasPositionAndRotation();
-#pragma warning restore CS0618
             }
         }
 
@@ -115,7 +117,7 @@ namespace MixedReality.Toolkit.Input
             {
 #pragma warning disable CS0618 // Type or member is obsolete
 #pragma warning disable CS0612 // Type or member is obsolete
-                if (xrController != null)
+                if (forceDeprecatedInput)
                 {
                     return (xrController is ArticulatedHandController handController) ? handController.HandNode.ToHandedness() : Handedness.None;
                 }
@@ -228,7 +230,7 @@ namespace MixedReality.Toolkit.Input
 
 #pragma warning disable CS0618 // Type or member is obsolete
 #pragma warning disable CS0612 // Type or member is obsolete
-                        if (xrController != null)
+                        if (forceDeprecatedInput)
                         {
                             if (xrController is ArticulatedHandController handController)
                             {

--- a/org.mixedrealitytoolkit.input/Interactors/Ray/MRTKRayInteractor.cs
+++ b/org.mixedrealitytoolkit.input/Interactors/Ray/MRTKRayInteractor.cs
@@ -96,7 +96,7 @@ namespace MixedReality.Toolkit.Input
         {
             get
             {
-#pragma warning disable CS0618 // Type or member is obsolete
+                #pragma warning disable CS0618 // Type or member is obsolete
                 if (XRBaseController == null) //If no XRController is associated with this interactor then try to get the TrackedPoseDriver component instead
                 {
                     if (TrackedPoseDriver == null) //If the interactor does not have a TrackedPoseDriver component then it is not tracked
@@ -110,7 +110,7 @@ namespace MixedReality.Toolkit.Input
 
                 //If the XRController has already been set then use it to check if the controller is tracked
                 return XRBaseController.currentControllerState.inputTrackingState.HasPositionAndRotation();
-#pragma warning disable CS0618 // Type or member is obsolete
+                #pragma warning restore CS0618
             }
         }
 
@@ -145,7 +145,33 @@ namespace MixedReality.Toolkit.Input
 
         #region IHandedInteractor
 
-        Handedness IHandedInteractor.Handedness => (XRBaseController is ArticulatedHandController handController) ? handController.HandNode.ToHandedness() : Handedness.None;
+        Handedness IHandedInteractor.Handedness
+        {
+            get
+            {
+                #pragma warning disable CS0618 // Type or member is obsolete
+                #pragma warning disable CS0612 // Type or member is obsolete
+                if (XRBaseController != null)
+                {
+                    return (XRBaseController is ArticulatedHandController handController) ? handController.HandNode.ToHandedness() : Handedness.None;
+                }
+                else if (TrackedPoseDriver != null)
+                {
+                    HandModel handModel = GetComponentInParent<HandModel>();
+                    if (handModel != null)
+                    {
+                        return handModel.HandNode.ToHandedness();
+                    }
+                    else
+                    {
+                        Debug.LogWarning($"Cannot determin Handedness of {name} because there is no associated HandModel.");
+                    }
+                }
+                return Handedness.None; //If neither an XRController nor a TrackedPoseDriver is associated with this interactor then return None as handedness.
+                #pragma warning restore CS0612
+                #pragma warning restore CS0618
+            }
+        }
 
         #endregion IHandedInteractor
 

--- a/org.mixedrealitytoolkit.input/Interactors/Ray/MRTKRayInteractor.cs
+++ b/org.mixedrealitytoolkit.input/Interactors/Ray/MRTKRayInteractor.cs
@@ -55,27 +55,6 @@ namespace MixedReality.Toolkit.Input
         }
 
         /// <summary>
-        /// Holds a reference to the <see cref="HandModel"/> associated with this interactor's parent if it exists.
-        /// </summary>
-        private HandModel handModel = null;
-
-        /// <summary>
-        /// The <see cref="HandModel"/> associated with this interactor.  The <see cref="HandModel"/> is obtained from the parent if it hasn't been set yet.
-        /// </summary>
-        private HandModel HandModel
-        {
-            get
-            {
-                if (handModel == null) //Try to get the HandModel component from the parent if it hasn't been set yet
-                {
-                    handModel = GetComponentInParent<HandModel>();
-                }
-                return handModel;
-            }
-        }
-
-
-        /// <summary>
         /// Is this ray currently hovering a UnityUI/Canvas element?
         /// </summary>
         public bool HasUIHover => TryGetUIModel(out TrackedDeviceModel model) && model.currentRaycast.isValid;
@@ -154,15 +133,10 @@ namespace MixedReality.Toolkit.Input
                 }
 #pragma warning restore CS0612
 #pragma warning restore CS0618
-                else if (HandModel != null)
-                {
-                    return HandModel.HandNode.ToHandedness();
-                }
                 else
                 {
-                    Debug.LogWarning($"Cannot determine Handedness of {name} because there is no associated HandModel.");
+                    return handedness.ToMRTKHandedness();
                 }
-                return Handedness.None; //If neither an XRController nor a HandModel is associated with this interactor then return None as handedness.
             }
         }
 
@@ -278,16 +252,12 @@ namespace MixedReality.Toolkit.Input
                         }
 #pragma warning restore CS0612
 #pragma warning restore CS0618
-                        else if (HandModel != null)
+                        else
                         {
-                            if (XRSubsystemHelpers.HandsAggregator?.TryGetPalmFacingAway(HandModel.HandNode, out isPalmFacingAway) ?? true)
+                            if (XRSubsystemHelpers.HandsAggregator?.TryGetPalmFacingAway(handedness.ToXRNode(), out isPalmFacingAway) ?? true)
                             {
                                 hoverActive &= isPalmFacingAway;
                             }
-                        }
-                        else
-                        {
-                            Debug.LogWarning($"Unable to determine if {name} is hovering because there is neither an XRBaseController nor a HandModel associated with the parent of this interactor.");
                         }
                     }
 

--- a/org.mixedrealitytoolkit.input/Interactors/Ray/MRTKRayInteractor.cs
+++ b/org.mixedrealitytoolkit.input/Interactors/Ray/MRTKRayInteractor.cs
@@ -160,7 +160,7 @@ namespace MixedReality.Toolkit.Input
                 {
                     Debug.LogWarning($"Cannot determine Handedness of {name} because there is no associated HandModel.");
                 }
-                return Handedness.None; //If neither an XRController nor a TrackedPoseDriver is associated with this interactor then return None as handedness.
+                return Handedness.None; //If neither an XRController nor a HandModel is associated with this interactor then return None as handedness.
                 #pragma warning restore CS0612
                 #pragma warning restore CS0618
             }

--- a/org.mixedrealitytoolkit.input/Interactors/Ray/MRTKRayInteractor.cs
+++ b/org.mixedrealitytoolkit.input/Interactors/Ray/MRTKRayInteractor.cs
@@ -164,7 +164,7 @@ namespace MixedReality.Toolkit.Input
                     }
                     else
                     {
-                        Debug.LogWarning($"Cannot determin Handedness of {name} because there is no associated HandModel.");
+                        Debug.LogWarning($"Cannot determine Handedness of {name} because there is no associated HandModel.");
                     }
                 }
                 return Handedness.None; //If neither an XRController nor a TrackedPoseDriver is associated with this interactor then return None as handedness.
@@ -178,7 +178,27 @@ namespace MixedReality.Toolkit.Input
         #region IVariableSelectInteractor
 
         /// <inheritdoc />
-        public float SelectProgress => XRBaseController.selectInteractionState.value;
+        public float SelectProgress
+        {
+            get
+            {
+                #pragma warning disable CS0618 // Type or member is obsolete
+                if (XRBaseController != null)
+                {
+                    return XRBaseController.selectInteractionState.value;
+                }
+                else if (selectInput != null)
+                {
+                    return selectInput.ReadValue();
+                }
+                else
+                {
+                    Debug.LogWarning($"Unable to determine SelectProgress of {name} because there is neither an XRBaseController nor the Input Configuration has Select Input Actions referenced to it.");
+                }
+                return 0;
+                #pragma warning restore CS0618
+            }
+        }
 
         #endregion IVariableSelectInteractor
 

--- a/org.mixedrealitytoolkit.input/Interactors/Ray/MRTKRayInteractor.cs
+++ b/org.mixedrealitytoolkit.input/Interactors/Ray/MRTKRayInteractor.cs
@@ -34,25 +34,13 @@ namespace MixedReality.Toolkit.Input
     {
         #region MRTKRayInteractor
 
-        /// <summary>
-        /// Holds a reference to the <see cref="TrackedPoseDriver"/> associated to this interactor if it exists.
-        /// </summary>
+        [SerializeField, Tooltip("Holds a reference to the <see cref=\"TrackedPoseDriver\"/> associated to this interactor if it exists.")]
         private TrackedPoseDriver trackedPoseDriver = null;
 
         /// <summary>
-        /// Property for accessing trackedPoseDriver which holds a reference to the <see cref="TrackedPoseDriver"/> associated to this interactor if it exists.
+        /// Holds a reference to the <see cref="TrackedPoseDriver"/> associated to this interactor if it exists.
         /// </summary>
-        private TrackedPoseDriver TrackedPoseDriver
-        {
-            get
-            {
-                if (trackedPoseDriver == null) //Try to get the TrackedPoseDriver component from the parent if it hasn't been set yet
-                {
-                    trackedPoseDriver = GetComponentInParent<TrackedPoseDriver>();
-                }
-                return trackedPoseDriver;
-            }
-        }
+        private TrackedPoseDriver TrackedPoseDriver => trackedPoseDriver;
 
         /// <summary>
         /// Is this ray currently hovering a UnityUI/Canvas element?
@@ -323,6 +311,17 @@ namespace MixedReality.Toolkit.Input
         }
 
         #endregion XRBaseInteractor
+
+        /// <inheritdoc/>
+        protected override void Start()
+        {
+            base.Start();
+
+            if (trackedPoseDriver == null) //Try to get the TrackedPoseDriver component from the parent if it hasn't been set yet
+            {
+                trackedPoseDriver = GetComponentInParent<TrackedPoseDriver>();
+            }
+        }
 
         /// <summary>
         /// A Unity event function that is called every frame, if this object is enabled.

--- a/org.mixedrealitytoolkit.input/Interactors/Ray/MRTKRayInteractor.cs
+++ b/org.mixedrealitytoolkit.input/Interactors/Ray/MRTKRayInteractor.cs
@@ -35,30 +35,6 @@ namespace MixedReality.Toolkit.Input
         #region MRTKRayInteractor
 
         /// <summary>
-        /// Holds a reference to the deprecated <see cref="XRBaseController"/> associated to this interactor if it exists.  This
-        /// will be removed when the XRI3 migration is completed and all *Controller* stuff is removed.
-        /// </summary>
-        [Obsolete("Deprecated, please use trackedPoseDriver instead.")]
-        private XRBaseController xrBaseController = null;
-
-        /// <summary>
-        /// Property for accessing xrBaseController, will be removed for XRI3 migration completion.
-        /// </summary>
-        [Obsolete("Deprecated, please use TrackedPoseDriver instead.")]
-        private XRBaseController XRBaseController
-        {
-            get
-            {
-                //Note: This property will be removed when the XRI3 migration is completed and all *Controller* stuff is removed.
-                if (xrBaseController == null) //Try to get the XRController component from the parent if it hasn't been set yet
-                {
-                    xrBaseController = GetComponentInParent<XRBaseController>();
-                }
-                return xrBaseController;
-            }
-        }
-
-        /// <summary>
         /// Holds a reference to the <see cref="TrackedPoseDriver"/> associated to this interactor if it exists.
         /// </summary>
         private TrackedPoseDriver trackedPoseDriver = null;
@@ -118,7 +94,7 @@ namespace MixedReality.Toolkit.Input
             get
             {
                 #pragma warning disable CS0618 // Type or member is obsolete
-                if (XRBaseController == null) //If no XRController is associated with this interactor then try to get the TrackedPoseDriver component instead
+                if (xrController == null) //If no XRController is associated with this interactor then try to get the TrackedPoseDriver component instead
                 {
                     if (TrackedPoseDriver == null) //If the interactor does not have a TrackedPoseDriver component then it is not tracked
                     {
@@ -130,7 +106,7 @@ namespace MixedReality.Toolkit.Input
                 }
 
                 //If the XRController has already been set then use it to check if the controller is tracked
-                return XRBaseController.currentControllerState.inputTrackingState.HasPositionAndRotation();
+                return xrController.currentControllerState.inputTrackingState.HasPositionAndRotation();
                 #pragma warning restore CS0618
             }
         }
@@ -172,9 +148,9 @@ namespace MixedReality.Toolkit.Input
             {
                 #pragma warning disable CS0618 // Type or member is obsolete
                 #pragma warning disable CS0612 // Type or member is obsolete
-                if (XRBaseController != null)
+                if (xrController != null)
                 {
-                    return (XRBaseController is ArticulatedHandController handController) ? handController.HandNode.ToHandedness() : Handedness.None;
+                    return (xrController is ArticulatedHandController handController) ? handController.HandNode.ToHandedness() : Handedness.None;
                 }
                 else if (HandModel != null)
                 {
@@ -200,9 +176,9 @@ namespace MixedReality.Toolkit.Input
             get
             {
                 #pragma warning disable CS0618 // Type or member is obsolete
-                if (XRBaseController != null)
+                if (xrController != null)
                 {
-                    return XRBaseController.selectInteractionState.value;
+                    return xrController.selectInteractionState.value;
                 }
                 else if (selectInput != null)
                 {
@@ -290,9 +266,9 @@ namespace MixedReality.Toolkit.Input
 
                         #pragma warning disable CS0618 // Type or member is obsolete
                         #pragma warning disable CS0612 // Type or member is obsolete
-                        if (XRBaseController != null)
+                        if (xrController != null)
                         {
-                            if (XRBaseController is ArticulatedHandController handController)
+                            if (xrController is ArticulatedHandController handController)
                             {
                                 if (XRSubsystemHelpers.HandsAggregator?.TryGetPalmFacingAway(handController.HandNode, out isPalmFacingAway) ?? true)
                                 {

--- a/org.mixedrealitytoolkit.input/Interactors/Ray/MRTKRayInteractor.cs
+++ b/org.mixedrealitytoolkit.input/Interactors/Ray/MRTKRayInteractor.cs
@@ -102,7 +102,7 @@ namespace MixedReality.Toolkit.Input
                     }
 
                     //If this interactor has a TrackedPoseDriver then use it to check if this interactor is tracked
-                    ((InputTrackingState)TrackedPoseDriver.trackingStateInput.action.ReadValue<int>()).HasPositionAndRotation();
+                    return ((InputTrackingState)TrackedPoseDriver.trackingStateInput.action.ReadValue<int>()).HasPositionAndRotation();
                 }
 
                 //If the XRController has already been set then use it to check if the controller is tracked

--- a/org.mixedrealitytoolkit.input/Interactors/Ray/MRTKRayInteractor.cs
+++ b/org.mixedrealitytoolkit.input/Interactors/Ray/MRTKRayInteractor.cs
@@ -59,11 +59,24 @@ namespace MixedReality.Toolkit.Input
         }
 
         /// <summary>
-        /// Holds a reference to the <see cref="TrackedPoseDriver"/> associated to this interactor if it exists.  This field
-        /// is populated the first time IsTracked property is accessed AND there is no <see cref="XRBaseController"/> component
-        /// associated to the interactor.
+        /// Holds a reference to the <see cref="TrackedPoseDriver"/> associated to this interactor if it exists.
         /// </summary>
         private TrackedPoseDriver trackedPoseDriver = null;
+
+        /// <summary>
+        /// Property for accessing trackedPoseDriver which holds a reference to the <see cref="TrackedPoseDriver"/> associated to this interactor if it exists.
+        /// </summary>
+        private TrackedPoseDriver TrackedPoseDriver
+        {
+            get
+            {
+                if (trackedPoseDriver == null) //Try to get the TrackedPoseDriver component from the parent if it hasn't been set yet
+                {
+                    trackedPoseDriver = GetComponentInParent<TrackedPoseDriver>();
+                }
+                return trackedPoseDriver;
+            }
+        }
 
         /// <summary>
         /// Is this ray currently hovering a UnityUI/Canvas element?
@@ -83,21 +96,21 @@ namespace MixedReality.Toolkit.Input
         {
             get
             {
-                #pragma warning disable CS0618 // Type or member is obsolete
+#pragma warning disable CS0618 // Type or member is obsolete
                 if (XRBaseController == null) //If no XRController is associated with this interactor then try to get the TrackedPoseDriver component instead
                 {
-                    trackedPoseDriver = GetComponentInParent<TrackedPoseDriver>();
-                    if (trackedPoseDriver == null) //If TrackedPoseDriver was not found either then the controller is not tracked
+                    if (TrackedPoseDriver == null) //If the interactor does not have a TrackedPoseDriver component then it is not tracked
                     {
                         return false;
                     }
-                    //If a TrackedPoseDriver was found or was already set then use it to check if this interactor is tracked
-                    ((InputTrackingState)trackedPoseDriver.trackingStateInput.action.ReadValue<int>()).HasPositionAndRotation();
+
+                    //If this interactor has a TrackedPoseDriver then use it to check if this interactor is tracked
+                    ((InputTrackingState)TrackedPoseDriver.trackingStateInput.action.ReadValue<int>()).HasPositionAndRotation();
                 }
 
                 //If the XRController has already been set then use it to check if the controller is tracked
                 return XRBaseController.currentControllerState.inputTrackingState.HasPositionAndRotation();
-                #pragma warning disable CS0618 // Type or member is obsolete
+#pragma warning disable CS0618 // Type or member is obsolete
             }
         }
 

--- a/org.mixedrealitytoolkit.input/Interactors/Ray/MRTKRayInteractor.cs
+++ b/org.mixedrealitytoolkit.input/Interactors/Ray/MRTKRayInteractor.cs
@@ -176,16 +176,13 @@ namespace MixedReality.Toolkit.Input
                 {
                     return (XRBaseController is ArticulatedHandController handController) ? handController.HandNode.ToHandedness() : Handedness.None;
                 }
-                else if (TrackedPoseDriver != null)
+                else if (HandModel != null)
                 {
-                    if (HandModel != null)
-                    {
-                        return HandModel.HandNode.ToHandedness();
-                    }
-                    else
-                    {
-                        Debug.LogWarning($"Cannot determine Handedness of {name} because there is no associated HandModel.");
-                    }
+                    return HandModel.HandNode.ToHandedness();
+                }
+                else
+                {
+                    Debug.LogWarning($"Cannot determine Handedness of {name} because there is no associated HandModel.");
                 }
                 return Handedness.None; //If neither an XRController nor a TrackedPoseDriver is associated with this interactor then return None as handedness.
                 #pragma warning restore CS0612

--- a/org.mixedrealitytoolkit.input/Interactors/Ray/MRTKRayInteractor.cs
+++ b/org.mixedrealitytoolkit.input/Interactors/Ray/MRTKRayInteractor.cs
@@ -93,7 +93,7 @@ namespace MixedReality.Toolkit.Input
         {
             get
             {
-                #pragma warning disable CS0618 // Type or member is obsolete
+#pragma warning disable CS0618 // Type or member is obsolete
                 if (xrController == null) //If no XRController is associated with this interactor then try to get the TrackedPoseDriver component instead
                 {
                     if (TrackedPoseDriver == null) //If the interactor does not have a TrackedPoseDriver component then it is not tracked
@@ -107,7 +107,7 @@ namespace MixedReality.Toolkit.Input
 
                 //If the XRController has already been set then use it to check if the controller is tracked
                 return xrController.currentControllerState.inputTrackingState.HasPositionAndRotation();
-                #pragma warning restore CS0618
+#pragma warning restore CS0618
             }
         }
 
@@ -146,12 +146,14 @@ namespace MixedReality.Toolkit.Input
         {
             get
             {
-                #pragma warning disable CS0618 // Type or member is obsolete
-                #pragma warning disable CS0612 // Type or member is obsolete
+#pragma warning disable CS0618 // Type or member is obsolete
+#pragma warning disable CS0612 // Type or member is obsolete
                 if (xrController != null)
                 {
                     return (xrController is ArticulatedHandController handController) ? handController.HandNode.ToHandedness() : Handedness.None;
                 }
+#pragma warning restore CS0612
+#pragma warning restore CS0618
                 else if (HandModel != null)
                 {
                     return HandModel.HandNode.ToHandedness();
@@ -161,8 +163,6 @@ namespace MixedReality.Toolkit.Input
                     Debug.LogWarning($"Cannot determine Handedness of {name} because there is no associated HandModel.");
                 }
                 return Handedness.None; //If neither an XRController nor a HandModel is associated with this interactor then return None as handedness.
-                #pragma warning restore CS0612
-                #pragma warning restore CS0618
             }
         }
 
@@ -175,11 +175,12 @@ namespace MixedReality.Toolkit.Input
         {
             get
             {
-                #pragma warning disable CS0618 // Type or member is obsolete
+#pragma warning disable CS0618 // Type or member is obsolete
                 if (xrController != null)
                 {
                     return xrController.selectInteractionState.value;
                 }
+#pragma warning restore CS0618
                 else if (selectInput != null)
                 {
                     return selectInput.ReadValue();
@@ -189,7 +190,6 @@ namespace MixedReality.Toolkit.Input
                     Debug.LogWarning($"Unable to determine SelectProgress of {name} because there is neither an XRBaseController nor the Input Configuration has Select Input Actions referenced to it.");
                 }
                 return 0;
-                #pragma warning restore CS0618
             }
         }
 
@@ -264,8 +264,8 @@ namespace MixedReality.Toolkit.Input
                     {
                         bool isPalmFacingAway = false;
 
-                        #pragma warning disable CS0618 // Type or member is obsolete
-                        #pragma warning disable CS0612 // Type or member is obsolete
+#pragma warning disable CS0618 // Type or member is obsolete
+#pragma warning disable CS0612 // Type or member is obsolete
                         if (xrController != null)
                         {
                             if (xrController is ArticulatedHandController handController)
@@ -276,6 +276,8 @@ namespace MixedReality.Toolkit.Input
                                 }
                             }
                         }
+#pragma warning restore CS0612
+#pragma warning restore CS0618
                         else if (HandModel != null)
                         {
                             if (XRSubsystemHelpers.HandsAggregator?.TryGetPalmFacingAway(HandModel.HandNode, out isPalmFacingAway) ?? true)
@@ -287,8 +289,6 @@ namespace MixedReality.Toolkit.Input
                         {
                             Debug.LogWarning($"Unable to determine if {name} is hovering because there is neither an XRBaseController nor a HandModel associated with the parent of this interactor.");
                         }
-                        #pragma warning restore CS0612
-                        #pragma warning restore CS0618
                     }
 
                     return hoverActive && IsTracked;


### PR DESCRIPTION
Aiming for the goal of removing *Controller* references in Interactors in this PR:
* Upgraded MRTKRayInteractor to handle the new components that replace pre-XRI3 components in experimental prefabs.
* Adjusted logic to have backward compatibility to support pre-XRI3 components.

Updated experimental prefabs so that the new TrackedPoseDriver field is linked to the parental MRTK*Hand prefab's TrackedPoseDriver as in:

![image](https://github.com/MixedRealityToolkit/MixedRealityToolkit-Unity/assets/84108471/01aecd43-72e8-44e8-88f3-e8b3388059bd)
