### PR TITLE
XRI3 migration step06

### DIFF
--- a/org.mixedrealitytoolkit.input/Interactors/Poke/PokeInteractor.cs
+++ b/org.mixedrealitytoolkit.input/Interactors/Poke/PokeInteractor.cs
@@ -229,7 +229,7 @@ namespace MixedReality.Toolkit.Input
                     }
                     else
                     {
-                        // If we don't have a poke pose, reset to whatever our parent XRController's pose is.
+                        // If we don't have a poke pose, reset to whatever our parent's pose is.
                         transform.localPosition = Vector3.zero;
                         transform.localRotation = Quaternion.identity;
                     }

--- a/org.mixedrealitytoolkit.input/Interactors/Poke/PokeInteractor.cs
+++ b/org.mixedrealitytoolkit.input/Interactors/Poke/PokeInteractor.cs
@@ -105,7 +105,29 @@ namespace MixedReality.Toolkit.Input
         #region IHandedInteractor
 
         /// <inheritdoc />
-        Handedness IHandedInteractor.Handedness => (xrController is ArticulatedHandController handController) ? handController.HandNode.ToHandedness() : Handedness.None;
+        Handedness IHandedInteractor.Handedness
+        {
+            get
+            {
+                #pragma warning disable CS0618 // Type or member is obsolete
+                #pragma warning disable CS0612 // Type or member is obsolete
+                if (xrController != null)
+                {
+                    return (xrController is ArticulatedHandController handController) ? handController.HandNode.ToHandedness() : Handedness.None;
+                }
+                else if (HandModel != null)
+                {
+                    return HandModel.HandNode.ToHandedness();
+                }
+                else
+                {
+                    Debug.LogWarning($"Cannot determine Handedness of {name} because there is no associated HandModel.");
+                }
+                return Handedness.None; //If neither an XRController nor a TrackedPoseDriver is associated with this interactor then return None as handedness.
+                #pragma warning restore CS0612
+                #pragma warning restore CS0618
+            }
+        }
 
         #endregion IHandedInteractor
 

--- a/org.mixedrealitytoolkit.input/Interactors/Ray/MRTKRayInteractor.cs
+++ b/org.mixedrealitytoolkit.input/Interactors/Ray/MRTKRayInteractor.cs
@@ -16,13 +16,13 @@ using UnityEngine.XR.Interaction.Toolkit.UI;
 namespace MixedReality.Toolkit.Input
 {
     /// <summary>
-    /// A wrapper for the XRRayInteractor which stores extra information for MRTK management/services
+    /// A wrapper for the <see cref="XRRayInteractor"/> which stores extra information for MRTK management/services
     /// </summary>
     [AddComponentMenu("MRTK/Input/MRTK Ray Interactor")]
     // This execution order ensures that the MRTKRayInteractor runs its update function right after the
-    // XRController. We do this because the MRTKRayInteractor needs to set its own pose after the parent controller transform,
+    // <see cref="XRController"/>. We do this because the <see cref="MRTKRayInteractor"/> needs to set its own pose after the parent controller transform,
     // but before any physics raycast calls are made to determine selection. The earliest a physics call can be made is within
-    // the UIInputModule, which has an update order much higher than XRControllers.
+    // the UIInputModule, which has an update order much higher than <see cref="XRController"/>s.
     // TODO: Examine the update order of other interactors in the future with respect to when their physics calls happen,
     // or create a system to keep ensure interactor poses aren't ever implicitly set via parenting.
     [DefaultExecutionOrder(XRInteractionUpdateOrder.k_Controllers + 1)]

--- a/org.mixedrealitytoolkit.input/Interactors/Ray/MRTKRayInteractor.cs
+++ b/org.mixedrealitytoolkit.input/Interactors/Ray/MRTKRayInteractor.cs
@@ -38,13 +38,13 @@ namespace MixedReality.Toolkit.Input
         /// Holds a reference to the deprecated <see cref="XRBaseController"/> associated to this interactor if it exists.  This
         /// will be removed when the XRI3 migration is completed and all *Controller* stuff is removed.
         /// </summary>
-        [Obsolete]
+        [Obsolete("Deprecated, please use trackedPoseDriver instead.")]
         private XRBaseController xrBaseController = null;
 
         /// <summary>
         /// Property for accessing xrBaseController, will be removed for XRI3 migration completion.
         /// </summary>
-        [Obsolete]
+        [Obsolete("Deprecated, please use TrackedPoseDriver instead.")]
         private XRBaseController XRBaseController
         {
             get
@@ -60,8 +60,8 @@ namespace MixedReality.Toolkit.Input
 
         /// <summary>
         /// Holds a reference to the <see cref="TrackedPoseDriver"/> associated to this interactor if it exists.  This field
-        /// is popualted the first time IsTracked property is accessed AND there is no <see cref="XRBaseController"/> component
-        /// associated to to interactor.
+        /// is populated the first time IsTracked property is accessed AND there is no <see cref="XRBaseController"/> component
+        /// associated to the interactor.
         /// </summary>
         private TrackedPoseDriver trackedPoseDriver = null;
 
@@ -72,7 +72,7 @@ namespace MixedReality.Toolkit.Input
 
         /// <summary>
         /// Is this ray currently selecting a UnityUI/Canvas element?
-        /// </summary> 
+        /// </summary>
         public bool HasUISelection => HasUIHover && isUISelectActive;
 
         /// <summary>
@@ -83,6 +83,7 @@ namespace MixedReality.Toolkit.Input
         {
             get
             {
+                #pragma warning disable CS0618 // Type or member is obsolete
                 if (XRBaseController == null) //If no XRController is associated with this interactor then try to get the TrackedPoseDriver component instead
                 {
                     trackedPoseDriver = GetComponentInParent<TrackedPoseDriver>();
@@ -96,6 +97,7 @@ namespace MixedReality.Toolkit.Input
 
                 //If the XRController has already been set then use it to check if the controller is tracked
                 return XRBaseController.currentControllerState.inputTrackingState.HasPositionAndRotation();
+                #pragma warning disable CS0618 // Type or member is obsolete
             }
         }
 

--- a/org.mixedrealitytoolkit.input/Interactors/Ray/MRTKRayInteractor.cs
+++ b/org.mixedrealitytoolkit.input/Interactors/Ray/MRTKRayInteractor.cs
@@ -96,7 +96,7 @@ namespace MixedReality.Toolkit.Input
         {
             get
             {
-#pragma warning disable CS0618 // Type or member is obsolete
+                #pragma warning disable CS0618 // Type or member is obsolete
                 if (XRBaseController == null) //If no XRController is associated with this interactor then try to get the TrackedPoseDriver component instead
                 {
                     if (TrackedPoseDriver == null) //If the interactor does not have a TrackedPoseDriver component then it is not tracked
@@ -110,7 +110,7 @@ namespace MixedReality.Toolkit.Input
 
                 //If the XRController has already been set then use it to check if the controller is tracked
                 return XRBaseController.currentControllerState.inputTrackingState.HasPositionAndRotation();
-#pragma warning disable CS0618 // Type or member is obsolete
+                #pragma warning restore CS0618
             }
         }
 
@@ -145,7 +145,33 @@ namespace MixedReality.Toolkit.Input
 
         #region IHandedInteractor
 
-        Handedness IHandedInteractor.Handedness => (XRBaseController is ArticulatedHandController handController) ? handController.HandNode.ToHandedness() : Handedness.None;
+        Handedness IHandedInteractor.Handedness
+        {
+            get
+            {
+                #pragma warning disable CS0618 // Type or member is obsolete
+                #pragma warning disable CS0612 // Type or member is obsolete
+                if (XRBaseController != null)
+                {
+                    return (XRBaseController is ArticulatedHandController handController) ? handController.HandNode.ToHandedness() : Handedness.None;
+                }
+                else if (TrackedPoseDriver != null)
+                {
+                    HandModel handModel = GetComponentInParent<HandModel>();
+                    if (handModel != null)
+                    {
+                        return handModel.HandNode.ToHandedness();
+                    }
+                    else
+                    {
+                        Debug.LogWarning($"Cannot determin Handedness of {name} because there is no associated HandModel.");
+                    }
+                }
+                return Handedness.None; //If neither an XRController nor a TrackedPoseDriver is associated with this interactor then return None as handedness.
+                #pragma warning restore CS0612
+                #pragma warning restore CS0618
+            }
+        }
 
         #endregion IHandedInteractor
 

--- a/org.mixedrealitytoolkit.input/Interactors/Ray/MRTKRayInteractor.cs
+++ b/org.mixedrealitytoolkit.input/Interactors/Ray/MRTKRayInteractor.cs
@@ -164,7 +164,7 @@ namespace MixedReality.Toolkit.Input
                     }
                     else
                     {
-                        Debug.LogWarning($"Cannot determin Handedness of {name} because there is no associated HandModel.");
+                        Debug.LogWarning($"Cannot determine Handedness of {name} because there is no associated HandModel.");
                     }
                 }
                 return Handedness.None; //If neither an XRController nor a TrackedPoseDriver is associated with this interactor then return None as handedness.
@@ -178,7 +178,27 @@ namespace MixedReality.Toolkit.Input
         #region IVariableSelectInteractor
 
         /// <inheritdoc />
-        public float SelectProgress => XRBaseController.selectInteractionState.value;
+        public float SelectProgress
+        {
+            get
+            {
+                #pragma warning disable CS0618 // Type or member is obsolete
+                if (XRBaseController != null)
+                {
+                    return XRBaseController.selectInteractionState.value;
+                }
+                else if (selectInput != null)
+                {
+                    return selectInput.ReadValue();
+                }
+                else
+                {
+                    Debug.LogWarning($"Unable to determine SelectProgress of {name} because there is neither an XRBaseController nor the Input Configuration has Select Input Actions referenced to it.");
+                }
+                return 0;
+                #pragma warning restore CS0618
+            }
+        }
 
         #endregion IVariableSelectInteractor
 

--- a/org.mixedrealitytoolkit.input/Interactors/Ray/MRTKRayInteractor.cs
+++ b/org.mixedrealitytoolkit.input/Interactors/Ray/MRTKRayInteractor.cs
@@ -59,11 +59,24 @@ namespace MixedReality.Toolkit.Input
         }
 
         /// <summary>
-        /// Holds a reference to the <see cref="TrackedPoseDriver"/> associated to this interactor if it exists.  This field
-        /// is populated the first time IsTracked property is accessed AND there is no <see cref="XRBaseController"/> component
-        /// associated to the interactor.
+        /// Holds a reference to the <see cref="TrackedPoseDriver"/> associated to this interactor if it exists.
         /// </summary>
         private TrackedPoseDriver trackedPoseDriver = null;
+
+        /// <summary>
+        /// Property for accessing trackedPoseDriver which holds a reference to the <see cref="TrackedPoseDriver"/> associated to this interactor if it exists.
+        /// </summary>
+        private TrackedPoseDriver TrackedPoseDriver
+        {
+            get
+            {
+                if (trackedPoseDriver == null) //Try to get the TrackedPoseDriver component from the parent if it hasn't been set yet
+                {
+                    trackedPoseDriver = GetComponentInParent<TrackedPoseDriver>();
+                }
+                return trackedPoseDriver;
+            }
+        }
 
         /// <summary>
         /// Is this ray currently hovering a UnityUI/Canvas element?
@@ -83,21 +96,21 @@ namespace MixedReality.Toolkit.Input
         {
             get
             {
-                #pragma warning disable CS0618 // Type or member is obsolete
+#pragma warning disable CS0618 // Type or member is obsolete
                 if (XRBaseController == null) //If no XRController is associated with this interactor then try to get the TrackedPoseDriver component instead
                 {
-                    trackedPoseDriver = GetComponentInParent<TrackedPoseDriver>();
-                    if (trackedPoseDriver == null) //If TrackedPoseDriver was not found either then the controller is not tracked
+                    if (TrackedPoseDriver == null) //If the interactor does not have a TrackedPoseDriver component then it is not tracked
                     {
                         return false;
                     }
-                    //If a TrackedPoseDriver was found or was already set then use it to check if this interactor is tracked
-                    ((InputTrackingState)trackedPoseDriver.trackingStateInput.action.ReadValue<int>()).HasPositionAndRotation();
+
+                    //If this interactor has a TrackedPoseDriver then use it to check if this interactor is tracked
+                    ((InputTrackingState)TrackedPoseDriver.trackingStateInput.action.ReadValue<int>()).HasPositionAndRotation();
                 }
 
                 //If the XRController has already been set then use it to check if the controller is tracked
                 return XRBaseController.currentControllerState.inputTrackingState.HasPositionAndRotation();
-                #pragma warning disable CS0618 // Type or member is obsolete
+#pragma warning disable CS0618 // Type or member is obsolete
             }
         }
 


### PR DESCRIPTION
Aiming for the goal of removing Controller references in Interactors in this PR:

Upgraded PokeInteractor to handle the new components that replace pre-XRI3 components in experimental prefabs.
Adjusted logic to have backward compatibility to support pre-XRI3 components.

Manual testing done: <TBC> / Made a build with experimental prefabs and sideloaded to HL2. Verified core functionality remains and that no assets were broken.