### PR TITLE
XRI3 migration step 06

### DIFF
--- a/org.mixedrealitytoolkit.input/Assets/Prefabs/Experimental-XRI3/MRTK LeftHand Controller.prefab
+++ b/org.mixedrealitytoolkit.input/Assets/Prefabs/Experimental-XRI3/MRTK LeftHand Controller.prefab
@@ -1483,6 +1483,7 @@ MonoBehaviour:
   m_HapticHoverCancelIntensity: 0
   m_HapticHoverCancelDuration: 0
   m_AllowHoverHapticsWhileSelecting: 1
+  trackedPoseDriver: {fileID: 9028998875765828509}
   pokePoseSource:
     rid: 0
   references:

--- a/org.mixedrealitytoolkit.input/Interactors/Poke/PokeInteractor.cs
+++ b/org.mixedrealitytoolkit.input/Interactors/Poke/PokeInteractor.cs
@@ -81,7 +81,22 @@ namespace MixedReality.Toolkit.Input
         #region IHandedInteractor
 
         /// <inheritdoc />
-        Handedness IHandedInteractor.Handedness => (xrController is ArticulatedHandController handController) ? handController.HandNode.ToHandedness() : Handedness.None;
+        Handedness IHandedInteractor.Handedness
+        {
+            get
+            {
+#pragma warning disable CS0618 // Type or member is obsolete
+                if (forceDeprecatedInput)
+                {
+                    return (xrController is ArticulatedHandController handController) ? handController.HandNode.ToHandedness() : Handedness.None;
+                }
+#pragma warning restore CS0618 // Type or member is obsolete
+                else
+                {
+                    return handedness.ToHandedness();
+                }
+            }
+        }
 
         #endregion IHandedInteractor
 

--- a/org.mixedrealitytoolkit.input/Interactors/Poke/PokeInteractor.cs
+++ b/org.mixedrealitytoolkit.input/Interactors/Poke/PokeInteractor.cs
@@ -49,11 +49,27 @@ namespace MixedReality.Toolkit.Input
         protected virtual bool TryGetPokeRadius(out float radius)
         {
             HandJointPose jointPose = default;
-            if (xrController is ArticulatedHandController handController
-                && (XRSubsystemHelpers.HandsAggregator?.TryGetNearInteractionPoint(handController.HandNode, out jointPose) ?? false))
+
+#pragma warning disable CS0618 // Type or member is obsolete
+#pragma warning disable CS0612 // Type or member is obsolete
+            if (forceDeprecatedInput)
             {
-                radius = jointPose.Radius;
-                return true;
+                if (xrController is ArticulatedHandController handController
+                    && (XRSubsystemHelpers.HandsAggregator?.TryGetNearInteractionPoint(handController.HandNode, out jointPose) ?? false))
+                {
+                    radius = jointPose.Radius;
+                    return true;
+                }
+            }
+#pragma warning disable CS0612 // Type or member is obsolete
+#pragma warning restore CS0618 // Type or member is obsolete
+            else
+            {
+                if (XRSubsystemHelpers.HandsAggregator?.TryGetNearInteractionPoint(handedness.ToXRNode(), out jointPose) ?? false)
+                {
+                    radius = jointPose.Radius;
+                    return true;
+                }
             }
 
             radius = default;

--- a/org.mixedrealitytoolkit.input/Interactors/Poke/PokeInteractor.cs
+++ b/org.mixedrealitytoolkit.input/Interactors/Poke/PokeInteractor.cs
@@ -62,14 +62,12 @@ namespace MixedReality.Toolkit.Input
 
 #pragma warning disable CS0618 // Type or member is obsolete
 #pragma warning disable CS0612 // Type or member is obsolete
-            if (forceDeprecatedInput)
+            if (forceDeprecatedInput &&
+                xrController is ArticulatedHandController handController &&
+                (XRSubsystemHelpers.HandsAggregator?.TryGetNearInteractionPoint(handController.HandNode, out jointPose) ?? false))
             {
-                if (xrController is ArticulatedHandController handController
-                    && (XRSubsystemHelpers.HandsAggregator?.TryGetNearInteractionPoint(handController.HandNode, out jointPose) ?? false))
-                {
-                    radius = jointPose.Radius;
-                    return true;
-                }
+                radius = jointPose.Radius;
+                return true;
             }
 #pragma warning disable CS0612 // Type or member is obsolete
 #pragma warning restore CS0618 // Type or member is obsolete

--- a/org.mixedrealitytoolkit.input/Interactors/Poke/PokeInteractor.cs
+++ b/org.mixedrealitytoolkit.input/Interactors/Poke/PokeInteractor.cs
@@ -135,7 +135,7 @@ namespace MixedReality.Toolkit.Input
         {
             base.Start();
 
-            if (trackedPoseDriver == null) //Try to get the TrackedPoseDriver component from the parent if it hasn't been set yet
+            if (trackedPoseDriver == null) //Try to get the <see cref="TrackedPoseDriver"> component from the parent if it hasn't been set yet
             {
                 trackedPoseDriver = GetComponentInParent<TrackedPoseDriver>();
             }
@@ -190,12 +190,12 @@ namespace MixedReality.Toolkit.Input
 #pragma warning restore CS0618 // Type or member is obsolete
                 else
                 {
-                    if (TrackedPoseDriver == null) //If the interactor does not have a TrackedPoseDriver component then we cannot determine if it is hover active
+                    if (TrackedPoseDriver == null) //If the interactor does not have a <see cref="TrackedPoseDriver"> component then we cannot determine if it is hover active
                     {
                         return false;
                     }
 
-                    //If this intreactor has an associated TrackedPoseDriver component then use it to determine if the interactor is hover active
+                    //If this interactor has an associated <see cref="TrackedPoseDriver"> component then use it to determine if the interactor is hover active
                     return base.isHoverActive && ((InputTrackingState)TrackedPoseDriver.trackingStateInput.action.ReadValue<int>()).HasPositionAndRotation();
                 }
             }


### PR DESCRIPTION
Aiming for the goal of removing *Controller* references in Interactors for XRI3 migration in this PR:

* Upgraded PokeInteractor::TryGetPokeRadius()
* Upgraded PokeInteractor.Handedness
* Upgraded PokeInteractor.isHoverActive
  * Added a TrackedPoseDriver field
* Added a reference to the PokeInteractor's parent TrackedPoseDriver to the new TrackedPoseDriver field in the experimental *Hand Controler prefab, the experimental prefab now looks like this:

![image](https://github.com/MixedRealityToolkit/MixedRealityToolkit-Unity/assets/84108471/a98d71ce-5329-44c4-9035-22505edffdcc)

Manual testing done:
* Sideloaded a build with experimental prefabs on HL2, tested core scenes; all functionality works as expected, no broken assets detected.