### PR TITLE
XRI3 migration step07

### DIFF
--- a/org.mixedrealitytoolkit.input/Assets/Prefabs/Experimental-XRI3/MRTK LeftHand Controller.prefab
+++ b/org.mixedrealitytoolkit.input/Assets/Prefabs/Experimental-XRI3/MRTK LeftHand Controller.prefab
@@ -1843,6 +1843,7 @@ MonoBehaviour:
   m_HapticHoverCancelIntensity: 0
   m_HapticHoverCancelDuration: 0
   m_AllowHoverHapticsWhileSelecting: 1
+  trackedPoseDriver: {fileID: 9028998875765828509}
   handController: {fileID: 6164080946324827545}
   devicePoseSource:
     rid: 0

--- a/org.mixedrealitytoolkit.input/Interactors/GazePinch/GazePinchInteractor.cs
+++ b/org.mixedrealitytoolkit.input/Interactors/GazePinch/GazePinchInteractor.cs
@@ -200,7 +200,29 @@ namespace MixedReality.Toolkit.Input
         #region IVariableSelectInteractor
 
         /// <inheritdoc />
-        public float SelectProgress => handController.selectInteractionState.value;
+        public float SelectProgress
+        {
+            get
+            {
+#pragma warning disable CS0618 // Type or member is obsolete
+                if (forceDeprecatedInput)
+                {
+#pragma warning disable CS0612 // Type or member is obsolete
+                    return handController.selectInteractionState.value;
+#pragma warning restore CS0612 // Type or member is obsolete
+                }
+#pragma warning restore CS0618 // Type or member is obsolete
+                else if (selectInput != null)
+                {
+                    return selectInput.ReadValue();
+                }
+                else
+                {
+                    Debug.LogWarning($"Unable to determine SelectProgress of {name} because there is no Select Input Configuration set for this interactor.");
+                }
+                return 0.0f;
+            }
+        }
 
         #endregion IVariableSelectInteractor
 

--- a/org.mixedrealitytoolkit.input/Interactors/GazePinch/GazePinchInteractor.cs
+++ b/org.mixedrealitytoolkit.input/Interactors/GazePinch/GazePinchInteractor.cs
@@ -37,7 +37,7 @@ namespace MixedReality.Toolkit.Input
 
         [SerializeField]
         [Tooltip("The hand controller used to get the selection progress values")]
-        [Obsolete]
+        [Obsolete("Deprecated, please use this.TrackedPoseDriver instead.")]
         private ArticulatedHandController handController;
 
         /// <summary>
@@ -79,20 +79,20 @@ namespace MixedReality.Toolkit.Input
 
         [SerializeReference]
         [InterfaceSelector(true)]
-        [Tooltip("The pose source representing the pose this interactor uses for aiming and positioning. Follows the 'pointer pose'")]
+        [Tooltip("The pose source representing the pose this interactor uses for aiming and positioning. Follows the 'pointer pose'.")]
         private IPoseSource aimPoseSource;
 
         /// <summary>
-        /// The pose source representing the ray this interactor uses for aiming and positioning.
+        /// The pose source representing the pose this interactor uses for aiming and positioning. Follows the 'pointer pose'.
         /// </summary>
         protected IPoseSource AimPoseSource { get => aimPoseSource; set => aimPoseSource = value; }
 
         [SerializeField]
-        [Tooltip("The interactor we're using to query potential gaze pinch targets")]
+        [Tooltip("The interactor we're using to query potential gaze pinch targets.")]
         private XRBaseInputInteractor dependentInteractor;
 
         /// <summary>
-        /// The pose source representing the ray this interactor uses for aiming and positioning.
+        /// The interactor we're using to query potential gaze pinch targets.
         /// </summary>
         protected XRBaseInputInteractor DependentInteractor { get => dependentInteractor; set => dependentInteractor = value; }
 
@@ -145,7 +145,7 @@ namespace MixedReality.Toolkit.Input
         private Vector3 interactorLocalAttachPoint;
 
         /// <summary>
-        /// Used to check if the parent controller is tracked or not
+        /// Used to check if the parent controller is tracked or not.
         /// Hopefully this becomes part of the base Unity XRI API.
         /// </summary>
         private bool IsTracked
@@ -181,12 +181,12 @@ namespace MixedReality.Toolkit.Input
             get
             {
 #pragma warning disable CS0618 // Type or member is obsolete
-#pragma warning disable CS0612 // Type or member is obsolete
                 if (forceDeprecatedInput)
                 {
+#pragma warning disable CS0612 // Type or member is obsolete
                     return handController.HandNode.ToHandedness();
-                }
 #pragma warning restore CS0612 // Type or member is obsolete
+                }
 #pragma warning restore CS0618 // Type or member is obsolete
                 else
                 {
@@ -239,6 +239,7 @@ namespace MixedReality.Toolkit.Input
             }
         }
 
+        /// <inheritdoc/>
         private void OnDrawGizmosSelected()
         {
             if (Application.isPlaying)
@@ -253,7 +254,7 @@ namespace MixedReality.Toolkit.Input
 
         #region XRBaseInteractor
 
-        /// <inheritdoc />
+        /// <inheritdoc/>
         /// <remarks>
         /// This indirect interactor harvests the valid targets from the associated
         /// <see cref="dependentInteractor"/>, allowing for gaze-targeting or other

--- a/org.mixedrealitytoolkit.input/Interactors/GazePinch/GazePinchInteractor.cs
+++ b/org.mixedrealitytoolkit.input/Interactors/GazePinch/GazePinchInteractor.cs
@@ -176,7 +176,24 @@ namespace MixedReality.Toolkit.Input
         #region IHandedInteractor
 
         /// <inheritdoc />
-        Handedness IHandedInteractor.Handedness => handController.HandNode.ToHandedness();
+        Handedness IHandedInteractor.Handedness
+        {
+            get
+            {
+#pragma warning disable CS0618 // Type or member is obsolete
+#pragma warning disable CS0612 // Type or member is obsolete
+                if (forceDeprecatedInput)
+                {
+                    return handController.HandNode.ToHandedness();
+                }
+#pragma warning restore CS0612 // Type or member is obsolete
+#pragma warning restore CS0618 // Type or member is obsolete
+                else
+                {
+                    return handedness.ToHandedness();
+                }
+            }
+        }
 
         #endregion IHandedInteractor
 

--- a/org.mixedrealitytoolkit.input/Interactors/GazePinch/GazePinchInteractor.cs
+++ b/org.mixedrealitytoolkit.input/Interactors/GazePinch/GazePinchInteractor.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Mixed Reality Toolkit Contributors
 // Licensed under the BSD 3-Clause
 
+using System;
 using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.XR;
@@ -27,6 +28,7 @@ namespace MixedReality.Toolkit.Input
 
         [SerializeField]
         [Tooltip("The hand controller used to get the selection progress values")]
+        [Obsolete]
         private ArticulatedHandController handController;
 
         /// <summary>


### PR DESCRIPTION
Aiming for the goal of removing *Controller* references in Interactors for XRI3 migration in this PR:

* Upgraded GazePinchInteractor.Handedness
* Upgraded GazePinchInteractor.SelectProgress
* Updated comments
* Upgraded GazePinchInteractor.IsTracked
  * Added TrackedPoseDriver field + linked to parent's TrackedPoseDriver in experimental prefab.  The prefab now looks like this:

![image](https://github.com/MixedRealityToolkit/MixedRealityToolkit-Unity/assets/84108471/9b7ed355-b2ac-4d3c-923b-de348bf0a738)

Manual testing done:

* Sideloaded a build with experimental prefabs on HL2, tested core scenes; all functionality works as expected, no broken assets detected.