### PR TITLE
XRI3 migration step11

### DIFF
--- a/org.mixedrealitytoolkit.spatialmanipulation/Solvers/TapToPlace.cs
+++ b/org.mixedrealitytoolkit.spatialmanipulation/Solvers/TapToPlace.cs
@@ -556,10 +556,27 @@ namespace MixedReality.Toolkit.SpatialManipulation
             interactionManager.GetRegisteredInteractors(interactorsCache);
             foreach (IXRInteractor interactor in interactorsCache)
             {
-                if (interactor is XRBaseInputInteractor controllerInteractor &&
-                    controllerInteractor.xrController is ActionBasedController actionController)
+                if (interactor is XRBaseInputInteractor controllerInteractor)
                 {
-                    actionController.selectAction.action.performed += StopPlacementViaPerformedAction;
+#pragma warning disable CS0618 // ActionBasedController and XRBaseInputInteractor.forceDeprecatedInput are obsolete
+                    if (controllerInteractor.xrController is ActionBasedController actionController)
+                    {
+                        if (controllerInteractor.forceDeprecatedInput &&
+                            actionController.selectAction.action != null)
+                        {
+                            actionController.selectAction.action.performed += StopPlacementViaPerformedAction;
+                        }
+                        else if (controllerInteractor.selectInput.inputActionReferenceValue != null &&
+                                 controllerInteractor.selectInput.inputActionReferenceValue.action != null) //Use the controller-less select action if it is set
+                        {
+                            controllerInteractor.selectInput.inputActionReferenceValue.action.performed += StopPlacementViaPerformedAction;
+                        }
+                        else
+                        {
+                            Debug.LogWarning($"Neither the deprecated XRController.selectAction nor the ControllerLess Interactor/InputConfiguration.SelectInput action are set.");
+                        }
+                    }
+#pragma warning restore CS0618 // ActionBasedController and XRBaseInputInteractor.forceDeprecatedInput are obsolete
                 }
                 else if (interactor is IXRSelectInteractor selectInteractor)
                 {
@@ -577,10 +594,27 @@ namespace MixedReality.Toolkit.SpatialManipulation
             {
                 foreach (IXRInteractor interactor in interactorsCache)
                 {
-                    if (interactor is XRBaseInputInteractor controllerInteractor &&
-                        controllerInteractor.xrController is ActionBasedController actionController)
+                    if (interactor is XRBaseInputInteractor controllerInteractor)
                     {
-                        actionController.selectAction.action.performed -= StopPlacementViaPerformedAction;
+#pragma warning disable CS0618 // ActionBasedController and XRBaseInputInteractor.forceDeprecatedInput are obsolete
+                        if (controllerInteractor.xrController is ActionBasedController actionController)
+                        {
+                            if (controllerInteractor.forceDeprecatedInput &&
+                                actionController.selectAction.action != null)
+                            {
+                                actionController.selectAction.action.performed -= StopPlacementViaPerformedAction;
+                            }
+                            else if (controllerInteractor.selectInput.inputActionReferenceValue != null &&
+                                     controllerInteractor.selectInput.inputActionReferenceValue.action != null) //Use the controller-less select action if it is set
+                            {
+                                controllerInteractor.selectInput.inputActionReferenceValue.action.performed -= StopPlacementViaPerformedAction;
+                            }
+                            else
+                            {
+                                Debug.LogWarning($"Neither the deprecated XRController.selectAction nor the ControllerLess Interactor/InputConfiguration.SelectInput action are set.");
+                            }
+                        }
+#pragma warning restore CS0618 // ActionBasedController and XRBaseInputInteractor.forceDeprecatedInput are obsolete
                     }
                     else if (interactor is IXRSelectInteractor selectInteractor)
                     {

--- a/org.mixedrealitytoolkit.spatialmanipulation/Tests/Runtime/SolverTapToPlaceTests.cs
+++ b/org.mixedrealitytoolkit.spatialmanipulation/Tests/Runtime/SolverTapToPlaceTests.cs
@@ -23,6 +23,7 @@ namespace MixedReality.Toolkit.SpatialManipulation.Runtime.Tests
         /// Verify TapToPlace can move an object to the end of the right hand ray.
         /// </summary>
         [UnityTest]
+#pragma warning disable CS0618 // Adding this pragma because all the encompassed tests depend on deprecated ControllerLookup
         public IEnumerator TapToPlaceFollowsRightHandRay()
         {
             // Disable gaze interactions for this unit test;
@@ -184,6 +185,7 @@ namespace MixedReality.Toolkit.SpatialManipulation.Runtime.Tests
             var testObjectFinalPosition = testObject.transform.position;
             Assert.AreEqual(testObjectPlacementPosition, testObjectFinalPosition, $"Game object should not have moved.");
         }
+#pragma warning restore CS0618 // Adding this pragma because all the encompassed tests depend on deprecated ControllerLookup
     }
 }
 #pragma warning restore CS1591

--- a/org.mixedrealitytoolkit.spatialmanipulation/Tests/Runtime/SolverTapToPlaceTestsForControllerlessRig.cs
+++ b/org.mixedrealitytoolkit.spatialmanipulation/Tests/Runtime/SolverTapToPlaceTestsForControllerlessRig.cs
@@ -15,7 +15,7 @@ using MixedReality.Toolkit.Core.Tests;
 namespace MixedReality.Toolkit.SpatialManipulation.Runtime.Tests
 {
     /// <summary>
-    /// Tests for TapToPlace solver.
+    /// Tests for TapToPlace solver for the XRI3+ controllerless MRTK rig.
     /// </summary>
     /// <remarks>
     /// These tests are equivalent to those in <see cref="SolverTapToPlaceTests"/> but they test with the new MRTK Rig that was

--- a/org.mixedrealitytoolkit.spatialmanipulation/Tests/Runtime/SolverTapToPlaceTestsForControllerlessRig.cs
+++ b/org.mixedrealitytoolkit.spatialmanipulation/Tests/Runtime/SolverTapToPlaceTestsForControllerlessRig.cs
@@ -1,0 +1,203 @@
+// Copyright (c) Mixed Reality Toolkit Contributors
+// Licensed under the BSD 3-Clause
+
+// Disable "missing XML comment" warning for tests. While nice to have, this documentation is not required.
+#pragma warning disable CS1591
+
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.TestTools;
+using MixedReality.Toolkit.Input;
+using System.Collections;
+using MixedReality.Toolkit.Input.Tests;
+using MixedReality.Toolkit.Core.Tests;
+
+namespace MixedReality.Toolkit.SpatialManipulation.Runtime.Tests
+{
+    /// <summary>
+    /// Tests for TapToPlace solver.
+    /// </summary>
+    /// <remarks>
+    /// These tests are equivalent to those in <see cref="SolverTapToPlaceTests"/> but they test with the new MRTK Rig that was
+    /// created for the XRI3 migration.  Eventually, this will replace the original <see cref="SolverTapToPlaceTests"/> when
+    /// the deprecated pre-XRI3 rig is removed in its entirety from MRTK3.
+    /// Note:  This class contains only the tests that are specific to the XRI3+ rig.  Tests that are common to both rigs are in the
+    ///        original <see cref="SolverTapToPlaceTests"/>.  Once the XRI3 migration is completed by removing all the pre-XRI3
+    ///        prefabs then those tests can be moved to this class.
+    /// </remarks>
+    public class SolverTapToPlaceTestsForControllerlessRig : BaseRuntimeInputTests
+    {
+        [UnitySetUp]
+        public override IEnumerator Setup()
+        {
+            yield return base.SetupForControllerlessRig();
+        }
+
+        /// <summary>
+        /// Verify TapToPlace can move an object to the end of the right hand ray.
+        /// </summary>
+        [UnityTest]
+        public IEnumerator TapToPlaceFollowsRightHandRay()
+        {
+            // Disable gaze interactions for this unit test;
+            InputTestUtilities.DisableGazeInteractor();
+
+            // Set up GameObject with a SolverHandler
+            var testObject = GameObject.CreatePrimitive(PrimitiveType.Cube);
+            var solverHandler = testObject.AddComponent<SolverHandler>();
+            var solver = testObject.AddComponent<TapToPlace>();
+
+            // Disable smoothing so moving happens instantly. This makes testing positions easier.
+            solver.Smoothing = false;
+
+            // Set it to track interactors
+            solverHandler.TrackedHandedness = Handedness.Both;
+            solverHandler.TrackedTargetType = TrackedObjectType.Interactor;
+            var lookup = FindObjectUtility.FindAnyObjectByType<TrackedPoseDriverLookup>();
+            var leftInteractor = lookup.LeftHandTrackedPoseDriver.GetComponentInChildren<MRTKRayInteractor>();
+            var rightInteractor = lookup.RightHandTrackedPoseDriver.GetComponentInChildren<MRTKRayInteractor>();
+            solverHandler.LeftInteractor = leftInteractor;
+            solverHandler.RightInteractor = rightInteractor;
+
+            yield return RuntimeTestUtilities.WaitForUpdates();
+
+            TestHand rightHand = new TestHand(Handedness.Right);
+            TestHand leftHand = new TestHand(Handedness.Left);
+            var rightHandPosition = InputTestUtilities.InFrontOfUser(new Vector3(0.05f, -0.05f, 1f));
+            var leftHandPosition = InputTestUtilities.InFrontOfUser(new Vector3(-0.05f, -0.05f, 1f));
+
+            testObject.transform.position = InputTestUtilities.InFrontOfUser(3.0f);
+
+            yield return rightHand.Show(rightHandPosition);
+            yield return RuntimeTestUtilities.WaitForUpdates();
+            yield return rightHand.AimAt(testObject.transform.position);
+            yield return RuntimeTestUtilities.WaitForUpdates();
+
+            yield return leftHand.Show(leftHandPosition);
+            yield return RuntimeTestUtilities.WaitForUpdates();
+            yield return leftHand.AimAt(testObject.transform.position);
+            yield return RuntimeTestUtilities.WaitForUpdates();
+
+            // Check if TapToPlace starts without being in "placement" mode.
+            Assert.IsFalse(solver.IsBeingPlaced, "TapToPlace should have starting without being in placement mode.");
+
+            // Start placement and move hand.
+            solver.StartPlacement();
+            yield return RuntimeTestUtilities.WaitForUpdates();
+
+            // Check if TapToPlace started.
+            Assert.IsTrue(solver.IsBeingPlaced, "TapToPlace should have started.");
+            var testObjectStartPosition = testObject.transform.position;
+
+            // Aim hand and move object.
+            yield return rightHand.AimAt(InputTestUtilities.InFrontOfUser(new Vector3(0.05f, 0.1f, 2.0f)));
+            yield return RuntimeTestUtilities.WaitForUpdates();
+
+            // Verify shape moved to placement
+            var testObjectPlacementPosition = testObject.transform.position;
+            Assert.AreNotEqual(testObjectStartPosition, testObjectPlacementPosition, $"Game object did not move");
+
+            // Wait for solvers double click prevention timeout
+            yield return new WaitForSeconds(0.5f + 0.1f);
+
+            // Clicking with opposite hand should stop movement
+            yield return leftHand.Click();
+            yield return RuntimeTestUtilities.WaitForUpdates();
+
+            // Check if TapToPlace stopped with pinch.
+            Assert.IsFalse(solver.IsBeingPlaced, "TapToPlace should have stopped with left hand pinch.");
+
+            // Aim hand
+            yield return rightHand.AimAt(InputTestUtilities.InFrontOfUser(new Vector3(-0.05f, -0.1f, 2.0f)));
+            yield return RuntimeTestUtilities.WaitForUpdates();
+
+            // Verify shape did not moved 
+            var testObjectFinalPosition = testObject.transform.position;
+            Assert.AreEqual(testObjectPlacementPosition, testObjectFinalPosition, $"Game object should not have moved.");
+        }
+
+        /// <summary>
+        /// Verify TapToPlace can move an object to the end of the left hand ray.
+        /// </summary>
+        [UnityTest]
+        public IEnumerator TapToPlaceFollowsLeftHandRay()
+        {
+            // Disable gaze interactions for this unit test;
+            InputTestUtilities.DisableGazeInteractor();
+
+            // Set up GameObject with a SolverHandler
+            var testObject = GameObject.CreatePrimitive(PrimitiveType.Cube);
+            var solverHandler = testObject.AddComponent<SolverHandler>();
+            var solver = testObject.AddComponent<TapToPlace>();
+
+            // Disable smoothing so moving happens instantly. This makes testing positions easier.
+            solver.Smoothing = false;
+
+            // Set it to track interactors
+            solverHandler.TrackedHandedness = Handedness.Both;
+            solverHandler.TrackedTargetType = TrackedObjectType.Interactor;
+            var lookup = FindObjectUtility.FindAnyObjectByType<TrackedPoseDriverLookup>();
+            var leftInteractor = lookup.LeftHandTrackedPoseDriver.GetComponentInChildren<MRTKRayInteractor>();
+            var rightInteractor = lookup.RightHandTrackedPoseDriver.GetComponentInChildren<MRTKRayInteractor>();
+            solverHandler.LeftInteractor = leftInteractor;
+            solverHandler.RightInteractor = rightInteractor;
+
+            yield return RuntimeTestUtilities.WaitForUpdates();
+
+            TestHand rightHand = new TestHand(Handedness.Right);
+            TestHand leftHand = new TestHand(Handedness.Left);
+            var rightHandPosition = InputTestUtilities.InFrontOfUser(new Vector3(0.05f, -0.05f, 1f));
+            var leftHandPosition = InputTestUtilities.InFrontOfUser(new Vector3(-0.05f, -0.05f, 1f));
+
+            testObject.transform.position = InputTestUtilities.InFrontOfUser(3.0f);
+
+            yield return leftHand.Show(leftHandPosition);
+            yield return RuntimeTestUtilities.WaitForUpdates();
+            yield return leftHand.AimAt(testObject.transform.position);
+            yield return RuntimeTestUtilities.WaitForUpdates();
+
+            yield return rightHand.Show(rightHandPosition);
+            yield return RuntimeTestUtilities.WaitForUpdates();
+            yield return rightHand.AimAt(testObject.transform.position);
+            yield return RuntimeTestUtilities.WaitForUpdates();
+
+            // Check if TapToPlace starts without being in "placement" mode.
+            Assert.IsFalse(solver.IsBeingPlaced, "TapToPlace should have starting without being in placement mode.");
+
+            // Start placement and move hand.
+            solver.StartPlacement();
+            yield return RuntimeTestUtilities.WaitForUpdates();
+
+            // Check if TapToPlace started.
+            Assert.IsTrue(solver.IsBeingPlaced, "TapToPlace should have started.");
+            var testObjectStartPosition = testObject.transform.position;
+
+            // Aim hand and move object.
+            yield return leftHand.AimAt(InputTestUtilities.InFrontOfUser(new Vector3(-0.05f, 0.1f, 2.0f)));
+            yield return RuntimeTestUtilities.WaitForUpdates();
+
+            // Verify shape moved to placement
+            var testObjectPlacementPosition = testObject.transform.position;
+            Assert.AreNotEqual(testObjectStartPosition, testObjectPlacementPosition, $"Game object did not move");
+
+            // Wait for solvers double click prevention timeout
+            yield return new WaitForSeconds(0.5f + 0.1f);
+
+            // Clicking with opposite hand should stop movement
+            yield return rightHand.Click();
+            yield return RuntimeTestUtilities.WaitForUpdates();
+
+            // Check if TapToPlace stopped with pinch.
+            Assert.IsFalse(solver.IsBeingPlaced, "TapToPlace should have stopped with left hand pinch.");
+
+            // Aim hand
+            yield return leftHand.AimAt(InputTestUtilities.InFrontOfUser(new Vector3(0.05f, -0.1f, 2.0f)));
+            yield return RuntimeTestUtilities.WaitForUpdates();
+
+            // Verify shape did not moved 
+            var testObjectFinalPosition = testObject.transform.position;
+            Assert.AreEqual(testObjectPlacementPosition, testObjectFinalPosition, $"Game object should not have moved.");
+        }
+    }
+}
+#pragma warning restore CS1591

--- a/org.mixedrealitytoolkit.spatialmanipulation/Tests/Runtime/SolverTapToPlaceTestsForControllerlessRig.cs
+++ b/org.mixedrealitytoolkit.spatialmanipulation/Tests/Runtime/SolverTapToPlaceTestsForControllerlessRig.cs
@@ -36,6 +36,9 @@ namespace MixedReality.Toolkit.SpatialManipulation.Runtime.Tests
         /// <summary>
         /// Verify TapToPlace can move an object to the end of the right hand ray.
         /// </summary>
+        /// <remarks>
+        /// This test is the XRI3+ equivalent of <see cref="SolverTapToPlaceTests.TapToPlaceFollowsRightHandRay"/>
+        /// </remarks>
         [UnityTest]
         public IEnumerator TapToPlaceFollowsRightHandRay()
         {
@@ -119,6 +122,9 @@ namespace MixedReality.Toolkit.SpatialManipulation.Runtime.Tests
         /// <summary>
         /// Verify TapToPlace can move an object to the end of the left hand ray.
         /// </summary>
+        /// <remarks>
+        /// This test is the XRI3+ equivalent of <see cref="SolverTapToPlaceTests.TapToPlaceFollowsLeftHandRay"/>
+        /// </remarks>
         [UnityTest]
         public IEnumerator TapToPlaceFollowsLeftHandRay()
         {

--- a/org.mixedrealitytoolkit.spatialmanipulation/Tests/Runtime/SolverTapToPlaceTestsForControllerlessRig.cs.meta
+++ b/org.mixedrealitytoolkit.spatialmanipulation/Tests/Runtime/SolverTapToPlaceTestsForControllerlessRig.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3522e9470dd3df54db6bf1b40c49b77a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
In this PR:
* Upgraded TapToPlace::RegisterPlacementAction() and TapToPlace::UnregisterPlacementAction() logic to handle both deprecated XRController selectActions and new XRI3+ Interactor's selectInput actions.
* Added XRI3+ versions of SolverTapToPlaceTests TapToPlaceFollowsRightHandRay and TapToPlaceFollowsLeftHandRay.