### PR TITLE
Ignore "Asset Store Publisher" test failures

### DIFF
--- a/org.mixedrealitytoolkit.core/CHANGELOG.md
+++ b/org.mixedrealitytoolkit.core/CHANGELOG.md
@@ -2,7 +2,13 @@
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
-## [3.2.1-development] - 2024-04-24
+## [3.2.2-development] - 2024-06-13
+
+### Fixed
+
+* Fixed UPM package validation so that it ignores errors caused when the test runner is not part of the MRTK publisher account. [PR #775](https://github.com/MixedRealityToolkit/MixedRealityToolkit-Unity/pull/775/)
+
+## [3.2.1] - 2024-04-24
 
 ### Fixed
 

--- a/org.mixedrealitytoolkit.core/Tests/TestUtilities/PackageValidatorResults.cs
+++ b/org.mixedrealitytoolkit.core/Tests/TestUtilities/PackageValidatorResults.cs
@@ -242,6 +242,7 @@ namespace MixedReality.Toolkit.Core.Tests.EditMode
             return IgnoreAccountErrors &&
                 (message.Contains("\"Asset Store Terms Accepted Publish\"") ||
                 message.Contains("\"User logged in\"") ||
+                message.Contains("\"Asset Store Publisher\"") ||
                 message.Contains("\"Publisher Account Exists\""));
         }
     }

--- a/org.mixedrealitytoolkit.core/package.json
+++ b/org.mixedrealitytoolkit.core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "org.mixedrealitytoolkit.core",
-  "version": "3.2.1-development",
+  "version": "3.2.2-development",
   "description": "A limited collection of common interfaces and utilities that most MRTK packages share. Most implementations of these interfaces are contained in other packages in the MRTK ecosystem.",
   "displayName": "MRTK Core Definitions",
   "msftFeatureCategory": "MRTK3",


### PR DESCRIPTION
# Overview

After some of our packages were published to the Unity Asset Store, different error messages started to appear in our test suite. Ignore this message that's caused because the test runner is not part of our Publisher Account.

> Failed - "Asset Store Publisher"
    Error: There is no publisher linked to this account. Read more about this error and potential solutions at https://docs.unity3d.com/Packages/com.unity.asset-store-validation@latest/index.html?preview=1&subfolder=/manual/asset_store_publisher_validation.html#there_is_no_publisher_linked_to_this_account