### PR TITLE
XRI3 migration readying [4.0.0-development.pre.1] packages

### DIFF
--- a/UnityProjects/MRTKDevTemplate/Packages/packages-lock.json
+++ b/UnityProjects/MRTKDevTemplate/Packages/packages-lock.json
@@ -246,8 +246,8 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.xr.interaction.toolkit": {
-      "version": "3.0.1",
-      "depth": 0,
+      "version": "3.0.3",
+      "depth": 1,
       "source": "registry",
       "dependencies": {
         "com.unity.inputsystem": "1.8.1",
@@ -318,7 +318,7 @@
       "depth": 0,
       "source": "local",
       "dependencies": {
-        "com.unity.xr.interaction.toolkit": "3.0.1",
+        "com.unity.xr.interaction.toolkit": "3.0.3",
         "com.unity.xr.management": "4.2.1",
         "com.unity.xr.core-utils": "2.1.0"
       }
@@ -360,7 +360,7 @@
         "com.unity.xr.arfoundation": "5.0.5",
         "com.unity.xr.core-utils": "2.1.0",
         "com.unity.xr.hands": "1.3.0",
-        "com.unity.xr.interaction.toolkit": "3.0.1",
+        "com.unity.xr.interaction.toolkit": "3.0.3",
         "org.mixedrealitytoolkit.core": "4.0.0"
       }
     },
@@ -372,7 +372,7 @@
         "org.mixedrealitytoolkit.core": "4.0.0",
         "org.mixedrealitytoolkit.uxcore": "4.0.0",
         "com.unity.inputsystem": "1.6.1",
-        "com.unity.xr.interaction.toolkit": "3.0.1"
+        "com.unity.xr.interaction.toolkit": "3.0.3"
       }
     },
     "org.mixedrealitytoolkit.standardassets": {
@@ -400,7 +400,7 @@
         "org.mixedrealitytoolkit.uxcore": "4.0.0",
         "org.mixedrealitytoolkit.spatialmanipulation": "4.0.0",
         "org.mixedrealitytoolkit.standardassets": "3.1.0",
-        "com.unity.xr.interaction.toolkit": "3.0.1"
+        "com.unity.xr.interaction.toolkit": "3.0.3"
       }
     },
     "org.mixedrealitytoolkit.uxcomponents.noncanvas": {
@@ -422,7 +422,7 @@
         "org.mixedrealitytoolkit.core": "4.0.0",
         "com.unity.inputsystem": "1.6.1",
         "com.unity.textmeshpro": "3.0.6",
-        "com.unity.xr.interaction.toolkit": "3.0.1"
+        "com.unity.xr.interaction.toolkit": "3.0.3"
       }
     },
     "org.mixedrealitytoolkit.windowsspeech": {

--- a/org.mixedrealitytoolkit.core/CHANGELOG.md
+++ b/org.mixedrealitytoolkit.core/CHANGELOG.md
@@ -27,7 +27,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Removed
 
 * Removed obsolete methods.
-* Removed legacy dialog*.
+* Removed legacy dialog.
 
 ## [3.2.2] - 2024-06-13
 

--- a/org.mixedrealitytoolkit.core/CHANGELOG.md
+++ b/org.mixedrealitytoolkit.core/CHANGELOG.md
@@ -2,11 +2,32 @@
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
-## [4.0.0-development] - 2024-06-13
+## [4.0.0-development.pre.1] - 2024-06-18
+
+### Added
+
+* MRTK3 controllerless prefabs.
+* Added ObsoleteHandInteractionExamples scene that still uses deprecated MRTK3 rig.
+* Added XRI3+ exclusive unity-tests.
+* Added new TrackedPoseDriver lookup.
 
 ### Changed
 
-* Updated package com.unity.xr.interaction.toolkit to 3.0.1
+* Updated package com.unity.xr.interaction.toolkit to 3.0.3
+* Updated Unity Editor to 2022.3.7f1
+* Updated all scenes to consume new MRTK3 controllerless prefabs.
+* Updated existing unity-tests.
+* Updated code to support new XRI3 patterns.
+
+### Deprecated
+
+* MRTK3 controller-based prefabs marked as obsolete and deprecated.
+* Controller lookup deprecated.
+
+### Removed
+
+* Removed obsolete methods.
+* Removed legacy dialog*.
 
 ## [3.2.2] - 2024-06-13
 

--- a/org.mixedrealitytoolkit.core/CHANGELOG.md
+++ b/org.mixedrealitytoolkit.core/CHANGELOG.md
@@ -4,30 +4,22 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [4.0.0-development.pre.1] - 2024-06-18
 
-### Added
-
-* MRTK3 controllerless prefabs.
-* Added ObsoleteHandInteractionExamples scene that still uses deprecated MRTK3 rig.
-* Added XRI3+ exclusive unity-tests.
-* Added new TrackedPoseDriver lookup.
-
 ### Changed
 
 * Updated package com.unity.xr.interaction.toolkit to 3.0.3
-* Updated Unity Editor to 2022.3.7f1
-* Updated all scenes to consume new MRTK3 controllerless prefabs.
-* Updated existing unity-tests.
-* Updated code to support new XRI3 patterns.
-
-### Deprecated
-
-* MRTK3 controller-based prefabs marked as obsolete and deprecated.
-* Controller lookup deprecated.
+* Updated InteractorHandednessExtensions.
 
 ### Removed
 
-* Removed obsolete methods.
-* Removed legacy dialog.
+* Removed obsolete HandednessExtensions::IsRight method.
+* Removed obsolete HandednessExtensions::IsLeft method.
+* Removed obsolete HandsUtils::GetSubsystem method.
+* Removed obsolete PlayspaceUtilities.ReferenceTransform field.
+* Removed obsolete XRSubsystemHelpers::GetAllRunningSubsystemsNonAlloc method.
+
+### Deprecated
+
+* ControllerLookup marked as Obsolete.
 
 ## [3.2.2] - 2024-06-13
 

--- a/org.mixedrealitytoolkit.core/package.json
+++ b/org.mixedrealitytoolkit.core/package.json
@@ -17,7 +17,7 @@
   "unityRelease": "26f1",
   "documentationUrl": "https://www.mixedrealitytoolkit.org",
   "dependencies": {
-    "com.unity.xr.interaction.toolkit": "3.0.1",
+    "com.unity.xr.interaction.toolkit": "3.0.3",
     "com.unity.xr.management": "4.2.1",
     "com.unity.xr.core-utils": "2.1.0"
   }

--- a/org.mixedrealitytoolkit.core/package.json
+++ b/org.mixedrealitytoolkit.core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "org.mixedrealitytoolkit.core",
-  "version": "4.0.0-development",
+  "version": "4.0.0-development.pre.1",
   "description": "A limited collection of common interfaces and utilities that most MRTK packages share. Most implementations of these interfaces are contained in other packages in the MRTK ecosystem.",
   "displayName": "MRTK Core Definitions",
   "msftFeatureCategory": "MRTK3",

--- a/org.mixedrealitytoolkit.input/CHANGELOG.md
+++ b/org.mixedrealitytoolkit.input/CHANGELOG.md
@@ -6,28 +6,55 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
-* MRTK3 controllerless prefabs.
-* Added ObsoleteHandInteractionExamples scene that still uses deprecated MRTK3 rig.
-* Added XRI3+ exclusive unity-tests.
-* Added new TrackedPoseDriver lookup.
+* SpatialMouseInputTestsForControllerlessRig Unity-tests.
+* BasicInputTestsForControllerlessRig Unity-tests.
+* MRTKRayInteractorVisualsTestsForControllerlessRig Unity-tests.
+* InteractionModeManagerTestsForControllerlessRig Unity-tests.
+* FuzzyGazeInteractorTestsForControllerlessRig Unity-tests.
+* TrackedPoseDriverLookup as the XRI3+ equivalent of ControllerLookup.
+* TrackedPoseDriverWithFallback as the XRI3+ equivalent of ActionBasedControllerWithFallbacks.
+* Controllerless version of MRTK XR Rig prefab.
+* Controllerless version of MRTK LeftHand Controller prefab.
+* Controllerless version of MRTK RightHand Controller prefab.
+* Controllerless version of MRTK Gaze Controller prefab.
+* Controllerless version of MRTK Interaction Manager prefab.
 
 ### Changed
 
 * Updated package com.unity.xr.interaction.toolkit to 3.0.3
-* Updated Unity Editor to 2022.3.7f1
-* Updated all scenes to consume new MRTK3 controllerless prefabs.
-* Updated existing unity-tests.
-* Updated code to support new XRI3 patterns.
+* Updated BaseRuntimeInputTests logic to handle both deprecated XRController and new controllerless actions.
+* Updated GazePinchInteractor logic to handle both deprecated XRController and new controllerless actions.
+* Updated PokeInteractor logic to handle both deprecated XRController and new controllerless actions.
+* Updated MRTKRayInteractor logic to handle both deprecated XRController and new controllerless actions.
+* Updated FlatScreenModeDetector logic to handle both deprecated XRController and new controllerless actions.
+* Renamed MRTK XR Rig prefab as Obsolete MRTK XR Rig.
+* Renamed MRTK LeftHand Controller prefab as Obsolete MRTK LeftHand Controller.
+* Renamed MRTK RightHand Controller prefab as Obsolete MRTK RightHand Controller.
+* Renamed MRTK Gaze Controller prefab as Obsolete MRTK Gaze Controller.
+* Renamed MRTK Interaction Manager prefab as Obsolete MRTK Interaction Manager.
 
 ### Deprecated
 
-* MRTK3 controller-based prefabs marked as obsolete and deprecated.
-* Controller lookup deprecated.
+* ActionBasedControllerWithFallbacks marked as Obsolete.
+* ArticulatedHandController marked as Obsolete.
 
 ### Removed
 
-* Removed obsolete methods.
-* Removed legacy dialog*.
+* Removed obsolete ArticulatedHandController.HandsAggregatorSubsystem field.
+* Removed obsolete MRTKRayInteractor.HandsAggregatorSubsystem field.
+* Removed obsolete ControllerSimulationSettings.InputActionReference field.
+* Removed obsolete SyntheticsHandsSubsystem::GetNeutralPose method.
+* Removed obsolete SyntheticsHandsSubsystem::SetNeutralPose method.
+* Removed obsolete SyntheticsHandsSubsystem::GetSelectionPose method.
+* Removed obsolete SyntheticsHandsSubsystem::SetSelectionPose method.
+* Removed obsolete SyntheticsHandsSubsystem::GetNeutralPose method.
+* Removed obsolete SyntheticsHandsSubsystem::SetNeutralPose method.
+* Removed obsolete FollowJoint.migratedSuccessfully field.
+* Removed obsolete FollowJoint.hand field.
+* Removed obsolete FollowJoint.Joint field.
+* Removed obsolete FollowJoint::OnAfterDeserialize method.
+* Removed obsolete HandBasedPoseSource.HandsAggregator field.
+* Removed obsolete ControllerVisualizer.HandsAggregator field.
 
 ## [3.2.1] - 2024-4-23
 

--- a/org.mixedrealitytoolkit.input/CHANGELOG.md
+++ b/org.mixedrealitytoolkit.input/CHANGELOG.md
@@ -2,11 +2,32 @@
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
-## [4.0.0-development] - 2024-05-08
+## [4.0.0-development.pre.1] - 2024-06-18
+
+### Added
+
+* MRTK3 controllerless prefabs.
+* Added ObsoleteHandInteractionExamples scene that still uses deprecated MRTK3 rig.
+* Added XRI3+ exclusive unity-tests.
+* Added new TrackedPoseDriver lookup.
 
 ### Changed
 
-* Updated package com.unity.xr.interaction.toolkit to 3.0.1
+* Updated package com.unity.xr.interaction.toolkit to 3.0.3
+* Updated Unity Editor to 2022.3.7f1
+* Updated all scenes to consume new MRTK3 controllerless prefabs.
+* Updated existing unity-tests.
+* Updated code to support new XRI3 patterns.
+
+### Deprecated
+
+* MRTK3 controller-based prefabs marked as obsolete and deprecated.
+* Controller lookup deprecated.
+
+### Removed
+
+* Removed obsolete methods.
+* Removed legacy dialog*.
 
 ## [3.2.1] - 2024-4-23
 

--- a/org.mixedrealitytoolkit.input/package.json
+++ b/org.mixedrealitytoolkit.input/package.json
@@ -1,6 +1,6 @@
 {
   "name": "org.mixedrealitytoolkit.input",
-  "version": "4.0.0-development",
+  "version": "4.0.0-development.pre.1",
   "description": "This package extends the XR Interaction Toolkit with custom interactors and controllers, hand-joint aggregation, and simulation subsystems. It seamlessly integrates with the Unity Input System.",
   "displayName": "MRTK Input",
   "msftFeatureCategory": "MRTK3",

--- a/org.mixedrealitytoolkit.input/package.json
+++ b/org.mixedrealitytoolkit.input/package.json
@@ -22,7 +22,7 @@
     "com.unity.xr.arfoundation": "5.0.5",
     "com.unity.xr.core-utils": "2.1.0",
     "com.unity.xr.hands": "1.3.0",
-    "com.unity.xr.interaction.toolkit": "3.0.1",
+    "com.unity.xr.interaction.toolkit": "3.0.3",
     "org.mixedrealitytoolkit.core": "4.0.0"
   }
 }

--- a/org.mixedrealitytoolkit.spatialmanipulation/CHANGELOG.md
+++ b/org.mixedrealitytoolkit.spatialmanipulation/CHANGELOG.md
@@ -6,28 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
-* MRTK3 controllerless prefabs.
-* Added ObsoleteHandInteractionExamples scene that still uses deprecated MRTK3 rig.
-* Added XRI3+ exclusive unity-tests.
-* Added new TrackedPoseDriver lookup.
+* SolverTapToPlaceTestsForControllerlessRig Unity-tests.
+* Updated TapToPlace logic to handle both deprecated XRController and new controllerless actions.
+* Updated HandConstraintPalmUp logic to handle both deprecated XRController and new controllerless actions.
+* Updated Solver logic to handle both deprecated XRController and new controllerless actions.
 
 ### Changed
 
 * Updated package com.unity.xr.interaction.toolkit to 3.0.3
-* Updated Unity Editor to 2022.3.7f1
-* Updated all scenes to consume new MRTK3 controllerless prefabs.
-* Updated existing unity-tests.
-* Updated code to support new XRI3 patterns.
-
-### Deprecated
-
-* MRTK3 controller-based prefabs marked as obsolete and deprecated.
-* Controller lookup deprecated.
-
-### Removed
-
-* Removed obsolete methods.
-* Removed legacy dialog*.
 
 ## [3.3.0] - 2024-04-30
 

--- a/org.mixedrealitytoolkit.spatialmanipulation/CHANGELOG.md
+++ b/org.mixedrealitytoolkit.spatialmanipulation/CHANGELOG.md
@@ -2,11 +2,32 @@
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
-## [4.0.0-development] - 2024-05-08
+## [4.0.0-development.pre.1] - 2024-06-18
+
+### Added
+
+* MRTK3 controllerless prefabs.
+* Added ObsoleteHandInteractionExamples scene that still uses deprecated MRTK3 rig.
+* Added XRI3+ exclusive unity-tests.
+* Added new TrackedPoseDriver lookup.
 
 ### Changed
 
-* Updated package com.unity.xr.interaction.toolkit to 3.0.1
+* Updated package com.unity.xr.interaction.toolkit to 3.0.3
+* Updated Unity Editor to 2022.3.7f1
+* Updated all scenes to consume new MRTK3 controllerless prefabs.
+* Updated existing unity-tests.
+* Updated code to support new XRI3 patterns.
+
+### Deprecated
+
+* MRTK3 controller-based prefabs marked as obsolete and deprecated.
+* Controller lookup deprecated.
+
+### Removed
+
+* Removed obsolete methods.
+* Removed legacy dialog*.
 
 ## [3.3.0] - 2024-04-30
 

--- a/org.mixedrealitytoolkit.spatialmanipulation/package.json
+++ b/org.mixedrealitytoolkit.spatialmanipulation/package.json
@@ -20,7 +20,7 @@
     "org.mixedrealitytoolkit.core": "4.0.0",
     "org.mixedrealitytoolkit.uxcore": "4.0.0",
     "com.unity.inputsystem": "1.6.1",
-    "com.unity.xr.interaction.toolkit": "3.0.1"
+    "com.unity.xr.interaction.toolkit": "3.0.3"
   },
   "msftOptionalPackages": {
     "org.mixedrealitytoolkit.input": "4.0.0"

--- a/org.mixedrealitytoolkit.spatialmanipulation/package.json
+++ b/org.mixedrealitytoolkit.spatialmanipulation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "org.mixedrealitytoolkit.spatialmanipulation",
-  "version": "4.0.0-development",
+  "version": "4.0.0-development.pre.1",
   "description": "Spatial manipulation features, including ObjectManipulator, BoundsControl, and the Solvers/Constraints systems.",
   "displayName": "MRTK Spatial Manipulation",
   "msftFeatureCategory": "MRTK3",

--- a/org.mixedrealitytoolkit.uxcomponents.noncanvas/CHANGELOG.md
+++ b/org.mixedrealitytoolkit.uxcomponents.noncanvas/CHANGELOG.md
@@ -4,30 +4,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [4.0.0-development.pre.1] - 2024-06-18
 
-### Added
-
-* MRTK3 controllerless prefabs.
-* Added ObsoleteHandInteractionExamples scene that still uses deprecated MRTK3 rig.
-* Added XRI3+ exclusive unity-tests.
-* Added new TrackedPoseDriver lookup.
-
 ### Changed
 
 * Updated package com.unity.xr.interaction.toolkit to 3.0.3
-* Updated Unity Editor to 2022.3.7f1
-* Updated all scenes to consume new MRTK3 controllerless prefabs.
-* Updated existing unity-tests.
-* Updated code to support new XRI3 patterns.
-
-### Deprecated
-
-* MRTK3 controller-based prefabs marked as obsolete and deprecated.
-* Controller lookup deprecated.
-
-### Removed
-
-* Removed obsolete methods.
-* Removed legacy dialog*.
 
 ## [3.1.3] - 2024-04-17
 

--- a/org.mixedrealitytoolkit.uxcomponents.noncanvas/CHANGELOG.md
+++ b/org.mixedrealitytoolkit.uxcomponents.noncanvas/CHANGELOG.md
@@ -2,11 +2,32 @@
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
-## [4.0.0-development] - 2024-04-18
+## [4.0.0-development.pre.1] - 2024-06-18
+
+### Added
+
+* MRTK3 controllerless prefabs.
+* Added ObsoleteHandInteractionExamples scene that still uses deprecated MRTK3 rig.
+* Added XRI3+ exclusive unity-tests.
+* Added new TrackedPoseDriver lookup.
 
 ### Changed
 
-* Updated package com.unity.xr.interaction.toolkit to 3.0.1
+* Updated package com.unity.xr.interaction.toolkit to 3.0.3
+* Updated Unity Editor to 2022.3.7f1
+* Updated all scenes to consume new MRTK3 controllerless prefabs.
+* Updated existing unity-tests.
+* Updated code to support new XRI3 patterns.
+
+### Deprecated
+
+* MRTK3 controller-based prefabs marked as obsolete and deprecated.
+* Controller lookup deprecated.
+
+### Removed
+
+* Removed obsolete methods.
+* Removed legacy dialog*.
 
 ## [3.1.3] - 2024-04-17
 

--- a/org.mixedrealitytoolkit.uxcomponents.noncanvas/package.json
+++ b/org.mixedrealitytoolkit.uxcomponents.noncanvas/package.json
@@ -1,6 +1,6 @@
 {
   "name": "org.mixedrealitytoolkit.uxcomponents.noncanvas",
-  "version": "4.0.0-development",
+  "version": "4.0.0-development.pre.1",
   "description": "UX component library for 3D UX without Canvas layout. In some cases, non-Canvas UI may offer better performance.",
   "displayName": "MRTK UX Components (Non-Canvas)",
   "msftFeatureCategory": "MRTK3",

--- a/org.mixedrealitytoolkit.uxcomponents/CHANGELOG.md
+++ b/org.mixedrealitytoolkit.uxcomponents/CHANGELOG.md
@@ -4,30 +4,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [4.0.0-development.pre.1] - 2024-06-18
 
-### Added
-
-* MRTK3 controllerless prefabs.
-* Added ObsoleteHandInteractionExamples scene that still uses deprecated MRTK3 rig.
-* Added XRI3+ exclusive unity-tests.
-* Added new TrackedPoseDriver lookup.
-
 ### Changed
 
 * Updated package com.unity.xr.interaction.toolkit to 3.0.3
-* Updated Unity Editor to 2022.3.7f1
-* Updated all scenes to consume new MRTK3 controllerless prefabs.
-* Updated existing unity-tests.
-* Updated code to support new XRI3 patterns.
-
-### Deprecated
-
-* MRTK3 controller-based prefabs marked as obsolete and deprecated.
-* Controller lookup deprecated.
-
-### Removed
-
-* Removed obsolete methods.
-* Removed legacy dialog*.
 
 ## [3.3.0] - 2024-04-26
 

--- a/org.mixedrealitytoolkit.uxcomponents/CHANGELOG.md
+++ b/org.mixedrealitytoolkit.uxcomponents/CHANGELOG.md
@@ -2,11 +2,32 @@
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
-## [4.0.0-development] - 2024-05-08
+## [4.0.0-development.pre.1] - 2024-06-18
+
+### Added
+
+* MRTK3 controllerless prefabs.
+* Added ObsoleteHandInteractionExamples scene that still uses deprecated MRTK3 rig.
+* Added XRI3+ exclusive unity-tests.
+* Added new TrackedPoseDriver lookup.
 
 ### Changed
 
-* Updated package com.unity.xr.interaction.toolkit to 3.0.1
+* Updated package com.unity.xr.interaction.toolkit to 3.0.3
+* Updated Unity Editor to 2022.3.7f1
+* Updated all scenes to consume new MRTK3 controllerless prefabs.
+* Updated existing unity-tests.
+* Updated code to support new XRI3 patterns.
+
+### Deprecated
+
+* MRTK3 controller-based prefabs marked as obsolete and deprecated.
+* Controller lookup deprecated.
+
+### Removed
+
+* Removed obsolete methods.
+* Removed legacy dialog*.
 
 ## [3.3.0] - 2024-04-26
 

--- a/org.mixedrealitytoolkit.uxcomponents/package.json
+++ b/org.mixedrealitytoolkit.uxcomponents/package.json
@@ -21,7 +21,7 @@
     "org.mixedrealitytoolkit.uxcore": "4.0.0",
     "org.mixedrealitytoolkit.spatialmanipulation": "4.0.0",
     "org.mixedrealitytoolkit.standardassets": "3.1.0",
-    "com.unity.xr.interaction.toolkit": "3.0.1"
+    "com.unity.xr.interaction.toolkit": "3.0.3"
   },
   "msftTestDependencies": {
     "org.mixedrealitytoolkit.input": "4.0.0",

--- a/org.mixedrealitytoolkit.uxcomponents/package.json
+++ b/org.mixedrealitytoolkit.uxcomponents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "org.mixedrealitytoolkit.uxcomponents",
-  "version": "4.0.0-development",
+  "version": "4.0.0-development.pre.1",
   "description": "UX library leveraging RectTransform and Canvas for dynamic layout and presentation. Contains prefabs, visuals, controls, and everything to get started building 3D user interfaces for mixed reality.",
   "displayName": "MRTK UX Components",
   "msftFeatureCategory": "MRTK3",

--- a/org.mixedrealitytoolkit.uxcore/CHANGELOG.md
+++ b/org.mixedrealitytoolkit.uxcore/CHANGELOG.md
@@ -2,11 +2,32 @@
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
-## [4.0.0-development] - 2024-05-08
+## [4.0.0-development.pre.1] - 2024-06-18
+
+### Added
+
+* MRTK3 controllerless prefabs.
+* Added ObsoleteHandInteractionExamples scene that still uses deprecated MRTK3 rig.
+* Added XRI3+ exclusive unity-tests.
+* Added new TrackedPoseDriver lookup.
 
 ### Changed
 
-* Updated package com.unity.xr.interaction.toolkit to 3.0.1
+* Updated package com.unity.xr.interaction.toolkit to 3.0.3
+* Updated Unity Editor to 2022.3.7f1
+* Updated all scenes to consume new MRTK3 controllerless prefabs.
+* Updated existing unity-tests.
+* Updated code to support new XRI3 patterns.
+
+### Deprecated
+
+* MRTK3 controller-based prefabs marked as obsolete and deprecated.
+* Controller lookup deprecated.
+
+### Removed
+
+* Removed obsolete methods.
+* Removed legacy dialog*.
 
 ## [3.2.1] - 2024-04-23
 

--- a/org.mixedrealitytoolkit.uxcore/CHANGELOG.md
+++ b/org.mixedrealitytoolkit.uxcore/CHANGELOG.md
@@ -4,30 +4,22 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [4.0.0-development.pre.1] - 2024-06-18
 
-### Added
-
-* MRTK3 controllerless prefabs.
-* Added ObsoleteHandInteractionExamples scene that still uses deprecated MRTK3 rig.
-* Added XRI3+ exclusive unity-tests.
-* Added new TrackedPoseDriver lookup.
-
 ### Changed
 
 * Updated package com.unity.xr.interaction.toolkit to 3.0.3
-* Updated Unity Editor to 2022.3.7f1
-* Updated all scenes to consume new MRTK3 controllerless prefabs.
-* Updated existing unity-tests.
-* Updated code to support new XRI3 patterns.
-
-### Deprecated
-
-* MRTK3 controller-based prefabs marked as obsolete and deprecated.
-* Controller lookup deprecated.
 
 ### Removed
 
-* Removed obsolete methods.
-* Removed legacy dialog*.
+* Removed LegacyDialog/Dialog files.
+* Removed LegacyDialog/DialogButton files.
+* Removed LegacyDialog/DialogButtonContext files.
+* Removed LegacyDialog/DialogButtonHelpers files.
+* Removed LegacyDialog/DialogButtonTypes files.
+* Removed LegacyDialog/DialogProperty files.
+* Removed LegacyDialog/DialogShell files.
+* Removed LegacyDialog/DialogState files.
+* Removed LegacyDialog/README files.
+* Removed obsolete Slider.SliderValue fields.
 
 ## [3.2.1] - 2024-04-23
 

--- a/org.mixedrealitytoolkit.uxcore/package.json
+++ b/org.mixedrealitytoolkit.uxcore/package.json
@@ -1,6 +1,6 @@
 {
   "name": "org.mixedrealitytoolkit.uxcore",
-  "version": "4.0.0-development",
+  "version": "4.0.0-development.pre.1",
   "description": "Core interaction and visualization scripts for building MR UI components. Intended to be consumed when building UX libraries. For pre-existing library of components see the UX Components package.",
   "displayName": "MRTK UX Core Scripts",
   "msftFeatureCategory": "MRTK3",

--- a/org.mixedrealitytoolkit.uxcore/package.json
+++ b/org.mixedrealitytoolkit.uxcore/package.json
@@ -21,7 +21,7 @@
     "org.mixedrealitytoolkit.core": "4.0.0",
     "com.unity.inputsystem": "1.6.1",
     "com.unity.textmeshpro": "3.0.6",
-    "com.unity.xr.interaction.toolkit": "3.0.1"
+    "com.unity.xr.interaction.toolkit": "3.0.3"
   },
   "msftOptionalPackages": {
     "org.mixedrealitytoolkit.data": "1.0.0-development",


### PR DESCRIPTION
* Updating modified packages to 4.0.0-development.pre.1 version
* Updating changelogs
* Bumping com.unity.xr.interaction.toolkit version 3.0.3

Additional manual testing:
* Quick test of all MRTK3 scenes with a sideloaded build on HL2:
  * No core functionality impairment detected.
  * No broken assets detected.