### PR TITLE
Fix for InputSimulator not executing before InteractionManager (#794)

### DIFF
--- a/org.mixedrealitytoolkit.input/CHANGELOG.md
+++ b/org.mixedrealitytoolkit.input/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 * Add logic to account for a bound but untracked interaction profile. [PR #704](https://github.com/MixedRealityToolkit/MixedRealityToolkit-Unity/pull/704)
 * Reduced package description to support for UPM package publishing in the Unity Asset Store.
 * Ensures the simulated input sources hold their state (including gestures) when their toggle state is locked on. [PR #705](https://github.com/MixedRealityToolkit/MixedRealityToolkit-Unity/pull/705)
+* InputSimulator execution order so that it executes before InteractionManager.
 
 ## [3.2.0] - 2024-03-20
 

--- a/org.mixedrealitytoolkit.input/Simulation/InputSimulator.cs
+++ b/org.mixedrealitytoolkit.input/Simulation/InputSimulator.cs
@@ -6,6 +6,7 @@ using UnityEngine;
 using UnityEngine.InputSystem;
 using UnityEngine.InputSystem.LowLevel;
 using UnityEngine.XR;
+using UnityEngine.XR.Interaction.Toolkit;
 using UnityEngine.XR.Interaction.Toolkit.Inputs;
 
 namespace MixedReality.Toolkit.Input.Simulation
@@ -14,6 +15,7 @@ namespace MixedReality.Toolkit.Input.Simulation
     /// Input device and HMD navigation simulator.
     /// </summary>
     [AddComponentMenu("MRTK/Input/Input Simulator")]
+    [DefaultExecutionOrder(XRInteractionUpdateOrder.k_DeviceSimulator)]
     public class InputSimulator : MonoBehaviour
     {
         #region MonoBehaviour


### PR DESCRIPTION
* Fix for InputSimulator not executing before InteractionManager
* Updated changelog.md accordingly