### PR TITLE
Removing the need for `TDPwithFallbackTrackingStates` and defining HAS_SET_LOCAL_POSITION_AND_ROTATION 

### DIFF
--- a/org.mixedrealitytoolkit.input/MRTK.Input.asmdef
+++ b/org.mixedrealitytoolkit.input/MRTK.Input.asmdef
@@ -43,6 +43,21 @@
             "name": "com.unity.xr.management",
             "expression": "4.2",
             "define": "UNITYXR_MANAGEMENT_PRESENT"
+        },
+        {
+            "name": "Unity",
+            "expression": "[2021.3.11,2022.1)",
+            "define": "HAS_SET_LOCAL_POSITION_AND_ROTATION"
+        },
+        {
+            "name": "Unity",
+            "expression": "[2022.1.19,2022.2)",
+            "define": "HAS_SET_LOCAL_POSITION_AND_ROTATION"
+        },
+        {
+            "name": "Unity",
+            "expression": "2022.2",
+            "define": "HAS_SET_LOCAL_POSITION_AND_ROTATION"
         }
     ],
     "noEngineReferences": false

--- a/org.mixedrealitytoolkit.input/Tracking/TrackedPoseDriverWithFallback.cs
+++ b/org.mixedrealitytoolkit.input/Tracking/TrackedPoseDriverWithFallback.cs
@@ -23,30 +23,6 @@ namespace MixedReality.Toolkit.Input
     [AddComponentMenu("MRTK/Input/Tracked Pose Driver (with Fallbacks)")]
     public class TrackedPoseDriverWithFallback : TrackedPoseDriver
     {
-        /// <summary>
-        /// These are the same flags as TrackingState in <seealso cref="TrackedPoseDriver"/> they are repeated here because enum
-        /// TrackingStates is not public in TrackedPoseDriver class (as of Unity.InputSystem 1.8.1.0).
-        /// </summary>
-        [Flags]
-        private enum TDPwithFallbackTrackingStates
-        {
-            /// <summary>
-            /// Position and rotation are not valid.
-            /// </summary>
-            None,
-
-            /// <summary>
-            /// Position is valid.
-            /// See <c>InputTrackingState.Position</c>.
-            /// </summary>
-            Position = 1 << 0,
-
-            /// <summary>
-            /// Rotation is valid.
-            /// See <c>InputTrackingState.Rotation</c>.
-            /// </summary>
-            Rotation = 1 << 1,
-        }
 
         #region Fallback actions values
 
@@ -126,17 +102,17 @@ namespace MixedReality.Toolkit.Input
 
             if (neededToGetFallbackData) //because either position, rotation, or both data were obtained from fallback actions
             {
-                SetLocalTransformFromFallback(position, rotation, (TDPwithFallbackTrackingStates)fallbackInputTrackingState);
+                SetLocalTransformFromFallback(position, rotation, (InputTrackingState)fallbackInputTrackingState);
             }
         }
 
-        private void SetLocalTransformFromFallback(Vector3 newPosition, Quaternion newRotation, TDPwithFallbackTrackingStates currentFallbackTrackingState)
+        private void SetLocalTransformFromFallback(Vector3 newPosition, Quaternion newRotation, InputTrackingState currentFallbackTrackingState)
         {
-            var positionValid = ignoreTrackingState || (currentFallbackTrackingState & TDPwithFallbackTrackingStates.Position) != 0;
-            var rotationValid = ignoreTrackingState || (currentFallbackTrackingState & TDPwithFallbackTrackingStates.Rotation) != 0;
+            var positionValid = ignoreTrackingState || (currentFallbackTrackingState & InputTrackingState.Position) != 0;
+            var rotationValid = ignoreTrackingState || (currentFallbackTrackingState & InputTrackingState.Rotation) != 0;
 
 #if HAS_SET_LOCAL_POSITION_AND_ROTATION
-            if (this.TrackingType == TrackingType.RotationAndPosition && rotationValid && positionValid)
+            if (trackingType == TrackingType.RotationAndPosition && rotationValid && positionValid)
             {
                 transform.SetLocalPositionAndRotation(newPosition, newRotation);
                 return;


### PR DESCRIPTION
# Overview

Refining the `TrackedPoseDriverWithFallback` implementation.

- Removing the need for `TDPwithFallbackTrackingStates`, we can just use `InputTrackingState`.
- Updating Input.asmdef to correctly define HAS_SET_LOCAL_POSITION_AND_ROTATION