### PR TITLE
[XRI3] Adding tracked pose driver extensions

### DIFF
--- a/org.mixedrealitytoolkit.input/Tracking/HandPoseDriver.cs
+++ b/org.mixedrealitytoolkit.input/Tracking/HandPoseDriver.cs
@@ -34,6 +34,14 @@ namespace MixedReality.Toolkit.Input
         private InputAction m_boundTrackingAction = null;
         private InputTrackingState m_trackingState = InputTrackingState.None;
 
+        /// <summary>
+        /// Expose the tracking state for the hand pose driver, to allow <see cref="TrackedPoseDriverExtensions"/> to query it.
+        /// </summary>
+        /// <remarks
+        /// Avoid exposing this publicly as this <see cref="HandPoseDriver"/> is a workaround solution to support hand tracking on devices without interaction profiles.
+        /// </remarks>
+        internal InputTrackingState CachedTrackingState => m_trackingState;
+
         #region Serialized Fields
         [Header("Hand Pose Driver Settings")]
 
@@ -193,31 +201,7 @@ namespace MixedReality.Toolkit.Input
             // `TrackedPoseDriver` also sets the tracking state in a similar manner. Please see 
             // `TrackedPoseDriver::ReadTrackingState`. Replicating this logic in a subclass is not ideal, but it is
             // necessary since the base class does not expose the tracking state logic.
-
-            var trackingStateAction = trackingStateInput.action;
-            if (trackingStateAction == null || trackingStateAction.bindings.Count == 0)
-            {
-                // Treat an Input Action Reference with no reference the same as
-                // an enabled Input Action with no authored bindings, and allow driving the Transform pose.
-                m_trackingState = InputTrackingState.Position | InputTrackingState.Rotation;
-                return;
-            }
-
-            if (trackingStateAction.enabled)
-            {
-                // Treat a disabled action as the default None value for the ReadValue call
-                m_trackingState = InputTrackingState.None;
-                return;
-            }
-
-            if (trackingStateAction.HasAnyControls())
-            {
-                m_trackingState = (InputTrackingState)trackingStateAction.ReadValue<int>();
-            }
-            else
-            {
-                m_trackingState = InputTrackingState.None;
-            }
+            m_trackingState = this.GetInputTrackingStateNoCache();
         }
 
         /// <summary>

--- a/org.mixedrealitytoolkit.input/Tracking/TrackedPoseDriverExtensions.cs
+++ b/org.mixedrealitytoolkit.input/Tracking/TrackedPoseDriverExtensions.cs
@@ -46,7 +46,7 @@ namespace MixedReality.Toolkit.Input
         /// </remarks>
         public static InputTrackingState GetInputTrackingState(this TrackedPoseDriver driver)
         {
-            // If the driver is a HandPoseDriver, return the cached value, istead of hitting the overhead of querying the action.
+            // If the driver is a HandPoseDriver, return the cached value, instead of hitting the overhead of querying the action.
             if (driver is HandPoseDriver handPoseDriver)
             {
                 return handPoseDriver.CachedTrackingState;

--- a/org.mixedrealitytoolkit.input/Tracking/TrackedPoseDriverExtensions.cs
+++ b/org.mixedrealitytoolkit.input/Tracking/TrackedPoseDriverExtensions.cs
@@ -61,7 +61,7 @@ namespace MixedReality.Toolkit.Input
         /// </summary>
         /// <remarks>
         /// If the <see cref="TrackedPoseDriver"/> has no tracking state action or the action has no bindings, it will return `<see cref="InputTrackingState.Position"/> |
-        /// <see cref="InputTrackingState.Rotation"/>`. If the action is enabled, it will return `<see cref="InputTrackingState.None"/>`. If the action has controls, it will return the value of the action.
+        /// <see cref="InputTrackingState.Rotation"/>`. If the action is disabled, it will return `<see cref="InputTrackingState.None"/>`. If the action has controls, it will return the value of the action.
         /// </remarks>
         internal static InputTrackingState GetInputTrackingStateNoCache(this TrackedPoseDriver driver)
         {

--- a/org.mixedrealitytoolkit.input/Tracking/TrackedPoseDriverExtensions.cs
+++ b/org.mixedrealitytoolkit.input/Tracking/TrackedPoseDriverExtensions.cs
@@ -68,7 +68,7 @@ namespace MixedReality.Toolkit.Input
             // Note, that the logic in this class is meant to reproduce the same logic as the base. The base
             // `TrackedPoseDriver` also sets the tracking state in a similar manner. Please see 
             // `TrackedPoseDriver::ReadTrackingState`. Replicating this logic in a subclass is not ideal, but it is
-            // necessary since the base class does not expose the tracking static update logic.
+            // necessary since the base class does not expose its tracking status field.
 
             var trackingStateAction = driver.trackingStateInput.action;
             if (trackingStateAction == null || trackingStateAction.bindings.Count == 0)

--- a/org.mixedrealitytoolkit.input/Tracking/TrackedPoseDriverExtensions.cs
+++ b/org.mixedrealitytoolkit.input/Tracking/TrackedPoseDriverExtensions.cs
@@ -42,7 +42,7 @@ namespace MixedReality.Toolkit.Input
         /// </summary>
         /// <remarks>
         /// If the <see cref="TrackedPoseDriver"/> has no tracking state action or the action has no bindings, it will return `<see cref="InputTrackingState.Position"/> |
-        /// <see cref="InputTrackingState.Rotation"/>`. If the action is enabled, it will return `<see cref="InputTrackingState.None"/>`. If the action has controls, it will return the value of the action.
+        /// <see cref="InputTrackingState.Rotation"/>`. If the action is disabled, it will return `<see cref="InputTrackingState.None"/>`. If the action has controls, it will return the value of the action.
         /// </remarks>
         public static InputTrackingState GetInputTrackingState(this TrackedPoseDriver driver)
         {

--- a/org.mixedrealitytoolkit.input/Tracking/TrackedPoseDriverExtensions.cs
+++ b/org.mixedrealitytoolkit.input/Tracking/TrackedPoseDriverExtensions.cs
@@ -1,0 +1,97 @@
+// Copyright (c) Mixed Reality Toolkit Contributors
+// Licensed under the BSD 3-Clause
+
+using UnityEngine.InputSystem.XR;
+using UnityEngine.XR;
+
+namespace MixedReality.Toolkit.Input
+{
+    /// <summary>
+    /// Extensions for Unity's <see cref="TrackedPoseDriver"/>
+    /// </summary>
+    public static class TrackedPoseDriverExtensions
+    {
+        /// <summary>
+        /// Gets the tracking state of the <see cref="TrackedPoseDriver"/>. If the tracking state is not available, returns false.
+        /// </summary>
+        public static bool TryGetTrackingState(this TrackedPoseDriver driver, out InputTrackingState state)
+        {
+            state = InputTrackingState.None;
+            var trackingStateAction = driver.trackingStateInput.action;
+            if (trackingStateAction == null || trackingStateAction.bindings.Count == 0)
+            {
+                return false;
+            }
+
+            if (trackingStateAction.enabled)
+            {
+                return false;
+            }
+
+            if (!trackingStateAction.HasAnyControls())
+            {
+                return false;
+            }
+
+            state = (InputTrackingState)trackingStateAction.ReadValue<int>();
+            return true;
+        }
+
+        /// <summary>
+        /// Gets the tracking state of the <see cref="TrackedPoseDriver"/>.
+        /// </summary>
+        /// <remarks>
+        /// If the <see cref="TrackedPoseDriver"/> has no tracking state action or the action has no bindings, it will return `<see cref="InputTrackingState.Position"/> |
+        /// <see cref="InputTrackingState.Rotation"/>`. If the action is enabled, it will return `<see cref="InputTrackingState.None"/>`. If the action has controls, it will return the value of the action.
+        /// </remarks>
+        public static InputTrackingState GetInputTrackingState(this TrackedPoseDriver driver)
+        {
+            // If the driver is a HandPoseDriver, return the cached value, istead of hitting the overhead of querying the action.
+            if (driver is HandPoseDriver handPoseDriver)
+            {
+                return handPoseDriver.CachedTrackingState;
+            }
+
+            return GetInputTrackingStateNoCache(driver);
+        }
+
+
+        /// <summary>
+        /// Gets the tracking state of the <see cref="TrackedPoseDriver"/>, avoid reading value for internal caches.
+        /// </summary>
+        /// <remarks>
+        /// If the <see cref="TrackedPoseDriver"/> has no tracking state action or the action has no bindings, it will return `<see cref="InputTrackingState.Position"/> |
+        /// <see cref="InputTrackingState.Rotation"/>`. If the action is enabled, it will return `<see cref="InputTrackingState.None"/>`. If the action has controls, it will return the value of the action.
+        /// </remarks>
+        internal static InputTrackingState GetInputTrackingStateNoCache(this TrackedPoseDriver driver)
+        {
+            // Note, that the logic in this class is meant to reproduce the same logic as the base. The base
+            // `TrackedPoseDriver` also sets the tracking state in a similar manner. Please see 
+            // `TrackedPoseDriver::ReadTrackingState`. Replicating this logic in a subclass is not ideal, but it is
+            // necessary since the base class does not expose the tracking static update logic.
+
+            var trackingStateAction = driver.trackingStateInput.action;
+            if (trackingStateAction == null || trackingStateAction.bindings.Count == 0)
+            {
+                // Treat an Input Action Reference with no reference the same as
+                // an enabled Input Action with no authored bindings, and allow driving the Transform pose.
+                return InputTrackingState.Position | InputTrackingState.Rotation;
+            }
+
+            if (!trackingStateAction.enabled)
+            {
+                // Treat a disabled action as the default None value for the ReadValue call
+                return InputTrackingState.None;
+            }
+
+            if (trackingStateAction.HasAnyControls())
+            {
+                return (InputTrackingState)trackingStateAction.ReadValue<int>();
+            }
+            else
+            {
+                return InputTrackingState.None;
+            }
+        }
+    }
+}

--- a/org.mixedrealitytoolkit.input/Tracking/TrackedPoseDriverExtensions.cs
+++ b/org.mixedrealitytoolkit.input/Tracking/TrackedPoseDriverExtensions.cs
@@ -23,7 +23,7 @@ namespace MixedReality.Toolkit.Input
                 return false;
             }
 
-            if (trackingStateAction.enabled)
+            if (!trackingStateAction.enabled)
             {
                 return false;
             }

--- a/org.mixedrealitytoolkit.input/Tracking/TrackedPoseDriverExtensions.cs.meta
+++ b/org.mixedrealitytoolkit.input/Tracking/TrackedPoseDriverExtensions.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 620ff90d95f38224ab928a98ba946918
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
# Overview

Adding tracked pose driver extensions. These will help improve "tracking status" queries across interactors.  It also exposes a way for callers to obtain the "cached tracking status" on the HandPoseDriver.