### PR TITLE
[XRI3] Updating IModeManagedInteractor to use something other than controllers

### DIFF
--- a/org.mixedrealitytoolkit.core/Interactors/IModeManagedInteractor.cs
+++ b/org.mixedrealitytoolkit.core/Interactors/IModeManagedInteractor.cs
@@ -1,8 +1,7 @@
 // Copyright (c) Mixed Reality Toolkit Contributors
 // Licensed under the BSD 3-Clause
 
-using System.Collections;
-using System.Collections.Generic;
+using System;
 using UnityEngine;
 
 namespace MixedReality.Toolkit
@@ -17,6 +16,13 @@ namespace MixedReality.Toolkit
         /// Returns the GameObject that this interactor belongs to. This GameObject is governed by the
         /// interaction mode manager and is assigned an interaction mode. This GameObject represents the 'controller' that this interactor belongs to.
         /// </summary>
+        [Obsolete("This function is obsolete and will be removed in the next major release. Use ModeManagedRoot instead.")]
         public GameObject GetModeManagedController();
+
+        /// <summary>
+        /// Returns the root management GameObject that interactor belongs to. This GameObject is governed by the
+        /// interaction mode manager and is assigned an interaction mode. 
+        /// </summary>
+        public GameObject ModeManagedRoot { get; }
     }
 }

--- a/org.mixedrealitytoolkit.input/Interactors/GazePinch/GazePinchInteractor.cs
+++ b/org.mixedrealitytoolkit.input/Interactors/GazePinch/GazePinchInteractor.cs
@@ -21,8 +21,7 @@ namespace MixedReality.Toolkit.Input
     public class GazePinchInteractor :
         XRBaseInputInteractor,
         IGazePinchInteractor,
-        IHandedInteractor,
-        IModeManagedInteractor
+        IHandedInteractor
     {
         #region GazePinchInteractor
 

--- a/org.mixedrealitytoolkit.input/Interactors/GazePinch/GazePinchInteractor.cs
+++ b/org.mixedrealitytoolkit.input/Interactors/GazePinch/GazePinchInteractor.cs
@@ -21,7 +21,8 @@ namespace MixedReality.Toolkit.Input
     public class GazePinchInteractor :
         XRBaseInputInteractor,
         IGazePinchInteractor,
-        IHandedInteractor
+        IHandedInteractor,
+        IModeManagedInteractor
     {
         #region GazePinchInteractor
 
@@ -32,6 +33,23 @@ namespace MixedReality.Toolkit.Input
         /// Holds a reference to the <see cref="TrackedPoseDriver"/> associated to this interactor if it exists.
         /// </summary>
         protected internal TrackedPoseDriver TrackedPoseDriver => trackedPoseDriver;
+
+        [SerializeField]
+        [Tooltip("The root management GameObject that interactor belongs to. T")]
+        private GameObject modeManagedRoot = null;
+
+        /// <summary>
+        /// Returns the GameObject that this interactor belongs to. This GameObject is governed by the
+        /// interaction mode manager and is assigned an interaction mode. This GameObject represents the group that this interactor belongs to.
+        /// </summary>
+        /// <remarks>
+        /// This will default to the GameObject that this attached to a parent <see cref="TrackedPoseDriver"/>.
+        /// </remarks>
+        public GameObject ModeManagedRoot
+        {
+            get => modeManagedRoot;
+            set => modeManagedRoot = value;
+        }
 
         [Header("Gaze Pinch interactor settings")]
 
@@ -165,8 +183,8 @@ namespace MixedReality.Toolkit.Input
                         return false;
                     }
 
-                    //If this interactor has a TrackedPoseDriver then use it to check if this interactor is tracked
-                    return ((InputTrackingState)TrackedPoseDriver.trackingStateInput.action.ReadValue<int>()).HasPositionAndRotation();
+                    // If this interactor has a TrackedPoseDriver then use it to check if this interactor is tracked
+                    return TrackedPoseDriver.GetInputTrackingState().HasPositionAndRotation();
                 }
             }
         }
@@ -233,9 +251,16 @@ namespace MixedReality.Toolkit.Input
         {
             base.Start();
 
-            if (trackedPoseDriver == null) //Try to get the TrackedPoseDriver component from the parent if it hasn't been set yet
+            // Try to get the TrackedPoseDriver component from the parent if it hasn't been set yet
+            if (trackedPoseDriver == null)
             {
                 trackedPoseDriver = GetComponentInParent<TrackedPoseDriver>();
+            }
+
+            // If mode managed root is not defined, default to the tracked pose driver's game object
+            if (modeManagedRoot == null && trackedPoseDriver != null)
+            {
+                modeManagedRoot = trackedPoseDriver.gameObject;
             }
         }
 
@@ -536,6 +561,13 @@ namespace MixedReality.Toolkit.Input
 
         #endregion XRBaseInteractor
 
+        #region IModeManagedInteractor
+        /// <inheritdoc/>
+        [Obsolete("This function is obsolete and will be removed in the next major release. Use ModeManagedRoot instead.")]
+        public GameObject GetModeManagedController() => ModeManagedRoot;
+        #endregion IModeManagedInteractor
+
+        #region Private Methods
         /// <summary>
         /// Updates the pinch state of the GazePinchInteractor.
         /// If handedness is not set then it defaults to right hand.
@@ -569,5 +601,6 @@ namespace MixedReality.Toolkit.Input
                 pinchReady = isPinchReady;
             }
         }
+        #endregion Private Methods
     }
 }

--- a/org.mixedrealitytoolkit.input/Interactors/HandJointInteractor.cs
+++ b/org.mixedrealitytoolkit.input/Interactors/HandJointInteractor.cs
@@ -18,8 +18,7 @@ namespace MixedReality.Toolkit.Input
     /// </summary>
     public abstract class HandJointInteractor :
         XRDirectInteractor,
-        IHandedInteractor,
-        IModeManagedInteractor
+        IHandedInteractor
     {
         #region Serialized Fields
         [SerializeField, Tooltip("Holds a reference to the <see cref=\"TrackedPoseDriver\"/> associated to this interactor if it exists.")]

--- a/org.mixedrealitytoolkit.input/Interactors/Poke/PokeInteractor.cs
+++ b/org.mixedrealitytoolkit.input/Interactors/Poke/PokeInteractor.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Mixed Reality Toolkit Contributors
 // Licensed under the BSD 3-Clause
 
+using System;
 using System.Collections.Generic;
 using Unity.Profiling;
 using UnityEngine;
@@ -20,7 +21,8 @@ namespace MixedReality.Toolkit.Input
     public class PokeInteractor :
         XRBaseInputInteractor,
         IPokeInteractor,
-        IHandedInteractor
+        IHandedInteractor,
+        IModeManagedInteractor
     {
         #region PokeInteractor
 
@@ -31,6 +33,23 @@ namespace MixedReality.Toolkit.Input
         /// Holds a reference to the <see cref="TrackedPoseDriver"/> associated to this interactor if it exists.
         /// </summary>
         protected internal TrackedPoseDriver TrackedPoseDriver => trackedPoseDriver;
+
+        [SerializeField]
+        [Tooltip("The root management GameObject that interactor belongs to. T")]
+        private GameObject modeManagedRoot = null;
+
+        /// <summary>
+        /// Returns the GameObject that this interactor belongs to. This GameObject is governed by the
+        /// interaction mode manager and is assigned an interaction mode. This GameObject represents the group that this interactor belongs to.
+        /// </summary>
+        /// <remarks>
+        /// This will default to the GameObject that this attached to a parent <see cref="TrackedPoseDriver"/>.
+        /// </remarks>
+        public GameObject ModeManagedRoot
+        {
+            get => modeManagedRoot;
+            set => modeManagedRoot = value;
+        }
 
         [SerializeReference]
         [InterfaceSelector(true)]
@@ -133,9 +152,16 @@ namespace MixedReality.Toolkit.Input
         {
             base.Start();
 
-            if (trackedPoseDriver == null) //Try to get the <see cref="TrackedPoseDriver"> component from the parent if it hasn't been set yet
+            // Try to get the <see cref="TrackedPoseDriver"> component from the parent if it hasn't been set yet
+            if (trackedPoseDriver == null) 
             {
                 trackedPoseDriver = GetComponentInParent<TrackedPoseDriver>();
+            }
+
+            // If mode managed root is not defined, default to the tracked pose driver's game object
+            if (modeManagedRoot == null && trackedPoseDriver != null)
+            {
+                modeManagedRoot = trackedPoseDriver.gameObject;
             }
         }
 
@@ -188,13 +214,13 @@ namespace MixedReality.Toolkit.Input
 #pragma warning restore CS0618 // Type or member is obsolete
                 else
                 {
-                    if (TrackedPoseDriver == null) //If the interactor does not have a <see cref="TrackedPoseDriver"> component then we cannot determine if it is hover active
+                    // If the interactor does not have a <see cref="TrackedPoseDriver"> component then we cannot determine if it is hover active
+                    if (TrackedPoseDriver == null) 
                     {
                         return false;
                     }
 
-                    //If this interactor has an associated <see cref="TrackedPoseDriver"> component then use it to determine if the interactor is hover active
-                    return base.isHoverActive && ((InputTrackingState)TrackedPoseDriver.trackingStateInput.action.ReadValue<int>()).HasPositionAndRotation();
+                    return base.isHoverActive && (TrackedPoseDriver.GetInputTrackingState().HasPositionAndRotation() || pokePointTracked);
                 }
             }
         }
@@ -292,5 +318,11 @@ namespace MixedReality.Toolkit.Input
         }
 
         #endregion XRBaseInteractor
+
+        #region IModeManagedInteractor
+        /// <inheritdoc/>
+        [Obsolete("This function is obsolete and will be removed in the next major release. Use ModeManagedRoot instead.")]
+        public GameObject GetModeManagedController() => ModeManagedRoot;
+        #endregion IModeManagedInteractor
     }
 }

--- a/org.mixedrealitytoolkit.input/Interactors/Poke/PokeInteractor.cs
+++ b/org.mixedrealitytoolkit.input/Interactors/Poke/PokeInteractor.cs
@@ -35,7 +35,7 @@ namespace MixedReality.Toolkit.Input
         protected internal TrackedPoseDriver TrackedPoseDriver => trackedPoseDriver;
 
         [SerializeField]
-        [Tooltip("The root management GameObject that interactor belongs to. T")]
+        [Tooltip("The root management GameObject that interactor belongs to.")]
         private GameObject modeManagedRoot = null;
 
         /// <summary>

--- a/org.mixedrealitytoolkit.input/Interactors/Poke/PokeInteractor.cs
+++ b/org.mixedrealitytoolkit.input/Interactors/Poke/PokeInteractor.cs
@@ -21,8 +21,7 @@ namespace MixedReality.Toolkit.Input
     public class PokeInteractor :
         XRBaseInputInteractor,
         IPokeInteractor,
-        IHandedInteractor,
-        IModeManagedInteractor
+        IHandedInteractor
     {
         #region PokeInteractor
 

--- a/org.mixedrealitytoolkit.input/Interactors/Ray/MRTKRayInteractor.cs
+++ b/org.mixedrealitytoolkit.input/Interactors/Ray/MRTKRayInteractor.cs
@@ -30,8 +30,7 @@ namespace MixedReality.Toolkit.Input
         XRRayInteractor,
         IRayInteractor,
         IHandedInteractor,
-        IVariableSelectInteractor,
-        IModeManagedInteractor
+        IVariableSelectInteractor
     {
         #region MRTKRayInteractor
 

--- a/org.mixedrealitytoolkit.uxcore/Interop/CanvasProxyInteractor.cs
+++ b/org.mixedrealitytoolkit.uxcore/Interop/CanvasProxyInteractor.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Mixed Reality Toolkit Contributors
 // Licensed under the BSD 3-Clause
 
+using System;
 using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.XR.Interaction.Toolkit.Interactables;
@@ -12,7 +13,10 @@ namespace MixedReality.Toolkit.UX
     /// A simple proxy interactor which will select and hover things on MRTK's behalf, for canvas input.
     /// </summary>
     [AddComponentMenu("MRTK/UX/Canvas Proxy Interactor")]
-    public class CanvasProxyInteractor : XRBaseInteractor, IProxyInteractor, IModeManagedInteractor
+    public class CanvasProxyInteractor :
+        XRBaseInteractor,
+        IProxyInteractor,
+        IModeManagedInteractor
     {
         /// <summary>
         /// The hash set containing a collection of valid interactable targets for this this interactor.
@@ -28,6 +32,9 @@ namespace MixedReality.Toolkit.UX
         // We set this flag whenever we're cancelling an interaction. This will suppress
         // events (like OnClicked) on any StatefulInteractable.
         private bool isCancellingInteraction = false;
+
+        /// <inheritdoc />
+        public GameObject ModeManagedRoot { get => gameObject; }
 
         /// <inheritdoc />
         public void StartHover(IXRHoverInteractable target)
@@ -144,6 +151,7 @@ namespace MixedReality.Toolkit.UX
         public override bool isHoverActive => base.isHoverActive && !isCancellingInteraction;
 
         /// <inheritdoc />
-        public GameObject GetModeManagedController() => gameObject;
+        [Obsolete("This function is obsolete and will be removed in the next major release. Use ModeManagedRoot instead.")]
+        public GameObject GetModeManagedController() => ModeManagedRoot;
     }
 }


### PR DESCRIPTION
# Overview

- Updating `IModeManagedInteractor` to use something other than controllers.  
- Also updating interactors to use the new `GetInputTrackingState` extension 

Updating `IModeManagedInteractor` to use something other than controllers.  This is needed for updating `InteractionModeManager` so it does not use controllers either.


NOTE:  Eventually all the MRTK interactors will implement `IModeManagedInteractor`, but this will come in with the changes to `IModeManagedInteractor`
