### PR TITLE
[XRI3] Updating RiggedHandMeshVisualizer so to not rely on deprecated XRI controller components

### DIFF
--- a/org.mixedrealitytoolkit.input/Visualizers/RiggedHandVisualizer/RiggedHandMeshVisualizer.cs
+++ b/org.mixedrealitytoolkit.input/Visualizers/RiggedHandVisualizer/RiggedHandMeshVisualizer.cs
@@ -410,7 +410,6 @@ namespace MixedReality.Toolkit.Input
                 {
                     controller = GetComponentInParent<XRController>();
                 }
-
                 if (controller != null)
                 {
                     value = controller.selectInteractionState.value;

--- a/org.mixedrealitytoolkit.input/Visualizers/RiggedHandVisualizer/RiggedHandMeshVisualizer.cs
+++ b/org.mixedrealitytoolkit.input/Visualizers/RiggedHandVisualizer/RiggedHandMeshVisualizer.cs
@@ -63,7 +63,7 @@ namespace MixedReality.Toolkit.Input
         private string pinchAmountMaterialProperty = "_PinchAmount";
 
         [SerializeField]
-        [Tooltip("The input reader user when pinch selecting an interactable.")]
+        [Tooltip("The input reader used when pinch selecting an interactable.")]
         XRInputButtonReader selectInput = new XRInputButtonReader("Select");
 
         /// <summary>

--- a/org.mixedrealitytoolkit.input/Visualizers/RiggedHandVisualizer/RiggedHandMeshVisualizer.cs
+++ b/org.mixedrealitytoolkit.input/Visualizers/RiggedHandVisualizer/RiggedHandMeshVisualizer.cs
@@ -391,7 +391,7 @@ namespace MixedReality.Toolkit.Input
         /// Try to obtain the tracked devices selection value from the provided input reader.
         /// </summary>
         /// <remarks>
-        /// For backwards compatibility, this method will also attempt to get the pinch amount from a
+        /// For backwards compatibility, this method will also attempt to get the selection amount from a
         /// legacy XRI controller if the input reader is not set.
         /// </remaks> 
         private bool TryGetSelectionValue(out float value)


### PR DESCRIPTION
# Overview

Updating `RiggedHandMeshVisualizer` so to not rely on deprecated XRI controller components.

This change will require the rig prefab to specify the input reader being used to obtain the selection value for the pinch gesture. Once the controller components are removed from the new rig, I'll update the new rig to hook-up the new `RiggedHandMeshVisualizer`