### PR TITLE
[XRI3] Updating `ObjectManipulator` so to not rely on obsolete XRI controllers. 

### DIFF
--- a/org.mixedrealitytoolkit.core/Interactors/ITrackedInteractor.cs
+++ b/org.mixedrealitytoolkit.core/Interactors/ITrackedInteractor.cs
@@ -11,7 +11,7 @@ namespace MixedReality.Toolkit
     public interface ITrackedInteractor
     {
         /// <summary>
-        /// Get the interactor's parent whoee pose is backed by a tracked input device.
+        /// Get the interactor's parent whose pose is backed by a tracked input device.
         /// </summary>
         public GameObject TrackedParent { get; }
     }

--- a/org.mixedrealitytoolkit.core/Interactors/ITrackedInteractor.cs
+++ b/org.mixedrealitytoolkit.core/Interactors/ITrackedInteractor.cs
@@ -1,0 +1,18 @@
+// Copyright (c) Mixed Reality Toolkit Contributors
+// Licensed under the BSD 3-Clause
+
+using UnityEngine;
+
+namespace MixedReality.Toolkit
+{
+    /// <summary>
+    /// Represents an interactor whose parent pose is backed by a tracked input device.
+    /// </summary>
+    public interface ITrackedInteractor
+    {
+        /// <summary>
+        /// Get the interactor's parent whoee pose is backed by a tracked input device.
+        /// </summary>
+        public GameObject TrackedParent { get; }
+    }
+}

--- a/org.mixedrealitytoolkit.core/Interactors/ITrackedInteractor.cs.meta
+++ b/org.mixedrealitytoolkit.core/Interactors/ITrackedInteractor.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 48be717443a73234da004d6812ced512
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/org.mixedrealitytoolkit.input/Interactors/GazePinch/GazePinchInteractor.cs
+++ b/org.mixedrealitytoolkit.input/Interactors/GazePinch/GazePinchInteractor.cs
@@ -22,7 +22,8 @@ namespace MixedReality.Toolkit.Input
         XRBaseInputInteractor,
         IGazePinchInteractor,
         IHandedInteractor,
-        IModeManagedInteractor
+        IModeManagedInteractor,
+        ITrackedInteractor
     {
         #region GazePinchInteractor
 
@@ -560,6 +561,11 @@ namespace MixedReality.Toolkit.Input
         }
 
         #endregion XRBaseInteractor
+
+        #region ITrackedInteractor
+        /// <inheritdoc />
+        public GameObject TrackedParent => trackedPoseDriver == null ? null : trackedPoseDriver.gameObject;
+        #endregion ITrackedInteractor
 
         #region IModeManagedInteractor
         /// <inheritdoc/>

--- a/org.mixedrealitytoolkit.input/Interactors/HandJointInteractor.cs
+++ b/org.mixedrealitytoolkit.input/Interactors/HandJointInteractor.cs
@@ -19,7 +19,8 @@ namespace MixedReality.Toolkit.Input
     public abstract class HandJointInteractor :
         XRDirectInteractor,
         IHandedInteractor,
-        IModeManagedInteractor
+        IModeManagedInteractor,
+        ITrackedInteractor
     {
         #region Serialized Fields
         [SerializeField, Tooltip("Holds a reference to the <see cref=\"TrackedPoseDriver\"/> associated to this interactor if it exists.")]
@@ -58,6 +59,11 @@ namespace MixedReality.Toolkit.Input
         protected abstract bool TryGetInteractionPoint(out Pose pose);
 
         #endregion HandJointInteractor
+
+        #region ITrackedInteractor
+        /// <inheritdoc />
+        public GameObject TrackedParent => trackedPoseDriver == null ? null : trackedPoseDriver.gameObject;
+        #endregion ITrackedInteractor
 
         #region IHandedInteractor
 

--- a/org.mixedrealitytoolkit.input/Interactors/Poke/PokeInteractor.cs
+++ b/org.mixedrealitytoolkit.input/Interactors/Poke/PokeInteractor.cs
@@ -22,7 +22,8 @@ namespace MixedReality.Toolkit.Input
         XRBaseInputInteractor,
         IPokeInteractor,
         IHandedInteractor,
-        IModeManagedInteractor
+        IModeManagedInteractor,
+        ITrackedInteractor
     {
         #region PokeInteractor
 
@@ -318,6 +319,11 @@ namespace MixedReality.Toolkit.Input
         }
 
         #endregion XRBaseInteractor
+
+        #region ITrackedInteractor
+        /// <inheritdoc />
+        public GameObject TrackedParent => trackedPoseDriver == null ? null : trackedPoseDriver.gameObject;
+        #endregion ITrackedInteractor
 
         #region IModeManagedInteractor
         /// <inheritdoc/>

--- a/org.mixedrealitytoolkit.input/Interactors/Ray/MRTKRayInteractor.cs
+++ b/org.mixedrealitytoolkit.input/Interactors/Ray/MRTKRayInteractor.cs
@@ -29,7 +29,8 @@ namespace MixedReality.Toolkit.Input
         IRayInteractor,
         IHandedInteractor,
         IVariableSelectInteractor,
-        IModeManagedInteractor
+        IModeManagedInteractor,
+        ITrackedInteractor
     {
         #region MRTKRayInteractor
 
@@ -140,8 +141,14 @@ namespace MixedReality.Toolkit.Input
 
         #endregion MRTKRayInteractor
 
+        #region ITrackedInteractor
+        /// <inheritdoc />
+        public GameObject TrackedParent => trackedPoseDriver == null ? null : trackedPoseDriver.gameObject;
+        #endregion ITrackedInteractor
+
         #region IHandedInteractor
 
+        /// <inheritdoc />
         Handedness IHandedInteractor.Handedness
         {
             get


### PR DESCRIPTION
# Overview

Updating `ObjectManipulator` so to not rely on obsolete XRI controllers. 

This required introducing a new interactor interface, `ITrackedInteractor`.  This interface provides a way for the `ObjectManipulator` to obtain the transform of the tracked input device.