### PR TITLE
[XRI3] Updating `InteractableEventRouterTests` so it no longer relying on o XRI controllers.

### DIFF
--- a/org.mixedrealitytoolkit.core/Tests/Runtime/InteractableEventRouterTests.cs
+++ b/org.mixedrealitytoolkit.core/Tests/Runtime/InteractableEventRouterTests.cs
@@ -363,7 +363,6 @@ namespace MixedReality.Toolkit.UX.Runtime.Tests
             level2 = new GameObject("level 2");
 
             // Setup interactor
-            interactorObject.AddComponent<XRController>();
             interactor = interactorObject.AddComponent<XRRayInteractor>();
             interactorObject.transform.SetParent(level0.transform, worldPositionStays: true);
 


### PR DESCRIPTION
# Overview

Updating `InteractableEventRouterTests` so it no longer relying on old XRI controllers. This no longer needed, tests pass fine without a need of a controller or an alternative to a controller.