### PR TITLE
XRI3 migration updating hand model

### DIFF
--- a/org.mixedrealitytoolkit.input/Experimental/XRI3/HandModel.cs
+++ b/org.mixedrealitytoolkit.input/Experimental/XRI3/HandModel.cs
@@ -74,5 +74,22 @@ namespace MixedReality.Toolkit.Input
                 model = Instantiate(ModelPrefab, ModelParent);
             }
         }
+
+        /// <summary>
+        /// See <see cref="MonoBehaviour"/>.
+        /// </summary>
+        protected virtual void Awake()
+        {
+            // Create empty container transform for the model if none specified.
+            // This is not strictly necessary to create since this GameObject could be used
+            // as the parent for the instantiated prefab, but doing so anyway for backwards compatibility.
+            if (modelParent == null)
+            {
+                modelParent = new GameObject($"[{gameObject.name}] Model Parent").transform;
+                modelParent.SetParent(transform, false);
+                modelParent.localPosition = Vector3.zero;
+                modelParent.localRotation = Quaternion.identity;
+            }
+        }
     }
 }

--- a/org.mixedrealitytoolkit.input/Tests/Runtime/BasicInputTestsForControllerlessRig.cs
+++ b/org.mixedrealitytoolkit.input/Tests/Runtime/BasicInputTestsForControllerlessRig.cs
@@ -466,7 +466,7 @@ namespace MixedReality.Toolkit.Input.Tests
             HandModel leftHandHandModel = leftHandHandModels[0];
             Assert.AreEqual(XRNode.LeftHand, leftHandHandModel.HandNode);
             Assert.IsTrue(leftHandHandModel.Model.name.Equals(OpenXRLeftHandCloneName));
-            Assert.IsNull(leftHandHandModel.ModelParent);
+            Assert.AreEqual(leftHandHandModel.ModelParent.transform.parent, leftHandGameObject.transform);
             Assert.IsTrue(leftHandHandModel.ModelPrefab.name.Equals(OpenXRLeftHandName));
 
             var rigtHandHandModels = rightHandGameObject.GetComponents<HandModel>();
@@ -474,7 +474,7 @@ namespace MixedReality.Toolkit.Input.Tests
             HandModel rightHandHandModel = rigtHandHandModels[0];
             Assert.AreEqual(XRNode.RightHand, rightHandHandModel.HandNode);
             Assert.IsTrue(rightHandHandModel.Model.name.Equals(OpenXRRightHandCloneName));
-            Assert.IsNull(rightHandHandModel.ModelParent);
+            Assert.AreEqual(rightHandHandModel.ModelParent.transform.parent, rightHandHandModel.transform);
             Assert.IsTrue(rightHandHandModel.ModelPrefab.name.Equals(OpenXRRightHandName));
 
             // Now check the interactors


### PR DESCRIPTION
* Updated HandModel to have the same MonoBehavior Awake() as the obsolete XRBaseController.
* Updated BasicInputTestsForControllerlessRig::ControllerlessRigSmokeTest accordingly.