### PR TITLE
Fix an issue with PinchInputReader's TryGetValue when using fallback.

### DIFF
--- a/org.mixedrealitytoolkit.input/Readers/PinchInputReader.cs
+++ b/org.mixedrealitytoolkit.input/Readers/PinchInputReader.cs
@@ -28,6 +28,7 @@ namespace MixedReality.Toolkit.Input
         /// </summary>
         private struct FallbackState
         {
+            public bool hasPinchData;
             public bool isPerformed;
             public bool wasPerformedThisFrame;
             public bool wasCompletedThisFrame;
@@ -249,7 +250,7 @@ namespace MixedReality.Toolkit.Input
             else
             {
                 value = m_fallbackState.value;
-                return m_fallbackState.isPerformed;
+                return m_fallbackState.hasPinchData;
             }
         }
 
@@ -293,6 +294,7 @@ namespace MixedReality.Toolkit.Input
                     m_fallbackState.wasCompletedThisFrame = !isPinched && m_fallbackState.isPerformed;
                     m_fallbackState.isPerformed = isPinched;
                     m_fallbackState.value = pinchAmount;
+                    m_fallbackState.hasPinchData = true;
                 }
                 else
                 {


### PR DESCRIPTION
* Previously, TryGetValue would only return a value successfully when using fallback and pinch was being performed, not during the whole range of pinch values as expected.