### PR TITLE
Allow the HandModel ModelPrefab property to be set at runtime.

### DIFF
--- a/org.mixedrealitytoolkit.input/Controllers/HandModel.cs
+++ b/org.mixedrealitytoolkit.input/Controllers/HandModel.cs
@@ -17,14 +17,18 @@ namespace MixedReality.Toolkit.Input
     {
         #region Properties
 
-        [SerializeField, Tooltip("The prefab of the MRTK Controller to show that will be automatically instantitated by this behaviour.")]
+        [SerializeField, Tooltip("The prefab of the MRTK Controller to show that will be automatically instantiated by this behavior.")]
         private Transform modelPrefab;
 
         /// <summary>
-        /// The prefab of the model to show that will be automatically instantitated by this <see cref="MonoBehaviour"/>.
+        /// The prefab of the model to show that will be automatically instantiated by this <see cref="MonoBehaviour"/>.
         /// </summary>
         /// <remarks>Expected to be XRNode.LeftHand or XRNode.RightHand.</remarks>
-        public Transform ModelPrefab => modelPrefab;
+        public Transform ModelPrefab
+        {
+            get => modelPrefab;
+            set => modelPrefab = value;
+        }
 
         [SerializeField, Tooltip("The transform that is used as the parent for the model prefab when it is instantiated.  Will be set to a new child GameObject if None.")]
         private Transform modelParent;


### PR DESCRIPTION
* This aligns with the functionality of the deprecated ArticulatedHandController's ModelPrefab, which allowed runtime setting, that this HandModel is meant to replace.