### PR TITLE
Fix issue with the HandMenu not working in new controllerless rig

### DIFF
--- a/org.mixedrealitytoolkit.spatialmanipulation/MRTK.SpatialManipulation.asmdef
+++ b/org.mixedrealitytoolkit.spatialmanipulation/MRTK.SpatialManipulation.asmdef
@@ -3,7 +3,6 @@
     "rootNamespace": "MixedReality.Toolkit.SpatialManipulation",
     "references": [
         "MixedReality.Toolkit.Core",
-        "MixedReality.Toolkit.Input",
         "Unity.InputSystem",
         "Unity.XR.Interaction.Toolkit"
     ],

--- a/org.mixedrealitytoolkit.spatialmanipulation/MRTK.SpatialManipulation.asmdef
+++ b/org.mixedrealitytoolkit.spatialmanipulation/MRTK.SpatialManipulation.asmdef
@@ -3,6 +3,7 @@
     "rootNamespace": "MixedReality.Toolkit.SpatialManipulation",
     "references": [
         "MixedReality.Toolkit.Core",
+        "MixedReality.Toolkit.Input",
         "Unity.InputSystem",
         "Unity.XR.Interaction.Toolkit"
     ],

--- a/org.mixedrealitytoolkit.spatialmanipulation/Solvers/HandConstraintPalmUp.cs
+++ b/org.mixedrealitytoolkit.spatialmanipulation/Solvers/HandConstraintPalmUp.cs
@@ -6,6 +6,7 @@ using Unity.Profiling;
 using UnityEngine;
 using UnityEngine.Serialization;
 using UnityEngine.XR;
+using MixedReality.Toolkit.Input;
 
 namespace MixedReality.Toolkit.SpatialManipulation
 {
@@ -296,14 +297,14 @@ namespace MixedReality.Toolkit.SpatialManipulation
                 #pragma warning restore CS0618
                 else if (TrackedPoseDriverLookup != null)
                 {
-                    InputTrackingState gazeTrackingStateInput = (InputTrackingState)TrackedPoseDriverLookup.GazeTrackedPoseDriver.trackingStateInput.action.ReadValue<int>();
                     if (TrackedPoseDriverLookup.GazeTrackedPoseDriver != null &&
+                        TrackedPoseDriverLookup.GazeTrackedPoseDriver.TryGetTrackingState(out InputTrackingState gazeTrackingStateInput) &&
                         gazeTrackingStateInput.HasFlag(InputTrackingState.Position) &&
                         gazeTrackingStateInput.HasFlag(InputTrackingState.Rotation))
                     {
                         gazeRay = new Ray(
-                                TrackedPoseDriverLookup.transform.position,
-                                TrackedPoseDriverLookup.transform.forward);
+                                TrackedPoseDriverLookup.GazeTrackedPoseDriver.transform.position,
+                                TrackedPoseDriverLookup.GazeTrackedPoseDriver.transform.forward);
                         usedEyeGaze = true;
                     }
                     else

--- a/org.mixedrealitytoolkit.spatialmanipulation/Solvers/HandConstraintPalmUp.cs
+++ b/org.mixedrealitytoolkit.spatialmanipulation/Solvers/HandConstraintPalmUp.cs
@@ -297,7 +297,7 @@ namespace MixedReality.Toolkit.SpatialManipulation
                 else if (TrackedPoseDriverLookup != null)
                 {
                     InputTrackingState gazeTrackingStateInput = TrackedPoseDriverLookup.GazeTrackedPoseDriver != null ?
-                        (InputTrackingState)TrackedPoseDriverLookup.GazeTrackedPoseDriver.trackingStateInput.action?.ReadValue<int>() :
+                        (InputTrackingState)(TrackedPoseDriverLookup.GazeTrackedPoseDriver.trackingStateInput.action?.ReadValue<int>() ?? default) :
                         InputTrackingState.None;
 
                     if (gazeTrackingStateInput.HasFlag(InputTrackingState.Position) &&

--- a/org.mixedrealitytoolkit.spatialmanipulation/Solvers/HandConstraintPalmUp.cs
+++ b/org.mixedrealitytoolkit.spatialmanipulation/Solvers/HandConstraintPalmUp.cs
@@ -1,12 +1,12 @@
 ﻿// Copyright (c) Mixed Reality Toolkit Contributors
 // Licensed under the BSD 3-Clause
 
+using MixedReality.Toolkit.Input;
 using System.Collections;
 using Unity.Profiling;
 using UnityEngine;
 using UnityEngine.Serialization;
 using UnityEngine.XR;
-using MixedReality.Toolkit.Input;
 
 namespace MixedReality.Toolkit.SpatialManipulation
 {
@@ -297,9 +297,11 @@ namespace MixedReality.Toolkit.SpatialManipulation
                 #pragma warning restore CS0618
                 else if (TrackedPoseDriverLookup != null)
                 {
-                    if (TrackedPoseDriverLookup.GazeTrackedPoseDriver != null &&
-                        TrackedPoseDriverLookup.GazeTrackedPoseDriver.TryGetTrackingState(out InputTrackingState gazeTrackingStateInput) &&
-                        gazeTrackingStateInput.HasFlag(InputTrackingState.Position) &&
+                    InputTrackingState gazeTrackingStateInput = TrackedPoseDriverLookup.GazeTrackedPoseDriver != null ?
+                        (InputTrackingState)TrackedPoseDriverLookup.GazeTrackedPoseDriver.trackingStateInput.action?.ReadValue<int>() :
+                        InputTrackingState.None;
+
+                    if (gazeTrackingStateInput.HasFlag(InputTrackingState.Position) &&
                         gazeTrackingStateInput.HasFlag(InputTrackingState.Rotation))
                     {
                         gazeRay = new Ray(

--- a/org.mixedrealitytoolkit.spatialmanipulation/Solvers/HandConstraintPalmUp.cs
+++ b/org.mixedrealitytoolkit.spatialmanipulation/Solvers/HandConstraintPalmUp.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Mixed Reality Toolkit Contributors
 // Licensed under the BSD 3-Clause
 
-using MixedReality.Toolkit.Input;
 using System.Collections;
 using Unity.Profiling;
 using UnityEngine;


### PR DESCRIPTION
The HandMenu was not working in the new controllerless rig.  This is a simple fix to use the GazeTrackedPoseDriver's transform, but also makes use of the TrackedPoseDriver extension TryGetTrackingState(...), which required an assembly reference on Input. 

Does this also mean SpatialManipulation should have a hard dependency on Input in package.manifest?

Solver.cs was already using TrackedPoseDriverLookup, defined in Input, so wouldn't that already cause dependency?

![image](https://github.com/user-attachments/assets/18e36b9b-184b-4986-98a2-b692370dfba8)
