### PR TITLE
Re-enabling SpatialMouseInputTests::SpatialMouseInteractorSmokeTest()…

### DIFF
--- a/org.mixedrealitytoolkit.input/Tests/Runtime/SpatialMouseInputTests.cs
+++ b/org.mixedrealitytoolkit.input/Tests/Runtime/SpatialMouseInputTests.cs
@@ -43,7 +43,6 @@ namespace MixedReality.Toolkit.Input.Tests
         /// Very basic test of SpatialMouseInteractor clicking an Interactable.
         /// </summary>
         [UnityTest]
-        [Ignore("Temporarily ignoring this while while its XRI3+ equivalent is created.")]
         public IEnumerator SpatialMouseInteractorSmokeTest()
         {
             var mouse = InputSystem.AddDevice<Mouse>();
@@ -91,7 +90,6 @@ namespace MixedReality.Toolkit.Input.Tests
             {
                 ((ButtonControl)mouse["press"]).WriteValueIntoEvent(1f, eventPtr);
                 InputSystem.QueueEvent(eventPtr);
-                InputSystem.Update();
             }
 
             yield return RuntimeTestUtilities.WaitForUpdates();
@@ -108,7 +106,6 @@ namespace MixedReality.Toolkit.Input.Tests
             {
                 ((ButtonControl)mouse["press"]).WriteValueIntoEvent(0f, eventPtr);
                 InputSystem.QueueEvent(eventPtr);
-                InputSystem.Update();
             }
 
             yield return RuntimeTestUtilities.WaitForUpdates();


### PR DESCRIPTION
… + fix

Root-cause:
![image](https://github.com/user-attachments/assets/bcc8afb4-0fb7-4220-ae2a-b2eca89968e0)
