### PR TITLE
Ensure all relevant interactor types show up in InteractionModeManager

### DIFF
--- a/org.mixedrealitytoolkit.input/InteractionModes/InteractionModeDefinition.cs
+++ b/org.mixedrealitytoolkit.input/InteractionModes/InteractionModeDefinition.cs
@@ -26,7 +26,7 @@ namespace MixedReality.Toolkit.Input
 
         // private field to ensure serialization
         [SerializeField]
-        [Extends(typeof(XRBaseControllerInteractor), TypeGrouping.ByNamespaceFlat)]
+        [Extends(typeof(XRBaseInteractor), TypeGrouping.ByNamespaceFlat)]
         [Tooltip("The class types of the interactors that this Interaction Mode Definition instance is targeting.")]
         private List<SystemType> associatedTypes = new List<SystemType>();
 


### PR DESCRIPTION
Fixes https://github.com/MixedRealityToolkit/MixedRealityToolkit-Unity/issues/843