### PR TITLE
Fix null ref in SpatialManipulationReticle when multiple interactables are hovered

### DIFF
--- a/org.mixedrealitytoolkit.spatialmanipulation/BoundsControl/Visuals/SpatialManipulationReticle.cs
+++ b/org.mixedrealitytoolkit.spatialmanipulation/BoundsControl/Visuals/SpatialManipulationReticle.cs
@@ -55,7 +55,7 @@ namespace MixedReality.Toolkit.SpatialManipulation
                     {
                         for (int i = 0; i < hoveredCount; i++)
                         {
-                            if (hoveredInteractables[i] is ISnapInteractable)
+                            if (hoveredInteractables[i] is BoundsHandleInteractable)
                             {
                                 interactableIndex = i;
                                 break;

--- a/org.mixedrealitytoolkit.spatialmanipulation/BoundsControl/Visuals/SpatialManipulationReticle.cs
+++ b/org.mixedrealitytoolkit.spatialmanipulation/BoundsControl/Visuals/SpatialManipulationReticle.cs
@@ -2,6 +2,7 @@
 // Licensed under the BSD 3-Clause
 
 using System;
+using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.XR.Interaction.Toolkit;
 
@@ -19,7 +20,6 @@ namespace MixedReality.Toolkit.SpatialManipulation
         [field: SerializeField, Tooltip("The type of the reticle visuals. Scale or Rotate.")]
         public SpatialManipulationReticleType ReticleType { get; set; }
 
-        private Transform contextTransform;
         private Quaternion worldRotationCache;
 
         /// <summary>
@@ -47,7 +47,23 @@ namespace MixedReality.Toolkit.SpatialManipulation
                 }
                 else if (rayInteractor.interactablesHovered.Count > 0)
                 {
-                    RotateReticle(args.ReticleNormal, rayInteractor.interactablesHovered[0].transform);
+                    int interactableIndex = 0;
+
+                    List<IXRHoverInteractable> hoveredInteractables = rayInteractor.interactablesHovered;
+                    int hoveredCount = hoveredInteractables.Count;
+                    if (hoveredCount > 1)
+                    {
+                        for (int i = 0; i < hoveredCount; i++)
+                        {
+                            if (hoveredInteractables[i] is ISnapInteractable)
+                            {
+                                interactableIndex = i;
+                                break;
+                            }
+                        }
+                    }
+
+                    RotateReticle(args.ReticleNormal, hoveredInteractables[interactableIndex].transform);
                 }
             }
         }

--- a/org.mixedrealitytoolkit.spatialmanipulation/CHANGELOG.md
+++ b/org.mixedrealitytoolkit.spatialmanipulation/CHANGELOG.md
@@ -7,8 +7,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Fixed
 
 * Fixed tap to place `StartPlacement()` when called just after instantiation of the component. [PR #785](https://github.com/MixedRealityToolkit/MixedRealityToolkit-Unity/pull/785)
+* Fix null ref in SpatialManipulationReticle when multiple interactables are hovered. [PR #873](https://github.com/MixedRealityToolkit/MixedRealityToolkit-Unity/pull/873)
 
-## [3.3.0-development] - 2024-04-30
+## [3.3.0] - 2024-04-30
 
 ### Added
 
@@ -18,7 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 * Added null check and index check when hiding colliders on BoundsHandleInteractable. [PR #730](https://github.com/MixedRealityToolkit/MixedRealityToolkit-Unity/pull/730)
 
-## [3.2.0-development] - 2024-03-20
+## [3.2.0] - 2024-03-20
 
 ### Added
 


### PR DESCRIPTION
Fixes https://github.com/MixedRealityToolkit/MixedRealityToolkit-Unity/issues/671

Ensures that we actually pass a `BoundsHandleInteractable` to `RotateReticle`, as that's what it's expecting as far as hierarchy. If we inadvertently pass the `BoundsControl`, the hierarchy logic is incorrect (no parent when it's in the root of the scene).

This case won't be hit in the default MRTK XR Rig. It's only when "Hit Closest Only" on a ray interactor is unchecked that this case is possible.