### PR TITLE
Fix rigged hand mesh with input actions

### DIFF
--- a/org.mixedrealitytoolkit.input/Controllers/HandModel.cs
+++ b/org.mixedrealitytoolkit.input/Controllers/HandModel.cs
@@ -109,8 +109,12 @@ namespace MixedReality.Toolkit.Input
             {
                 modelParent = new GameObject($"[{gameObject.name}] Model Parent").transform;
                 modelParent.SetParent(transform, false);
+#if HAS_SET_LOCAL_POSITION_AND_ROTATION
+                modelParent.SetLocalPositionAndRotation(Vector3.zero, Quaternion.identity);
+#else
                 modelParent.localPosition = Vector3.zero;
                 modelParent.localRotation = Quaternion.identity;
+#endif
             }
         }
     }

--- a/org.mixedrealitytoolkit.input/Visualizers/RiggedHandVisualizer/RiggedHandMeshVisualizer.cs
+++ b/org.mixedrealitytoolkit.input/Visualizers/RiggedHandVisualizer/RiggedHandMeshVisualizer.cs
@@ -381,14 +381,11 @@ namespace MixedReality.Toolkit.Input
                 return;
             }
 
-            if (TryGetSelectionValue(out float selectionValue))
-            {
-                // Update the hand material
-                float pinchAmount = Mathf.Pow(selectionValue, 2.0f);
-                handRenderer.GetPropertyBlock(propertyBlock);
-                propertyBlock.SetFloat(pinchAmountMaterialProperty, pinchAmount);
-                handRenderer.SetPropertyBlock(propertyBlock);
-            }
+            // Update the hand material
+            float pinchAmount = TryGetSelectionValue(out float selectionValue) ? Mathf.Pow(selectionValue, 2.0f) : 0;
+            handRenderer.GetPropertyBlock(propertyBlock);
+            propertyBlock.SetFloat(pinchAmountMaterialProperty, pinchAmount);
+            handRenderer.SetPropertyBlock(propertyBlock);
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes https://github.com/MixedRealityToolkit/MixedRealityToolkit-Unity/issues/890

Updates `RiggedHandMeshVisualizer` to treat a non-performed action as a 0 "selectedness".

> [!IMPORTANT]  
>
>I think we may want to consider reverting https://github.com/MixedRealityToolkit/MixedRealityToolkit-Unity/pull/852 (pinging @whebertML for his thoughts). The default implementation of `XRInputButtonReader` _does_ only return `true` when the action is in progress:
>
>![image](https://github.com/user-attachments/assets/76ccd3f9-cee3-489e-b516-d1f93cc888c6)
>
>I think the underlying issue was that we had at least one code path (the change in this PR) that wasn't properly treating a return value of `false` as equivalent to `0`. Where you seeing the previous return value be problematic in other places too?