### PR TITLE
Check input action availability every frame instead of once on startup

### DIFF
--- a/org.mixedrealitytoolkit.input/Readers/PinchInputReader.cs
+++ b/org.mixedrealitytoolkit.input/Readers/PinchInputReader.cs
@@ -104,9 +104,9 @@ namespace MixedReality.Toolkit.Input
         #region Private Fields
 
         private FallbackState m_fallbackState;
-        private bool m_firstUpdate = true;
-        private bool m_isSelectionActionValidCache = false;
-        private bool m_isSelectionActionValueValidCache = false; 
+        private bool m_isTrackingStatePolyfilled = false;
+        private bool m_isSelectPolyfilled = false;
+        private bool m_isSelectValuePolyfilled = false;
 
         private static readonly ProfilerMarker UpdatePinchSelectionPerfMarker =
             new ProfilerMarker("[MRTK] PinchInputReader.UpdatePinchSelection");
@@ -122,10 +122,6 @@ namespace MixedReality.Toolkit.Input
         {
             selectAction.EnableDirectAction();
             selectActionValue.EnableDirectAction();
-
-            // Read current input values when becoming enabled,
-            // but wait until after the input update so the input is read at a consistent time
-            m_firstUpdate = true;
 
             // reset fallback state
             m_fallbackState = default;
@@ -145,16 +141,14 @@ namespace MixedReality.Toolkit.Input
         /// </summary>
         protected virtual void Update()
         {
-            if (m_firstUpdate)
-            {
-                UpdateActionValidCaches();
-                m_firstUpdate = false;
-            }
+            m_isTrackingStatePolyfilled = trackedPoseDriver.GetIsPolyfillDevicePose();
+            m_isSelectPolyfilled = !selectAction.action.HasAnyControls();
+            m_isSelectValuePolyfilled = !selectActionValue.action.HasAnyControls();
 
             // Workaround for missing select actions on devices without interaction profiles
             // for hands, such as Varjo and Quest. Should be removed once we have universal
             // hand interaction profile(s) across vendors.
-            if (!m_isSelectionActionValidCache || !m_isSelectionActionValueValidCache || GetIsPolyfillDevicePose())
+            if (m_isTrackingStatePolyfilled || m_isSelectPolyfilled || m_isSelectValuePolyfilled)
             {
                 UpdatePinchSelection();
             }
@@ -167,10 +161,10 @@ namespace MixedReality.Toolkit.Input
         /// <inheritdoc />
         public bool ReadIsPerformed()
         {
-            if (m_isSelectionActionValidCache && !GetIsPolyfillDevicePose())
+            if (!m_isSelectPolyfilled && !m_isTrackingStatePolyfilled)
             {
-                var action = selectAction.action;
-                var phase = action.phase;
+                InputAction action = selectAction.action;
+                InputActionPhase phase = action.phase;
                 return phase == InputActionPhase.Performed || (phase != InputActionPhase.Disabled && action.WasPerformedThisFrame());
             }
             else
@@ -182,7 +176,7 @@ namespace MixedReality.Toolkit.Input
         /// <inheritdoc />
         public bool ReadWasPerformedThisFrame()
         {
-            if (m_isSelectionActionValidCache && !GetIsPolyfillDevicePose())
+            if (!m_isSelectPolyfilled && !m_isTrackingStatePolyfilled)
             {
                 return selectAction.action.WasPerformedThisFrame();
             }
@@ -195,7 +189,7 @@ namespace MixedReality.Toolkit.Input
         /// <inheritdoc />
         public bool ReadWasCompletedThisFrame()
         {
-            if (m_isSelectionActionValidCache && !GetIsPolyfillDevicePose())
+            if (!m_isSelectPolyfilled && !m_isTrackingStatePolyfilled)
             {
                 return selectAction.action.WasCompletedThisFrame();
             }
@@ -208,7 +202,7 @@ namespace MixedReality.Toolkit.Input
         /// <inheritdoc />
         public float ReadValue()
         {
-            if (m_isSelectionActionValueValidCache && !GetIsPolyfillDevicePose())
+            if (!m_isSelectValuePolyfilled && !m_isTrackingStatePolyfilled)
             {
                 return selectActionValue.action.ReadValue<float>();
             }
@@ -221,9 +215,9 @@ namespace MixedReality.Toolkit.Input
         /// <inheritdoc />
         public bool TryReadValue(out float value)
         {
-            if (m_isSelectionActionValueValidCache && !GetIsPolyfillDevicePose())
+            if (!m_isSelectValuePolyfilled && !m_isTrackingStatePolyfilled)
             {
-                var action = selectActionValue.action;
+                InputAction action = selectActionValue.action;
                 value = action.ReadValue<float>();
                 return action.IsInProgress();
             }
@@ -237,6 +231,7 @@ namespace MixedReality.Toolkit.Input
         #endregion IXRInputButtonReader
 
         #region Private Functions
+
         /// <summary>
         /// Workaround for missing select actions on devices without interaction profiles for hands, such as Varjo and Quest.
         /// </summary>
@@ -253,15 +248,12 @@ namespace MixedReality.Toolkit.Input
                     return;
                 }
 
-                bool gotPinchData = XRSubsystemHelpers.HandsAggregator.TryGetPinchProgress(
-                    handNode,
-                    out bool isPinchReady,
-                    out bool isPinching,
-                    out float pinchAmount
-                );
-
                 // If we got pinch data, write it into our select interaction state.
-                if (gotPinchData)
+                if (XRSubsystemHelpers.HandsAggregator.TryGetPinchProgress(
+                    handNode,
+                    out _,
+                    out _,
+                    out float pinchAmount))
                 {
                     // Workaround for missing select actions on devices without interaction profiles
                     // for hands, such as Varjo and Quest. Should be removed once we have universal
@@ -285,28 +277,6 @@ namespace MixedReality.Toolkit.Input
         }
 
         /// <summary>
-        /// Update the cached "is valid" states of the selection action and selection action value.
-        /// </summary>
-        /// <remarks>
-        /// If actions are not considered "valid", the actions are considered "polyfilled", and the
-        /// HandsAggregator subsystem should be used to determine selection state and value.
-        /// </remarks>
-        private void UpdateActionValidCaches()
-        {
-            m_isSelectionActionValidCache = selectAction.action.HasAnyControls();
-            m_isSelectionActionValueValidCache = selectActionValue.action.HasAnyControls();
-        }
-
-        /// <summary>
-        /// Check if the device pose is a polyfill device pose. If polyfill device pose is true,
-        /// this means the pose is being driven by the HandsAggregator subsystem.
-        /// </summary>
-        private bool GetIsPolyfillDevicePose()
-        {
-            return trackedPoseDriver != null && trackedPoseDriver.GetIsPolyfillDevicePose();
-        }
-
-        /// <summary>
         /// Apply and enable the new action property if the application is running and this component is enabled.
         /// </summary>
         private void SetInputActionProperty(ref InputActionProperty property, InputActionProperty value)
@@ -323,6 +293,7 @@ namespace MixedReality.Toolkit.Input
                 property.EnableDirectAction();
             }
         }
+
         #endregion Private Functions
     }
 }

--- a/org.mixedrealitytoolkit.input/Readers/PinchInputReader.cs
+++ b/org.mixedrealitytoolkit.input/Readers/PinchInputReader.cs
@@ -148,7 +148,7 @@ namespace MixedReality.Toolkit.Input
             if (m_firstUpdate)
             {
                 UpdateActionValidCaches();
-                m_firstUpdate = false;                
+                m_firstUpdate = false;
             }
 
             // Workaround for missing select actions on devices without interaction profiles
@@ -287,43 +287,14 @@ namespace MixedReality.Toolkit.Input
         /// <summary>
         /// Update the cached "is valid" states of the selection action and selection action value.
         /// </summary>
+        /// <remarks>
+        /// If actions are not considered "valid", the actions are considered "polyfilled", and the
+        /// HandsAggregator subsystem should be used to determine selection state and value.
+        /// </remarks>
         private void UpdateActionValidCaches()
         {
-            m_isSelectionActionValidCache = IsSelectionActionValid();
-            m_isSelectionActionValueValidCache = IsSelectionActionValueValid();
-        }
-
-        /// <summary>
-        /// Get if the selection action is attached to a control and the hand is being tracked. If not, the selection state is
-        /// considered "polyfilled" and the HandsAggregator subsystem should be used to determine selection state.
-        /// </summary>
-        private bool IsSelectionActionValid()
-        {
-            return IsActionValid(selectAction.action);
-        }
-
-        /// <summary>
-        /// Get if the selection action value is attached to a control and the hand is being tracked. If not, the selection state is
-        /// considered "polyfilled" and the HandsAggregator subsystem should be used to determine selection value.
-        /// </summary>
-        private bool IsSelectionActionValueValid()
-        {
-            return IsActionValid(selectActionValue.action);
-        }
-
-        /// <summary>
-        /// Get if the action value is attached to a control and the hand is being tracked. If not, the selection state is
-        /// considered "polyfilled" and the HandsAggregator subsystem should be used to determine selection state and value.
-        /// </summary>
-        /// <remarks>
-        /// We need to consider the fact that the action can be bound to a control, but the control may not be active even
-        /// if the tracking state is valid. So we need to check if there's an active control before using the action.
-        /// If there is no active control, this component will fallback to using the HandsAggregator subsystem to determine
-        /// selection press and value.
-        /// </remarks>
-        private bool IsActionValid(InputAction action)
-        {
-            return action != null && action.HasAnyControls();
+            m_isSelectionActionValidCache = selectAction.action.HasAnyControls();
+            m_isSelectionActionValueValidCache = selectActionValue.action.HasAnyControls();
         }
 
         /// <summary>

--- a/org.mixedrealitytoolkit.input/Readers/PinchInputReader.cs
+++ b/org.mixedrealitytoolkit.input/Readers/PinchInputReader.cs
@@ -146,7 +146,7 @@ namespace MixedReality.Toolkit.Input
             m_isSelectValuePolyfilled = !selectActionValue.action.HasAnyControls();
 
             // Workaround for missing select actions on devices without interaction profiles
-            // for hands, such as Varjo and Quest. Should be removed once we have universal
+            // for hands, such as Quest. Should be removed once we have universal
             // hand interaction profile(s) across vendors.
             if (m_isTrackingStatePolyfilled || m_isSelectPolyfilled || m_isSelectValuePolyfilled)
             {

--- a/org.mixedrealitytoolkit.input/Tracking/TrackedPoseDriverExtensions.cs
+++ b/org.mixedrealitytoolkit.input/Tracking/TrackedPoseDriverExtensions.cs
@@ -57,7 +57,7 @@ namespace MixedReality.Toolkit.Input
         }
 
         /// <summary>
-        /// Get if the last pose set was from a polyfill device pose. 
+        /// Get if the last pose set was from a polyfill device pose.
         /// </summary>
         /// <returns>
         /// Returns <see langword="true"/> if the last pose originated from the <see cref="XRSubsystemHelpers.HandsAggregator "/>.
@@ -81,7 +81,7 @@ namespace MixedReality.Toolkit.Input
         /// <see cref="InputTrackingState.Rotation"/>`. If the action is disabled, it will return `<see cref="InputTrackingState.None"/>`. If the action has controls, it will return the value of the action.
         /// </remarks>
         internal static InputTrackingState GetInputTrackingStateNoCache(this TrackedPoseDriver driver)
-        {           
+        {
             return GetInputTrackingState(driver.trackingStateInput);
         }
 

--- a/org.mixedrealitytoolkit.input/Utilities/InputActionExtensions.cs
+++ b/org.mixedrealitytoolkit.input/Utilities/InputActionExtensions.cs
@@ -13,6 +13,11 @@ namespace MixedReality.Toolkit.Input
         /// <summary>
         /// Checks if any active controls match this InputAction's bindings.
         /// </summary>
+        /// <remarks>
+        /// We need to consider the fact that the action can be bound to a control, but the control may not be active even
+        /// if the tracking state is valid. So we need to check if there's an active control before using the action.
+        /// If there is no active control, MRTK will need to provide a fallback or known failure state.
+        /// </remarks>
         /// <returns><see langword="true"/> if <paramref name="action"/> is non-null and there are any number of controls matching its bindings.</returns>
         public static bool HasAnyControls(this InputAction action)
         {


### PR DESCRIPTION
Fixes https://github.com/MixedRealityToolkit/MixedRealityToolkit-Unity/issues/885

Since we were caching the input action availability once on startup, it became impossible to switch between input actions and the polyfill fallback, such as when switching between hands and controllers on a device that doesn't support a hand interaction profile or in an app that doesn't have a hand interaction profile enabled.

This PR updates the input reader logic to check the input action availability once each frame, caching that value for all subsequent uses in the same frame. Since this MonoBehaviour runs at position `k_XRInputDeviceButtonReader = -31000`, it's basically the first thing that runs and it's guaranteed to cache these values before any of it's `Read` methods are called.