### PR TITLE
Update patch versions of packages that failed to publish to UPM

### DIFF
--- a/org.mixedrealitytoolkit.audio/CHANGELOG.md
+++ b/org.mixedrealitytoolkit.audio/CHANGELOG.md
@@ -2,7 +2,13 @@
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
-## [3.0.3-development] - 2024-04-17
+## [3.0.4-development] - 2024-08-29
+
+### Changed
+
+* Package patch version update to allow UPM publishing
+
+## [3.0.3] - 2024-04-17
 
 ### Fixed
 

--- a/org.mixedrealitytoolkit.audio/package.json
+++ b/org.mixedrealitytoolkit.audio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "org.mixedrealitytoolkit.audio",
-  "version": "3.0.3-development",
+  "version": "3.0.4-development",
   "description": "Features to enhance audio in xr experiences.\n\nFor the audio effects to be spatialized, a spatializer plugin must be imported into the project. Spatializer plugins may be platform specific.",
   "displayName": "MRTK Audio Effects",
   "msftFeatureCategory": "MRTK3",

--- a/org.mixedrealitytoolkit.extendedassets/CHANGELOG.md
+++ b/org.mixedrealitytoolkit.extendedassets/CHANGELOG.md
@@ -2,7 +2,13 @@
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
-## [3.0.2-development] - 2024-03-20
+## [3.0.3-development] - 2024-08-29
+
+### Changed
+
+* Package patch version update to allow UPM publishing
+
+## [3.0.2] - 2024-03-20
 
 ### Fixed
 

--- a/org.mixedrealitytoolkit.extendedassets/package.json
+++ b/org.mixedrealitytoolkit.extendedassets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "org.mixedrealitytoolkit.extendedassets",
-  "version": "3.0.2-development",
+  "version": "3.0.3-development",
   "description": "This package offers additional assets helpful for example scenes or rapid prototyping. These assets are in addition to the more commonly-used assets located in StandardAssets.",
   "displayName": "MRTK Extended Assets",
   "msftFeatureCategory": "MRTK3",

--- a/org.mixedrealitytoolkit.tools/CHANGELOG.md
+++ b/org.mixedrealitytoolkit.tools/CHANGELOG.md
@@ -2,7 +2,13 @@
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
-## [3.0.3-development] - 2024-04-17
+## [3.0.4-development] - 2024-08-29
+
+### Changed
+
+* Package patch version update to allow UPM publishing
+
+## [3.0.3] - 2024-04-17
 
 ### Fixed
 

--- a/org.mixedrealitytoolkit.tools/package.json
+++ b/org.mixedrealitytoolkit.tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "org.mixedrealitytoolkit.tools",
-  "version": "3.0.3-development",
+  "version": "3.0.4-development",
   "description": "A collection of tools, utilities, and wizards that can be used to create and analyze components for use with MRTK3.",
   "displayName": "MRTK Tools",
   "msftFeatureCategory": "MRTK3",

--- a/org.mixedrealitytoolkit.uxcomponents.noncanvas/CHANGELOG.md
+++ b/org.mixedrealitytoolkit.uxcomponents.noncanvas/CHANGELOG.md
@@ -2,7 +2,13 @@
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
-## [3.1.3-development] - 2024-04-17
+## [3.1.4-development] - 2024-08-29
+
+### Changed
+
+* Package patch version update to allow UPM publishing
+
+## [3.1.3] - 2024-04-17
 
 ### Fixed
 

--- a/org.mixedrealitytoolkit.uxcomponents.noncanvas/package.json
+++ b/org.mixedrealitytoolkit.uxcomponents.noncanvas/package.json
@@ -1,6 +1,6 @@
 {
   "name": "org.mixedrealitytoolkit.uxcomponents.noncanvas",
-  "version": "3.1.3-development",
+  "version": "3.1.4-development",
   "description": "UX component library for 3D UX without Canvas layout. In some cases, non-Canvas UI may offer better performance.",
   "displayName": "MRTK UX Components (Non-Canvas)",
   "msftFeatureCategory": "MRTK3",

--- a/org.mixedrealitytoolkit.uxcore/CHANGELOG.md
+++ b/org.mixedrealitytoolkit.uxcore/CHANGELOG.md
@@ -2,7 +2,13 @@
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
-## [3.2.1-development] - 2024-04-23
+## [3.2.2-development] - 2024-08-29
+
+### Changed
+
+* Package patch version update to allow UPM publishing
+
+## [3.2.1] - 2024-04-23
 
 ### Fixed
 

--- a/org.mixedrealitytoolkit.uxcore/package.json
+++ b/org.mixedrealitytoolkit.uxcore/package.json
@@ -1,6 +1,6 @@
 {
   "name": "org.mixedrealitytoolkit.uxcore",
-  "version": "3.2.1-development",
+  "version": "3.2.2-development",
   "description": "Core interaction and visualization scripts for building MR UI components. Intended to be consumed when building UX libraries. For pre-existing library of components see the UX Components package.",
   "displayName": "MRTK UX Core Scripts",
   "msftFeatureCategory": "MRTK3",


### PR DESCRIPTION
When a package fails to publish to UPM, a new patch release version is required for each subsequent retry.  