### PR TITLE
Increase job timeout now that SDL runs in all phases of the RC

### DIFF
--- a/Pipelines/rc.yaml
+++ b/Pipelines/rc.yaml
@@ -71,7 +71,7 @@ extends:
     - stage: 'Build'
       jobs:
       - job: UnityValidation
-
+        timeoutInMinutes: 120
         steps:
         - checkout: self
         - checkout: PipelineTools


### PR DESCRIPTION
Increase job timeout now that SDL runs in all phases of the RC