### PR TITLE
StateVisualizer: Add protected access to some internal members to allow subclassing to add new states

### DIFF
--- a/org.mixedrealitytoolkit.uxcore/CHANGELOG.md
+++ b/org.mixedrealitytoolkit.uxcore/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [3.3.2-development] - 2024-09-12
+
+### Changed
+
+* StateVisualizer: Modified access modifiers of State, stateContainers and UpdateStateValue to protected internal to allow adding states through subclassing. [PR #926](https://github.com/MixedRealityToolkit/MixedRealityToolkit-Unity/pull/926)
+
 ## [3.2.2-development] - 2024-08-29
 
 ### Changed

--- a/org.mixedrealitytoolkit.uxcore/CHANGELOG.md
+++ b/org.mixedrealitytoolkit.uxcore/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
-## [3.3.2-development] - 2024-09-12
+## [3.3.0-development] - 2024-09-12
 
 ### Changed
 

--- a/org.mixedrealitytoolkit.uxcore/StateVisualizer/StateVisualizer.cs
+++ b/org.mixedrealitytoolkit.uxcore/StateVisualizer/StateVisualizer.cs
@@ -41,7 +41,7 @@ namespace MixedReality.Toolkit.UX
         /// the value is submitted.
         /// </remarks>
         [Serializable]
-        internal class State
+        protected internal class State
         {
             [SerializeReference]
             [Tooltip("The list of effects to apply.")]
@@ -87,7 +87,7 @@ namespace MixedReality.Toolkit.UX
         /// The collection of feedback states that this <see cref="StateVisualizer"/> operates on.
         /// </summary>
         [SerializeField]
-        internal SerializableDictionary<string, State> stateContainers = new SerializableDictionary<string, State>();
+        protected internal SerializableDictionary<string, State> stateContainers = new SerializableDictionary<string, State>();
 
         // Default states that are written at validation + startup.
         private readonly Dictionary<string, State> defaultStates = new Dictionary<string, State>()
@@ -422,7 +422,7 @@ namespace MixedReality.Toolkit.UX
         /// <returns>
         /// <see langword="true"/> if the parameter was changed this frame, <see langword="false"/> if it remained constant.
         /// </returns>
-        internal bool UpdateStateValue(string stateName, float newValue)
+        protected internal bool UpdateStateValue(string stateName, float newValue)
         {
             if (stateContainers.TryGetValue(stateName, out var state))
             {

--- a/org.mixedrealitytoolkit.uxcore/package.json
+++ b/org.mixedrealitytoolkit.uxcore/package.json
@@ -1,6 +1,6 @@
 {
   "name": "org.mixedrealitytoolkit.uxcore",
-  "version": "3.3.2-development",
+  "version": "3.3.0-development",
   "description": "Core interaction and visualization scripts for building MR UI components. Intended to be consumed when building UX libraries. For pre-existing library of components see the UX Components package.",
   "displayName": "MRTK UX Core Scripts",
   "msftFeatureCategory": "MRTK3",

--- a/org.mixedrealitytoolkit.uxcore/package.json
+++ b/org.mixedrealitytoolkit.uxcore/package.json
@@ -1,6 +1,6 @@
 {
   "name": "org.mixedrealitytoolkit.uxcore",
-  "version": "3.2.2-development",
+  "version": "3.3.2-development",
   "description": "Core interaction and visualization scripts for building MR UI components. Intended to be consumed when building UX libraries. For pre-existing library of components see the UX Components package.",
   "displayName": "MRTK UX Core Scripts",
   "msftFeatureCategory": "MRTK3",


### PR DESCRIPTION
StateVisualizer: Add protected access to some internal members to allow subclassing to add new states

resolves #925