### PR TITLE
Add debug reference to "this" in ToggleCollection

### DIFF
--- a/org.mixedrealitytoolkit.uxcore/Toggle/ToggleCollection.cs
+++ b/org.mixedrealitytoolkit.uxcore/Toggle/ToggleCollection.cs
@@ -158,7 +158,7 @@ namespace MixedReality.Toolkit.UX
         {
             if (index < 0 || Toggles.Count <= index || Toggles == null || !isActiveAndEnabled)
             {
-                Debug.LogWarning("Index out of range of ToggleCollection: " + index);
+                Debug.LogWarning("Index out of range of ToggleCollection: " + index, this);
                 return;
             }
 


### PR DESCRIPTION
Minor change: added debug reference to "this" in ToggleCollection.

This permit developer to click on the debug log in the console and Unity focus the component responsible for the warning.
I had this warning but couldn't know from where it was comming (I have multiples ToggleCollection in scene).