### PR TITLE
Update tools commit ref to use new script to create the config file

### DIFF
--- a/Pipelines/ci.yaml
+++ b/Pipelines/ci.yaml
@@ -18,7 +18,7 @@ resources:
       type: git
       endpoint: ToolsAccess
       name: tools.internal
-      ref: 78ecf591964ecf511b4c7a0cd84d98ce11e8be16
+      ref: 9f54deb8134c5c910a302c5d70f61a3dc5ffc6fa
     - repository: DocToolUnityProject
       type: git
       endpoint: ToolsAccess

--- a/Pipelines/pr.yaml
+++ b/Pipelines/pr.yaml
@@ -12,7 +12,7 @@ resources:
       type: git
       endpoint: ToolsAccess
       name: tools.internal
-      ref: 78ecf591964ecf511b4c7a0cd84d98ce11e8be16
+      ref: 9f54deb8134c5c910a302c5d70f61a3dc5ffc6fa
 
 trigger: none # disable CI
 

--- a/Pipelines/rc.yaml
+++ b/Pipelines/rc.yaml
@@ -36,7 +36,7 @@ resources:
     type: git
     endpoint: ToolsAccess
     name: tools.internal
-    ref: 78ecf591964ecf511b4c7a0cd84d98ce11e8be16
+    ref: 9f54deb8134c5c910a302c5d70f61a3dc5ffc6fa
   - repository: DocToolUnityProject
     type: git
     endpoint: ToolsAccess


### PR DESCRIPTION
Tools repo has changed to use a script to create the unity license config file.  This updates the commit reference to use the new script.