### PR TITLE
Remove checkout of tools.internal repo

### DIFF
--- a/Pipelines/Templates/1ES/unity.yaml
+++ b/Pipelines/Templates/1ES/unity.yaml
@@ -16,7 +16,7 @@ parameters:
 
   - name: PathToProject
     type: string
-    default: $(Build.SourcesDirectory)/UnityProjects/MRTKDevTemplate
+    default: $(Build.SourcesDirectory)/MixedRealityToolkit-Unity/UnityProjects/MRTKDevTemplate
 
   - name: RunTests
     type: boolean

--- a/Pipelines/Templates/1ES/unity.yaml
+++ b/Pipelines/Templates/1ES/unity.yaml
@@ -16,7 +16,7 @@ parameters:
 
   - name: PathToProject
     type: string
-    default: $(Build.SourcesDirectory)/MixedRealityToolkit-Unity/UnityProjects/MRTKDevTemplate
+    default: $(Build.SourcesDirectory)/UnityProjects/MRTKDevTemplate
 
   - name: RunTests
     type: boolean

--- a/Pipelines/Templates/docs.yaml
+++ b/Pipelines/Templates/docs.yaml
@@ -10,6 +10,9 @@ parameters:
   outputDirectory: $(Build.ArtifactStagingDirectory)/docs
 
 steps:
+
+- template: license-unity.yaml
+
 - task: PowerShell@2
   displayName: 'Update package versions'
   inputs:

--- a/Pipelines/Templates/license-unity.yaml
+++ b/Pipelines/Templates/license-unity.yaml
@@ -1,0 +1,24 @@
+steps:
+- pwsh: |
+    $ConfigContent = @"
+    {
+        "licensingServiceBaseUrl": "http://10.0.0.4:33592",
+        "enableEntitlementLicensing": true,
+        "clientConnectTimeoutSec": 35,
+        "clientHandshakeTimeoutSec": 35,
+        "clientResolveEntitlementsTimeoutSec": 35,
+        "clientUpdateLicenseTimeoutSec": 35
+    }
+    "@
+
+    $ConfigPath = "C:\ProgramData\Unity\config\services-config.json"
+
+    # Ensure the directory exists
+    $Directory = Split-Path -Path $ConfigPath -Parent
+    If (!(Test-Path -Path $Directory)) {
+        New-Item -ItemType Directory -Path $Directory
+    }
+
+    # Create the config file
+    Set-Content -Path $ConfigPath -Value $ConfigContent
+  displayName: Create Unity license config file

--- a/Pipelines/Templates/unity.yaml
+++ b/Pipelines/Templates/unity.yaml
@@ -16,7 +16,7 @@ parameters:
 
   - name: PathToProject
     type: string
-    default: $(Build.SourcesDirectory)/UnityProjects/MRTKDevTemplate
+    default: $(Build.SourcesDirectory)/MixedRealityToolkit-Unity/UnityProjects/MRTKDevTemplate
 
   - name: RunTests
     type: boolean

--- a/Pipelines/Templates/unity.yaml
+++ b/Pipelines/Templates/unity.yaml
@@ -16,7 +16,7 @@ parameters:
 
   - name: PathToProject
     type: string
-    default: $(Build.SourcesDirectory)/MixedRealityToolkit-Unity/UnityProjects/MRTKDevTemplate
+    default: $(Build.SourcesDirectory)/UnityProjects/MRTKDevTemplate
 
   - name: RunTests
     type: boolean

--- a/Pipelines/Templates/unity.yaml
+++ b/Pipelines/Templates/unity.yaml
@@ -38,7 +38,7 @@ steps:
   - pwsh: Install-Module UnitySetup -Scope CurrentUser -Force -AllowPrerelease -RequiredVersion 5.6.161-develop
     displayName: Install unitysetup.powershell
 
-  - template: Templates/license-unity.yaml@PipelineTools
+  - template: license-unity.yaml
 
     # Standalone x64 tasks
 

--- a/Pipelines/ci.yaml
+++ b/Pipelines/ci.yaml
@@ -14,11 +14,6 @@ variables:
 
 resources:
   repositories:
-    - repository: PipelineTools
-      type: git
-      endpoint: ToolsAccess
-      name: tools.internal
-      ref: 9f54deb8134c5c910a302c5d70f61a3dc5ffc6fa
     - repository: DocToolUnityProject
       type: git
       endpoint: ToolsAccess

--- a/Pipelines/ci.yaml
+++ b/Pipelines/ci.yaml
@@ -32,8 +32,7 @@ jobs:
     pool: Unity_2021.3.21f1_Pool
     steps:
       - checkout: self
-
-      - checkout: PipelineTools
+        path: MixedRealityToolkit-Unity
 
       - task: ComponentGovernanceComponentDetection@0
         inputs:
@@ -63,11 +62,8 @@ jobs:
     pool: Unity_2021.3.21f1_Pool
     steps:
       - checkout: self
-
-      - checkout: PipelineTools
+        path: MixedRealityToolkit-Unity
 
       - checkout: DocToolUnityProject
-
-      - template: Templates/license-unity.yaml@PipelineTools
 
       - template: Templates/docs.yaml

--- a/Pipelines/pr.yaml
+++ b/Pipelines/pr.yaml
@@ -6,14 +6,6 @@
 variables:
   - template: Config/settings.yaml
 
-resources:
-  repositories:
-    - repository: PipelineTools
-      type: git
-      endpoint: ToolsAccess
-      name: tools.internal
-      ref: 9f54deb8134c5c910a302c5d70f61a3dc5ffc6fa
-
 trigger: none # disable CI
 
 stages:

--- a/Pipelines/pr.yaml
+++ b/Pipelines/pr.yaml
@@ -16,6 +16,7 @@ stages:
         steps:
           - checkout: self
             fetchDepth: 3
+            path: MixedRealityToolkit-Unity
 
           - template: Templates/unity.yaml
             parameters:
@@ -27,6 +28,7 @@ stages:
         steps:
           - checkout: self
             fetchDepth: 3
+            path: MixedRealityToolkit-Unity
 
           - template: Templates/unity.yaml
             parameters:
@@ -37,6 +39,7 @@ stages:
         steps:
           - checkout: self
             fetchDepth: 3
+            path: MixedRealityToolkit-Unity
 
           - template: Templates/unity.yaml
             parameters:

--- a/Pipelines/pr.yaml
+++ b/Pipelines/pr.yaml
@@ -17,8 +17,6 @@ stages:
           - checkout: self
             fetchDepth: 3
 
-          - checkout: PipelineTools
-
           - template: Templates/unity.yaml
             parameters:
               Platform: Standalone
@@ -30,8 +28,6 @@ stages:
           - checkout: self
             fetchDepth: 3
 
-          - checkout: PipelineTools
-
           - template: Templates/unity.yaml
             parameters:
               Platform: UWP
@@ -41,8 +37,6 @@ stages:
         steps:
           - checkout: self
             fetchDepth: 3
-
-          - checkout: PipelineTools
 
           - template: Templates/unity.yaml
             parameters:

--- a/Pipelines/rc.yaml
+++ b/Pipelines/rc.yaml
@@ -32,11 +32,7 @@ resources:
     type: git
     name: 1ESPipelineTemplates/1ESPipelineTemplates
     ref: refs/tags/release
-  - repository: PipelineTools
-    type: git
-    endpoint: ToolsAccess
-    name: tools.internal
-    ref: 9f54deb8134c5c910a302c5d70f61a3dc5ffc6fa
+
   - repository: DocToolUnityProject
     type: git
     endpoint: ToolsAccess
@@ -74,7 +70,6 @@ extends:
         timeoutInMinutes: 120
         steps:
         - checkout: self
-        - checkout: PipelineTools
         - checkout: DocToolUnityProject
 
         - powershell: Get-ChildItem -Path $(Build.SourcesDirectory) -recurse
@@ -85,9 +80,6 @@ extends:
 
         - pwsh: Install-Module UnitySetup -Scope CurrentUser -Force -AllowPrerelease -RequiredVersion 5.6.161-develop
           displayName: Install unitysetup.powershell
-
-        - template: Templates/license-unity.yaml@PipelineTools
-
 
         - template: /Pipelines/Templates/1ES/unity.yaml@self
           parameters:


### PR DESCRIPTION
This PR changes the build so we no longer need to checkout the tools.internal repo.  The necessary template to create the unity license config file moves to the pipelines\templates folder in the toolkit repo.