### PR TITLE
Update all builds to work without tool repo

### DIFF
--- a/Pipelines/Templates/1ES/unity.yaml
+++ b/Pipelines/Templates/1ES/unity.yaml
@@ -16,7 +16,7 @@ parameters:
 
   - name: PathToProject
     type: string
-    default: $(Build.SourcesDirectory)/UnityProjects/MRTKDevTemplate
+    default: $(Build.SourcesDirectory)/MixedRealityToolkit-Unity/UnityProjects/MRTKDevTemplate
 
   - name: RunTests
     type: boolean
@@ -33,6 +33,8 @@ parameters:
 
 steps:
 
+
+  - template: /Pipelines/Templates/license-unity.yaml
 
     # Standalone x64 tasks
 

--- a/Pipelines/Templates/unity.yaml
+++ b/Pipelines/Templates/unity.yaml
@@ -16,7 +16,7 @@ parameters:
 
   - name: PathToProject
     type: string
-    default: $(Build.SourcesDirectory)/UnityProjects/MRTKDevTemplate
+    default: $(Build.SourcesDirectory)/MixedRealityToolkit-Unity/UnityProjects/MRTKDevTemplate
 
   - name: RunTests
     type: boolean

--- a/Pipelines/ci.yaml
+++ b/Pipelines/ci.yaml
@@ -27,7 +27,7 @@ jobs:
     pool: Unity_2021.3.21f1_Pool
     steps:
       - checkout: self
-        path: MixedRealityToolkit-Unity
+      - checkout: DocToolUnityProject
 
       - task: ComponentGovernanceComponentDetection@0
         inputs:
@@ -57,7 +57,6 @@ jobs:
     pool: Unity_2021.3.21f1_Pool
     steps:
       - checkout: self
-        path: MixedRealityToolkit-Unity
 
       - checkout: DocToolUnityProject
 

--- a/Pipelines/pr.yaml
+++ b/Pipelines/pr.yaml
@@ -16,31 +16,31 @@ stages:
         steps:
           - checkout: self
             fetchDepth: 3
-            path: MixedRealityToolkit-Unity
 
           - template: Templates/unity.yaml
             parameters:
               Platform: Standalone
               RunTests: true
+              PathToProject: $(Build.SourcesDirectory)/UnityProjects/MRTKDevTemplate
 
       - job: BuildUWP
         pool: Unity_2021.3.21f1_Pool
         steps:
           - checkout: self
             fetchDepth: 3
-            path: MixedRealityToolkit-Unity
 
           - template: Templates/unity.yaml
             parameters:
               Platform: UWP
+              PathToProject: $(Build.SourcesDirectory)/UnityProjects/MRTKDevTemplate
 
       - job: BuildAndroid
         pool: Unity_2021.3.21f1_Pool
         steps:
           - checkout: self
             fetchDepth: 3
-            path: MixedRealityToolkit-Unity
 
           - template: Templates/unity.yaml
             parameters:
               Platform: Android
+              PathToProject: $(Build.SourcesDirectory)/UnityProjects/MRTKDevTemplate

--- a/Pipelines/rc.yaml
+++ b/Pipelines/rc.yaml
@@ -72,8 +72,6 @@ extends:
         - checkout: self
         - checkout: DocToolUnityProject
 
-        - powershell: Get-ChildItem -Path $(Build.SourcesDirectory) -recurse
-          displayName: 'Initial source tree'
 
         - pwsh: Install-Module PowerShellGet -Force
           displayName: Update PowerShellGet


### PR DESCRIPTION
Changes to the project path were necessary after removing the tools repo checkout.
Tested by running builds on the user/shaynie/testBuild branch.