### PR TITLE
Fix error message spamming when selecting PressableButtons in Editor

### DIFF
--- a/org.mixedrealitytoolkit.core/CHANGELOG.md
+++ b/org.mixedrealitytoolkit.core/CHANGELOG.md
@@ -2,11 +2,12 @@
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
-## [3.3.0-development] - 2024-06-24
+## [3.2.3-development] - 2024-06-24
 
 ### Fixed
 
-* Fixed broken project validation help link, for item 'MRTK3 profile may need to be assigned for the Standalone build target' (Issue #882) [PR#886 (https://github.com/MixedRealityToolkit/MixedRealityToolkit-Unity/pull/886)]
+* Fixed broken project validation help link, for item 'MRTK3 profile may need to be assigned for the Standalone build target' (Issue #882) [PR #886] (https://github.com/MixedRealityToolkit/MixedRealityToolkit-Unity/pull/886)
+* Fixed the "Is Interactable" convenience alias on StatefulInteractableEditor to allow multi-object editing in the Inspector to update all values. (Issue #573) [PR #943] (https://github.com/MixedRealityToolkit/MixedRealityToolkit-Unity/pull/943)
 
 ## [3.2.2-development] - 2024-06-13
 

--- a/org.mixedrealitytoolkit.core/CHANGELOG.md
+++ b/org.mixedrealitytoolkit.core/CHANGELOG.md
@@ -6,8 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
-* Fixed broken project validation help link, for item 'MRTK3 profile may need to be assigned for the Standalone build target' (Issue #882) [PR #886] (https://github.com/MixedRealityToolkit/MixedRealityToolkit-Unity/pull/886)
-* Fixed the "Is Interactable" convenience alias on StatefulInteractableEditor to allow multi-object editing in the Inspector to update all values. (Issue #573) [PR #943] (https://github.com/MixedRealityToolkit/MixedRealityToolkit-Unity/pull/943)
+* Fixed broken project validation help link, for item 'MRTK3 profile may need to be assigned for the Standalone build target' (Issue #882) [PR #886](https://github.com/MixedRealityToolkit/MixedRealityToolkit-Unity/pull/886)
+* Fixed the "Is Interactable" convenience alias on StatefulInteractableEditor to allow multi-object editing in the Inspector to update all values. (Issue #573) [PR #943](https://github.com/MixedRealityToolkit/MixedRealityToolkit-Unity/pull/943)
 
 ## [3.2.2-development] - 2024-06-13
 

--- a/org.mixedrealitytoolkit.core/Editor/Editors/StatefulInteractableEditor.cs
+++ b/org.mixedrealitytoolkit.core/Editor/Editors/StatefulInteractableEditor.cs
@@ -13,6 +13,7 @@ namespace MixedReality.Toolkit.Editor
     [CanEditMultipleObjects]
     public class StatefulInteractableEditor : BaseInteractableEditor
     {
+        private SerializedProperty IsInteractable;
         private SerializedProperty IsToggled;
         private SerializedProperty IsToggledStateActive;
         private SerializedProperty SelectThreshold;
@@ -41,6 +42,9 @@ namespace MixedReality.Toolkit.Editor
         protected override void OnEnable()
         {
             base.OnEnable();
+
+            // IsInteractable is a convenience alias for the built-in StatefulInteractable.enabled property.
+            IsInteractable = serializedObject.FindProperty("m_Enabled");
 
             IsToggled = SetUpAutoProperty(nameof(IsToggled));
             IsToggledStateActive = IsToggled.FindPropertyRelative("active");
@@ -91,12 +95,9 @@ namespace MixedReality.Toolkit.Editor
 
             StatefulInteractable interactable = target as StatefulInteractable;
 
-            bool interactableActive = EditorGUILayout.Toggle(new GUIContent("Is Interactable", "Convenience alias for StatefulInteractable.enabled"), interactable.enabled);
-
-            if (interactableActive != (target as StatefulInteractable).enabled)
+            if (IsInteractable != null)
             {
-                Undo.RecordObject(target, string.Concat("Set Interactable ", target.name));
-                interactable.enabled = interactableActive;
+                EditorGUILayout.PropertyField(IsInteractable, new GUIContent("Is Interactable", "Convenience alias for StatefulInteractable.enable"));
             }
 
             // Only show toggle settings if the subclass hasn't told us not to.

--- a/org.mixedrealitytoolkit.core/package.json
+++ b/org.mixedrealitytoolkit.core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "org.mixedrealitytoolkit.core",
-  "version": "3.2.2-development",
+  "version": "3.2.3-development",
   "description": "A limited collection of common interfaces and utilities that most MRTK packages share. Most implementations of these interfaces are contained in other packages in the MRTK ecosystem.",
   "displayName": "MRTK Core Definitions",
   "msftFeatureCategory": "MRTK3",

--- a/org.mixedrealitytoolkit.uxcore/CHANGELOG.md
+++ b/org.mixedrealitytoolkit.uxcore/CHANGELOG.md
@@ -10,7 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
-* Fixed an issue when selecting a PressableButton in Editor scene view causing error spam. (Issue #772) [PR #943] (https://github.com/MixedRealityToolkit/MixedRealityToolkit-Unity/pull/943)
+* Fixed an issue when selecting a PressableButton in Editor scene view causing error spam. (Issue #772) [PR #943](https://github.com/MixedRealityToolkit/MixedRealityToolkit-Unity/pull/943)
 
 ## [3.2.2-development] - 2024-08-29
 

--- a/org.mixedrealitytoolkit.uxcore/CHANGELOG.md
+++ b/org.mixedrealitytoolkit.uxcore/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 * StateVisualizer: Modified access modifiers of State, stateContainers and UpdateStateValue to protected internal to allow adding states through subclassing. [PR #926](https://github.com/MixedRealityToolkit/MixedRealityToolkit-Unity/pull/926)
 
+### Fixed
+
+* Fixed an issue when selecting a PressableButton in Editor scene view causing error spam. (Issue #772) [PR #943] (https://github.com/MixedRealityToolkit/MixedRealityToolkit-Unity/pull/943)
+
 ## [3.2.2-development] - 2024-08-29
 
 ### Changed

--- a/org.mixedrealitytoolkit.uxcore/Editor/Inspectors/PressableButton/PressableButtonInspector.cs
+++ b/org.mixedrealitytoolkit.uxcore/Editor/Inspectors/PressableButton/PressableButtonInspector.cs
@@ -101,7 +101,6 @@ namespace MixedReality.Toolkit.Editor
                 return;
             }
 
-            serializedObject.Update();
             currentInfo = GatherCurrentInfo();
             DrawButtonInfo(currentInfo, EditingEnabled);
         }


### PR DESCRIPTION
* Also fixes multi-object modification of "Is Interactable" convenience alias for StatefulInteractable.enabled.

The previous fix to #573 , which was #698, supposedly caused #772.  This should fix both.

Fixes #772
Fixes #573 