### PR TITLE
[feature/XRI3] Augment SerializableDictionary to allow temporary duplicates in Editor

### DIFF
--- a/org.mixedrealitytoolkit.core/Utilities/SerializableDictionary.cs
+++ b/org.mixedrealitytoolkit.core/Utilities/SerializableDictionary.cs
@@ -21,23 +21,78 @@ namespace MixedReality.Toolkit
 
         void ISerializationCallbackReceiver.OnBeforeSerialize()
         {
+#if !UNITY_EDITOR
             entries.Clear();
 
             foreach (KeyValuePair<TKey, TValue> pair in this)
             {
                 entries.Add(new SerializableDictionaryEntry(pair.Key, pair.Value));
             }
+#else
+            // While in Editor, the serialized entries list is managed differently and is not necessarily a 1:1 representation of
+            // the dictionary.  This allows for temporary duplicate keys, something the dictionary cannot do, while modifications
+            // are being made in the Inspector since the default behavior is to duplicate the last entry when adding a new one.
+
+            // Override the first entry that has a matching key from the dictionary, otherwise add to entries.
+            foreach (KeyValuePair<TKey, TValue> pair in this)
+            {
+                if (TryFindSerializableIndex(pair.Key, out int index))
+                {
+                    entries[index] = new SerializableDictionaryEntry(pair.Key, pair.Value);
+                }
+                else
+                {
+                    entries.Add(new SerializableDictionaryEntry(pair.Key, pair.Value));
+                }
+            }
+#endif
         }
 
         void ISerializationCallbackReceiver.OnAfterDeserialize()
         {
-            this.Clear();
+            base.Clear();
 
             foreach (SerializableDictionaryEntry entry in entries)
             {
-                this.Add(entry.Key, entry.Value);
+                base.TryAdd(entry.Key, entry.Value);
             }
         }
+
+#if UNITY_EDITOR
+        public new void Clear()
+        {
+            entries.Clear();
+            base.Clear();
+        }
+
+        public new bool Remove(TKey key, out TValue value)
+        {
+            if (base.Remove(key, out value))
+            {
+                if (TryFindSerializableIndex(key, out int index))
+                {
+                    entries.RemoveAt(index);
+                }
+
+                return true;
+            }
+
+            return false;
+        }
+
+        public new bool Remove(TKey key)
+        {
+            return Remove(key, out _);
+        }
+
+        private bool TryFindSerializableIndex(TKey key, out int index)
+        {
+            var keyComparer = EqualityComparer<TKey>.Default;
+
+            index = entries.FindIndex((entry) => keyComparer.Equals(entry.Key, key));
+            return index != -1;
+        }
+#endif
 
         [Serializable]
         private struct SerializableDictionaryEntry

--- a/org.mixedrealitytoolkit.input/InteractionModes/InteractionModeManager.cs
+++ b/org.mixedrealitytoolkit.input/InteractionModes/InteractionModeManager.cs
@@ -75,7 +75,7 @@ namespace MixedReality.Toolkit.Input
         [Obsolete("This method is obsolete. Please use InitializeInteractorGroups instead.")]
         public void InitializeControllers()
         {
-            foreach (XRController xrController in FindObjectUtility.FindObjectsByType<XRController>())
+            foreach (XRBaseController xrController in FindObjectUtility.FindObjectsByType<XRBaseController>())
             {
                 if (!interactorGroupMappings.ContainsKey(xrController.gameObject))
                 {


### PR DESCRIPTION
Fixes #958
(in feature/XRI3 branch)

* Also fixes an issue with the "Init Controllers" type lookup within
  InteractionModeManager.InitializeControllers() to find XRBaseControllers
  instead of XRControllers, since the legacy MRTK controllers derive from
  XRBaseControllers, and the GUI button previously wasn't finding any
  controller to initialize in the Inspector.