### PR TITLE
Update com.microsoft.mrtk.graphicstools.unity to 0.8.0

### DIFF
--- a/UnityProjects/MRTKDevTemplate/Packages/manifest.json
+++ b/UnityProjects/MRTKDevTemplate/Packages/manifest.json
@@ -4,7 +4,7 @@
     "com.atteneder.ktx": "https://github.com/atteneder/KtxUnity.git#v2.1.2",
     "com.microsoft.mixedreality.openxr": "file:../../../ExternalDependencies/com.microsoft.mixedreality.openxr-1.10.0.tgz",
     "com.microsoft.mixedreality.visualprofiler": "https://github.com/microsoft/VisualProfiler-Unity.git#v2.2.0",
-    "com.microsoft.mrtk.graphicstools.unity": "https://github.com/microsoft/MixedReality-GraphicsTools-Unity.git?path=/com.microsoft.mrtk.graphicstools.unity#v0.6.6",
+    "com.microsoft.mrtk.graphicstools.unity": "https://github.com/microsoft/MixedReality-GraphicsTools-Unity.git?path=/com.microsoft.mrtk.graphicstools.unity#v0.8.0",
     "com.microsoft.mrtk.tts.windows": "file:../../../ExternalDependencies/com.microsoft.mrtk.tts.windows-1.0.4.tgz",
     "com.microsoft.spatialaudio.spatializer.unity": "file:../../../ExternalDependencies/com.microsoft.spatialaudio.spatializer.unity-2.0.55.tgz",
     "org.mixedrealitytoolkit.accessibility": "file:../../../org.mixedrealitytoolkit.accessibility",

--- a/UnityProjects/MRTKDevTemplate/Packages/packages-lock.json
+++ b/UnityProjects/MRTKDevTemplate/Packages/packages-lock.json
@@ -41,11 +41,11 @@
       "hash": "22d727d4d1641c27fa85a7519cf76b81890c8f3d"
     },
     "com.microsoft.mrtk.graphicstools.unity": {
-      "version": "https://github.com/microsoft/MixedReality-GraphicsTools-Unity.git?path=/com.microsoft.mrtk.graphicstools.unity#v0.6.6",
+      "version": "https://github.com/microsoft/MixedReality-GraphicsTools-Unity.git?path=/com.microsoft.mrtk.graphicstools.unity#v0.8.0",
       "depth": 0,
       "source": "git",
       "dependencies": {},
-      "hash": "4497602bcf9d4e7a175cf9d2a2bee9f086a3129c"
+      "hash": "1e4ff5dd9cd8d4df317ec63d08072defb4d0295a"
     },
     "com.microsoft.mrtk.tts.windows": {
       "version": "file:../../../ExternalDependencies/com.microsoft.mrtk.tts.windows-1.0.4.tgz",


### PR DESCRIPTION
* This updates the com.microsoft.mrtk.graphicstools.unity package to version 0.8.0, which matches the latest version published to the Unity Asset Store at this time.
* This update should fix an issue when opening the project in Unity 6 and using URP.

Fixes #953 