### PR TITLE
Update .gitignore to include .utmp folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,6 +58,7 @@ doc/
 # Other files #
 # =========== #
 .DS_Store
+.utmp/
 
 # ================================#
 # MRTK2 for branch switching ease #


### PR DESCRIPTION
With Unity 6, I've started seeing this folder generated when creating Android builds. Adding it to the .gitignore.