### PR TITLE
Don't register an unsupported Windows speech subsystem

### DIFF
--- a/org.mixedrealitytoolkit.core/Subsystems/Speech/KeywordRecognitionSubsystemDescriptor.cs
+++ b/org.mixedrealitytoolkit.core/Subsystems/Speech/KeywordRecognitionSubsystemDescriptor.cs
@@ -2,7 +2,6 @@
 // Licensed under the BSD 3-Clause
 
 using System;
-using UnityEngine.SubsystemsImplementation;
 
 namespace MixedReality.Toolkit.Subsystems
 {
@@ -60,15 +59,15 @@ namespace MixedReality.Toolkit.Subsystems
         /// </returns>
         internal static KeywordRecognitionSubsystemDescriptor Create(KeywordRecognitionSubsystemCinfo cinfo)
         {
-           // Validates cinfo.
-           if (!XRSubsystemHelpers.CheckTypes<KeywordRecognitionSubsystem, KeywordRecognitionSubsystem.Provider>(cinfo.Name,
-                                                                                                               cinfo.SubsystemTypeOverride,
-                                                                                                               cinfo.ProviderType))
-           {
-               throw new ArgumentException("Could not create KeywordRecognitionSubsystemDescriptor.");
-           }
+            // Validates cinfo.
+            if (!XRSubsystemHelpers.CheckTypes<KeywordRecognitionSubsystem, KeywordRecognitionSubsystem.Provider>(cinfo.Name,
+                                                                                                                  cinfo.SubsystemTypeOverride,
+                                                                                                                  cinfo.ProviderType))
+            {
+                throw new ArgumentException("Could not create KeywordRecognitionSubsystemDescriptor.");
+            }
 
-           return new KeywordRecognitionSubsystemDescriptor(cinfo);
+            return new KeywordRecognitionSubsystemDescriptor(cinfo);
         }
     }
 }

--- a/org.mixedrealitytoolkit.input/Interactors/Speech/SpeechInteractor.cs
+++ b/org.mixedrealitytoolkit.input/Interactors/Speech/SpeechInteractor.cs
@@ -72,8 +72,8 @@ namespace MixedReality.Toolkit.Input
                     }
                     else
                     {
-                        Debug.LogError("Failed to retrieve a running KeywordRecognitionSubsystem while registering an interactable. " +
-                            "Please make sure the subsystem is correctly set up or disable this speech interactor.");
+                        Debug.LogWarning("Failed to retrieve a running KeywordRecognitionSubsystem while registering an interactable. " +
+                            "Please make sure the subsystem is correctly set up for this platform or disable this speech interactor if it's unused.");
                     }
                 }
             }

--- a/org.mixedrealitytoolkit.windowsspeech/CHANGELOG.md
+++ b/org.mixedrealitytoolkit.windowsspeech/CHANGELOG.md
@@ -2,7 +2,13 @@
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
-## [3.0.3-development] - 2024-04-17
+## [Unreleased]
+
+### Changed
+
+* Subsystem no longer registers itself on non-Windows platforms.
+
+## [3.0.3] - 2024-04-17
 
 ### Fixed
 

--- a/org.mixedrealitytoolkit.windowsspeech/Subsystems/WindowsKeywordRecognitionSubsystem.cs
+++ b/org.mixedrealitytoolkit.windowsspeech/Subsystems/WindowsKeywordRecognitionSubsystem.cs
@@ -15,7 +15,7 @@ using UnityEngine.Scripting;
 using Microsoft.MixedReality.OpenXR;
 #endif // MSFT_OPENXR_1_5_0_OR_NEWER
 using UnityEngine.Windows.Speech;
-#endif // UNITY_STANDALONE_WIN || UNITY_WSA || UNITY_EDITOR_WIN
+#endif // UNITY_EDITOR_WIN || UNITY_STANDALONE_WIN || UNITY_WSA
 
 namespace MixedReality.Toolkit.Speech.Windows
 {
@@ -43,16 +43,20 @@ namespace MixedReality.Toolkit.Speech.Windows
             // Fetch subsystem metadata from the attribute.
             var cinfo = XRSubsystemHelpers.ConstructCinfo<WindowsKeywordRecognitionSubsystem, KeywordRecognitionSubsystemCinfo>();
 
+#if UNITY_EDITOR_WIN || UNITY_STANDALONE_WIN || UNITY_WSA
             if (!Register(cinfo))
             {
                 Debug.LogError($"Failed to register the {cinfo.Name} subsystem.");
             }
+#else
+            Debug.Log($"Skipping registration of the {cinfo.Name} subsystem due to running on an unsupported platform.");
+#endif
         }
 
         /// <summary>
         /// A subsystem provider used with <see cref="WindowsKeywordRecognitionSubsystem"/> that exposes methods on the
-        /// <see cref="Microsoft.MixedReality.OpenXR.SelectKeywordRecognizer">SelectKeywordRecognizer</see> and Unity's 
-        /// `KeywordRecognizer`. 
+        /// <see cref="Microsoft.MixedReality.OpenXR.SelectKeywordRecognizer">SelectKeywordRecognizer</see> and Unity's
+        /// `KeywordRecognizer`.
         /// </summary>
         [Preserve]
         class WindowsKeywordRecognitionProvider : Provider

--- a/org.mixedrealitytoolkit.windowsspeech/package.json
+++ b/org.mixedrealitytoolkit.windowsspeech/package.json
@@ -1,6 +1,6 @@
 {
   "name": "org.mixedrealitytoolkit.windowsspeech",
-  "version": "3.0.3-development",
+  "version": "3.0.4-development",
   "description": "Speech subsystem implementation for native Windows speech APIs enables native Windows text-to-speech and speech recognition features, producing events to drive XRI interactions using speech.",
   "displayName": "MRTK Windows Speech",
   "msftFeatureCategory": "MRTK3",


### PR DESCRIPTION
`WindowsKeywordRecognitionSubsystem` now checks itself before attempting registration to ensure it'll run on a supported platform.

Fixes this exception on non-Windows platforms:

![{1EA4AD3A-10E9-4DF9-A502-6850FF16450E}](https://github.com/user-attachments/assets/328b280c-9eef-45f3-88d8-9c052d5a1d6b)
