### PR TITLE
Changed the parent of the MRTK Spatial Mouse Controller to the Main Camera, fixing the origin issues with interaction using a mouse

### DIFF
--- a/UnityProjects/MRTKDevTemplate/Assets/Scenes/Experimental/SpatialMouseSample.unity
+++ b/UnityProjects/MRTKDevTemplate/Assets/Scenes/Experimental/SpatialMouseSample.unity
@@ -137,7 +137,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 5604401826787249420, guid: dc525621b8522034e867ed2799129315, type: 3}
       propertyPath: m_RootOrder
-      value: 4
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5604401826787249420, guid: dc525621b8522034e867ed2799129315, type: 3}
       propertyPath: m_LocalPosition.x
@@ -4185,7 +4185,7 @@ PrefabInstance:
   m_SourcePrefab: {fileID: 100100000, guid: acbf65a81ce2cf94f82a0809298acf70, type: 3}
 --- !u!4 &1687818733 stripped
 Transform:
-  m_CorrespondingSourceObject: {fileID: 2351505566903569412, guid: acbf65a81ce2cf94f82a0809298acf70, type: 3}
+  m_CorrespondingSourceObject: {fileID: 2351505566771328526, guid: acbf65a81ce2cf94f82a0809298acf70, type: 3}
   m_PrefabInstance: {fileID: 1687818732}
   m_PrefabAsset: {fileID: 0}
 --- !u!1 &1708103289


### PR DESCRIPTION
Fixes #880

Tested on Quest 3 (native) and Windows with Quest 3 running as a SteamVR headset. 

Bug is as described, the origin of the spatial mouse interaction was the scene origin, meaning that when running in XR the mouse cursor does not move as expected relative to the camera view and scene objects. Setting the MRTK Spatial Mouse Controllers parent to the Main Camera fixes this issue and the mouse works and interacts with elements as expected. 
