### PR TITLE
Add hand tracking permission for AndroidXR

### DIFF
--- a/UnityProjects/MRTKDevTemplate/Assets/XR/XRGeneralSettings.asset
+++ b/UnityProjects/MRTKDevTemplate/Assets/XR/XRGeneralSettings.asset
@@ -16,7 +16,6 @@ MonoBehaviour:
   m_AutomaticLoading: 0
   m_AutomaticRunning: 0
   m_Loaders:
-  - {fileID: 11400000, guid: 702fb985f55d1764190faf519b2a5704, type: 2}
   - {fileID: 11400000, guid: 1aff1d0a357cadb42b05e6d26e0d5f63, type: 2}
 --- !u!114 &-3115139681434547076
 MonoBehaviour:

--- a/org.mixedrealitytoolkit.input/MRTK.Input.asmdef
+++ b/org.mixedrealitytoolkit.input/MRTK.Input.asmdef
@@ -9,7 +9,8 @@
         "Unity.XR.CoreUtils",
         "Unity.XR.Hands",
         "Unity.XR.Interaction.Toolkit",
-        "Unity.XR.Management"
+        "Unity.XR.Management",
+        "Unity.XR.OpenXR"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],
@@ -43,6 +44,11 @@
             "name": "com.unity.xr.management",
             "expression": "4.2",
             "define": "UNITYXR_MANAGEMENT_PRESENT"
+        },
+        {
+            "name": "com.unity.xr.openxr",
+            "expression": "",
+            "define": "UNITY_OPENXR_PRESENT"
         }
     ],
     "noEngineReferences": false

--- a/org.mixedrealitytoolkit.input/Subsystems/Hands/UnityHandsSubsystem.cs
+++ b/org.mixedrealitytoolkit.input/Subsystems/Hands/UnityHandsSubsystem.cs
@@ -64,13 +64,17 @@ namespace MixedReality.Toolkit.Input
             }
         }
 
-        const string HandTrackingPermission = "android.permission.HAND_TRACKING";
+        private const string HandTrackingPermission = "android.permission.HAND_TRACKING";
 
         void OnPermissionDenied(string permission)
         {
             if (permission == HandTrackingPermission)
             {
-                Debug.Log($"{HandTrackingPermission} denied. MRTK hand tracking may not work as expected.");
+                Debug.Log($"{HandTrackingPermission} denied or not needed on this runtime" +
+#if UNITY_OPENXR_PRESENT
+                    $" ({UnityEngine.XR.OpenXR.OpenXRRuntime.name})" +
+#endif
+                    ". MRTK hand tracking may not work as expected.");
             }
         }
 

--- a/org.mixedrealitytoolkit.input/Subsystems/Hands/UnityHandsSubsystem.cs
+++ b/org.mixedrealitytoolkit.input/Subsystems/Hands/UnityHandsSubsystem.cs
@@ -9,6 +9,10 @@ using UnityEngine.Scripting;
 using UnityEngine.XR;
 using UnityEngine.XR.Hands;
 
+#if UNITY_ANDROID
+using UnityEngine.Android;
+#endif
+
 namespace MixedReality.Toolkit.Input
 {
     /// <summary>
@@ -37,6 +41,41 @@ namespace MixedReality.Toolkit.Input
             {
                 Debug.LogError($"Failed to register the {cinfo.Name} subsystem.");
             }
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="UnityHandsSubsystem"/> class.
+        /// </summary>
+        public UnityHandsSubsystem()
+        {
+#if UNITY_ANDROID
+
+            if (!Permission.HasUserAuthorizedPermission(HandTrackingPermission))
+            {
+                var callbacks = new PermissionCallbacks();
+                callbacks.PermissionDenied += OnPermissionDenied;
+                callbacks.PermissionGranted += OnPermissionGranted;
+
+                Permission.RequestUserPermission(HandTrackingPermission, callbacks);
+                Debug.Log($"Requesting {HandTrackingPermission}!");
+            }
+            else
+            {
+                Debug.Log($"{HandTrackingPermission} already granted!");
+            }
+        }
+
+        const string HandTrackingPermission = "android.permission.HAND_TRACKING";
+
+        void OnPermissionDenied(string permission)
+        {
+            Debug.Log($"{HandTrackingPermission} denied :(");
+        }
+
+        void OnPermissionGranted(string permission)
+        {
+            Debug.Log($"{HandTrackingPermission} newly granted! :)");
+#endif // UNITY_ANDROID
         }
 
         private class UnityHandContainer : HandDataContainer

--- a/org.mixedrealitytoolkit.input/Subsystems/Hands/UnityHandsSubsystem.cs
+++ b/org.mixedrealitytoolkit.input/Subsystems/Hands/UnityHandsSubsystem.cs
@@ -49,19 +49,18 @@ namespace MixedReality.Toolkit.Input
         public UnityHandsSubsystem()
         {
 #if UNITY_ANDROID
-
             if (!Permission.HasUserAuthorizedPermission(HandTrackingPermission))
             {
-                var callbacks = new PermissionCallbacks();
+                PermissionCallbacks callbacks = new();
                 callbacks.PermissionDenied += OnPermissionDenied;
                 callbacks.PermissionGranted += OnPermissionGranted;
 
                 Permission.RequestUserPermission(HandTrackingPermission, callbacks);
-                Debug.Log($"Requesting {HandTrackingPermission}!");
+                Debug.Log($"MRTK is requesting {HandTrackingPermission}.");
             }
             else
             {
-                Debug.Log($"{HandTrackingPermission} already granted!");
+                Debug.Log($"{HandTrackingPermission} already granted for MRTK.");
             }
         }
 
@@ -69,12 +68,18 @@ namespace MixedReality.Toolkit.Input
 
         void OnPermissionDenied(string permission)
         {
-            Debug.Log($"{HandTrackingPermission} denied :(");
+            if (permission == HandTrackingPermission)
+            {
+                Debug.Log($"{HandTrackingPermission} denied. MRTK hand tracking may not work as expected.");
+            }
         }
 
         void OnPermissionGranted(string permission)
         {
-            Debug.Log($"{HandTrackingPermission} newly granted! :)");
+            if (permission == HandTrackingPermission)
+            {
+                Debug.Log($"{HandTrackingPermission} newly granted for MRTK.");
+            }
 #endif // UNITY_ANDROID
         }
 


### PR DESCRIPTION
Permission string and general flow from https://docs.unity3d.com/Packages/com.unity.xr.androidxr-openxr@0.4/manual/get-started/permissions.html

Also uncheck ARCore by default in our project setting for ease of using OpenXR.

Confirmed that on other Android runtimes, this simply auto-returns. Added a note to the log that this is an expected case on some runtimes.