### PR TITLE
Add example config helper for Android XR

### DIFF
--- a/UnityProjects/MRTKDevTemplate/Assets/Scripts/Editor.meta
+++ b/UnityProjects/MRTKDevTemplate/Assets/Scripts/Editor.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 4c15ba023d835404c8478e6366c833f2
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnityProjects/MRTKDevTemplate/Assets/Scripts/Editor/AndroidXRConfig.cs
+++ b/UnityProjects/MRTKDevTemplate/Assets/Scripts/Editor/AndroidXRConfig.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Mixed Reality Toolkit Contributors
+// Licensed under the BSD 3-Clause
+
+#if UNITY_6000_0_OR_NEWER
+using UnityEditor;
+using UnityEditor.PackageManager;
+using UnityEngine;
+#endif
+
+internal class AndroidXRConfig
+{
+#if UNITY_6000_0_OR_NEWER
+    [MenuItem("Mixed Reality/MRTK3/Examples/Configure for Android XR...", priority = int.MaxValue)]
+    public static void InstallPackages()
+    {
+        Debug.Log("Adding com.unity.xr.androidxr-openxr and com.google.xr.extensions...");
+        Client.AddAndRemove(new[] { "com.unity.xr.androidxr-openxr", "https://github.com/android/android-xr-unity-package.git" });
+    }
+#endif
+}

--- a/UnityProjects/MRTKDevTemplate/Assets/Scripts/Editor/AndroidXRConfig.cs
+++ b/UnityProjects/MRTKDevTemplate/Assets/Scripts/Editor/AndroidXRConfig.cs
@@ -4,17 +4,36 @@
 #if UNITY_6000_0_OR_NEWER
 using UnityEditor;
 using UnityEditor.PackageManager;
+using UnityEditor.PackageManager.Requests;
 using UnityEngine;
 #endif
 
 internal class AndroidXRConfig
 {
 #if UNITY_6000_0_OR_NEWER
+    private static AddAndRemoveRequest request;
+
     [MenuItem("Mixed Reality/MRTK3/Examples/Configure for Android XR...", priority = int.MaxValue)]
     public static void InstallPackages()
     {
+        // Already a request in progress, so don't re-run
+        if (request != null)
+        {
+            return;
+        }
+
         Debug.Log("Adding com.unity.xr.androidxr-openxr and com.google.xr.extensions...");
-        Client.AddAndRemove(new[] { "com.unity.xr.androidxr-openxr", "https://github.com/android/android-xr-unity-package.git" });
+        request = Client.AddAndRemove(new[] { "com.unity.xr.androidxr-openxr", "https://github.com/android/android-xr-unity-package.git" });
+        EditorApplication.update += Progress;
+    }
+
+    private static void Progress()
+    {
+        if (request.IsCompleted)
+        {
+            EditorApplication.update -= Progress;
+            request = null;
+        }
     }
 #endif
 }

--- a/UnityProjects/MRTKDevTemplate/Assets/Scripts/Editor/AndroidXRConfig.cs
+++ b/UnityProjects/MRTKDevTemplate/Assets/Scripts/Editor/AndroidXRConfig.cs
@@ -31,6 +31,7 @@ internal class AndroidXRConfig
     {
         if (request.IsCompleted)
         {
+            Debug.Log($"Package install request complete ({request.Status})");
             EditorApplication.update -= Progress;
             request = null;
         }

--- a/UnityProjects/MRTKDevTemplate/Assets/Scripts/Editor/AndroidXRConfig.cs.meta
+++ b/UnityProjects/MRTKDevTemplate/Assets/Scripts/Editor/AndroidXRConfig.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: affa66227cccb1742ab8a95d518c1787

--- a/UnityProjects/MRTKDevTemplate/Assets/XR/XRGeneralSettings.asset
+++ b/UnityProjects/MRTKDevTemplate/Assets/XR/XRGeneralSettings.asset
@@ -16,7 +16,6 @@ MonoBehaviour:
   m_AutomaticLoading: 0
   m_AutomaticRunning: 0
   m_Loaders:
-  - {fileID: 11400000, guid: 702fb985f55d1764190faf519b2a5704, type: 2}
   - {fileID: 11400000, guid: 1aff1d0a357cadb42b05e6d26e0d5f63, type: 2}
 --- !u!114 &-3115139681434547076
 MonoBehaviour:


### PR DESCRIPTION
Only affects our in-repo sample project.
Also removes the default ARCore setting as it was interfering, but it's easily re-addable by devs.