### PR TITLE
Update hands subsystem names for clarity

### DIFF
--- a/org.mixedrealitytoolkit.input/Subsystems/Hands/OpenXRHandsSubsystem.cs
+++ b/org.mixedrealitytoolkit.input/Subsystems/Hands/OpenXRHandsSubsystem.cs
@@ -22,7 +22,7 @@ namespace MixedReality.Toolkit.Input
     [Preserve]
     [MRTKSubsystem(
         Name = "org.mixedrealitytoolkit.openxrhands",
-        DisplayName = "Subsystem for OpenXR Hands API",
+        DisplayName = "Mixed Reality OpenXR Plugin Hands",
         Author = "Mixed Reality Toolkit Contributors",
         ProviderType = typeof(HandsProvider<OpenXRHandContainer>),
         SubsystemTypeOverride = typeof(OpenXRHandsSubsystem),

--- a/org.mixedrealitytoolkit.input/Subsystems/Hands/UnityHandsSubsystem.cs
+++ b/org.mixedrealitytoolkit.input/Subsystems/Hands/UnityHandsSubsystem.cs
@@ -18,7 +18,7 @@ namespace MixedReality.Toolkit.Input
     [Preserve]
     [MRTKSubsystem(
         Name = "org.mixedrealitytoolkit.unityxrhands",
-        DisplayName = "Subsystem for Unity XR Hands API",
+        DisplayName = "Unity XR Hands",
         Author = "Mixed Reality Toolkit Contributors",
         ProviderType = typeof(HandsProvider<UnityHandContainer>),
         SubsystemTypeOverride = typeof(UnityHandsSubsystem))]

--- a/org.mixedrealitytoolkit.input/Subsystems/Hands/XRSDKHandsSubsystem.cs
+++ b/org.mixedrealitytoolkit.input/Subsystems/Hands/XRSDKHandsSubsystem.cs
@@ -19,7 +19,7 @@ namespace MixedReality.Toolkit.Input
     [Preserve]
     [MRTKSubsystem(
         Name = "org.mixedrealitytoolkit.xrsdkhands",
-        DisplayName = "Subsystem for XRSDK Hands API",
+        DisplayName = "Unity XR SDK Hand Data",
         Author = "Mixed Reality Toolkit Contributors",
         ProviderType = typeof(HandsProvider<XRSDKHandContainer>),
         SubsystemTypeOverride = typeof(XRSDKHandsSubsystem),

--- a/org.mixedrealitytoolkit.input/Subsystems/SyntheticHands/SyntheticHandsSubsystem.cs
+++ b/org.mixedrealitytoolkit.input/Subsystems/SyntheticHands/SyntheticHandsSubsystem.cs
@@ -20,7 +20,7 @@ namespace MixedReality.Toolkit.Input
     [Preserve]
     [MRTKSubsystem(
         Name = "org.mixedrealitytoolkit.synthhands",
-        DisplayName = "Subsystem for Hand Synthesis",
+        DisplayName = "MRTK Hand Synthesis",
         Author = "Mixed Reality Toolkit Contributors",
         ProviderType = typeof(SyntheticHandsProvider),
         SubsystemTypeOverride = typeof(SyntheticHandsSubsystem),


### PR DESCRIPTION
Updated the display names to shorten them and make it a bit more clear which API each one supports.

From this:
![{6F2117C8-A61A-4A03-AE3A-8CF60C00938D}](https://github.com/user-attachments/assets/ee41a8ed-f488-4317-8c9d-f4ba7fe148ed)


To this:
![{E908FFED-9B18-451B-829F-60828B42D594}](https://github.com/user-attachments/assets/95ae65e4-a278-487c-bda9-d619109b3c3a)

