### PR TITLE
Add option for framerate independent movement in Input Simulator

### DIFF
--- a/org.mixedrealitytoolkit.input/Editor/Inspectors/CameraSimulationSettingsDrawer.cs
+++ b/org.mixedrealitytoolkit.input/Editor/Inspectors/CameraSimulationSettingsDrawer.cs
@@ -18,6 +18,7 @@ namespace MixedReality.Toolkit.Input.Simulation.Editor
 
         private readonly GUIContent moveSpeedContent = new GUIContent("Speed");
         private readonly GUIContent moveSmoothingContent = new GUIContent("Smoothed");
+        private readonly GUIContent framerateIndependentContent = new GUIContent("Framerate Independent");
         private readonly GUIContent moveDepthContent = new GUIContent("Depth");
         private readonly GUIContent moveHorizontalContent = new GUIContent("Horizontal");
         private readonly GUIContent moveVerticalContent = new GUIContent("Vertical");
@@ -78,6 +79,7 @@ namespace MixedReality.Toolkit.Input.Simulation.Editor
 
             SerializedProperty moveSpeed = property.FindPropertyRelative("moveSpeed");
             SerializedProperty moveSmoothing = property.FindPropertyRelative("isMovementSmoothed");
+            SerializedProperty framerateIndependent = property.FindPropertyRelative("isFramerateIndependent");
             SerializedProperty moveDepth = property.FindPropertyRelative("moveDepth");
             SerializedProperty moveHorizontal = property.FindPropertyRelative("moveHorizontal");
             SerializedProperty moveVertical = property.FindPropertyRelative("moveVertical");
@@ -97,6 +99,13 @@ namespace MixedReality.Toolkit.Input.Simulation.Editor
                     ++rowMultiplier,
                     PropertyDrawerUtilities.Height),
                 moveSpeed, moveSpeedContent);
+            EditorGUI.PropertyField(
+                PropertyDrawerUtilities.GetPosition(
+                    position,
+                    PropertyDrawerUtilities.VerticalSpacing,
+                    ++rowMultiplier,
+                    PropertyDrawerUtilities.Height),
+                framerateIndependent, framerateIndependentContent);
             EditorGUI.PropertyField(
                 PropertyDrawerUtilities.GetPosition(
                     position,

--- a/org.mixedrealitytoolkit.input/Simulation/Devices/CameraSimulationSettings.cs
+++ b/org.mixedrealitytoolkit.input/Simulation/Devices/CameraSimulationSettings.cs
@@ -40,6 +40,7 @@ namespace MixedReality.Toolkit.Input.Simulation
         }
 
         #region Move controls
+        
 
         [SerializeField]
         [Tooltip("Should camera movement be smoothed?")]
@@ -52,10 +53,23 @@ namespace MixedReality.Toolkit.Input.Simulation
         /// Enabling smoothing can result in the camera 'gliding' to a stop
         /// when movement controls are released.
         /// </remarks>
+      
         public bool IsMovementSmoothed
         {
             get => isMovementSmoothed;
             set => isMovementSmoothed = value;
+        }
+
+
+        [SerializeField]
+        [Tooltip("Multiply resulting speed with deltaTime?")]
+        private bool isFramerateIndependent = true;
+
+
+        public bool IsFramerateIndependent
+        {
+            get => isFramerateIndependent;
+            set => isFramerateIndependent = value;
         }
 
         [SerializeField]

--- a/org.mixedrealitytoolkit.input/Simulation/InputSimulator.cs
+++ b/org.mixedrealitytoolkit.input/Simulation/InputSimulator.cs
@@ -203,7 +203,8 @@ namespace MixedReality.Toolkit.Input.Simulation
                     rotationDelta,
                     CameraSettings.IsMovementSmoothed,
                     CameraSettings.MoveSpeed,
-                    CameraSettings.RotationSensitivity);
+                    CameraSettings.RotationSensitivity,
+                    CameraSettings.IsFramerateIndependent);
             }
         }
 


### PR DESCRIPTION
Implement changes suggested in FR #1005 to ensure consistent movement speed when using simulated input. 
Add option to make SimulatedHMD multiply camera movement speed with deltaTime, which has been originally ommited due to the Editor's mouse polling bug invalidating Time.deltaTime. 
Added a "Framerate Independent" checkbox in the Input Simulator inspector, to disable it if needed. 
 