### PR TITLE
Add new input action focus handling

### DIFF
--- a/org.mixedrealitytoolkit.core/Subsystems/MRTKLifecycleManager.cs
+++ b/org.mixedrealitytoolkit.core/Subsystems/MRTKLifecycleManager.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using Unity.Profiling;
 using UnityEngine;
+using UnityEngine.InputSystem;
 
 namespace MixedReality.Toolkit.Subsystems
 {
@@ -18,6 +19,9 @@ namespace MixedReality.Toolkit.Subsystems
         MonoBehaviour,
         IDisposable
     {
+        [SerializeField, Tooltip("A set of input actions to enable/disable according to the app's focus state.")]
+        private InputActionReference[] inputActionReferences;
+
         private List<IMRTKManagedSubsystem> managedSubsystems = new List<IMRTKManagedSubsystem>();
 
         /// <summary>
@@ -172,6 +176,33 @@ namespace MixedReality.Toolkit.Subsystems
                 foreach (IMRTKManagedSubsystem subsystem in managedSubsystems)
                 {
                     subsystem.LateUpdate();
+                }
+            }
+        }
+
+        /// <summary>
+        /// Sent to all GameObjects when the player gets or loses focus.
+        /// </summary>
+        /// <param name="focus"><see langword="true"/> if the GameObjects have focus, else <see langword="false"/>.</param>
+        protected void OnApplicationFocus(bool focus)
+        {
+            // We want to ensure we're focused for input, as some runtimes continue reporting "tracked" while pose updates are paused.
+            // This is allowed, per-spec, as a "should": "Runtimes should make input actions inactive while the application is unfocused,
+            // and applications should react to an inactive input action by skipping rendering of that action's input avatar
+            // (depictions of hands or other tracked objects controlled by the user)."
+
+            if (focus)
+            {
+                foreach (InputActionReference reference in inputActionReferences)
+                {
+                    reference.action.Enable();
+                }
+            }
+            else
+            {
+                foreach (InputActionReference reference in inputActionReferences)
+                {
+                    reference.action.Disable();
                 }
             }
         }

--- a/org.mixedrealitytoolkit.input/Assets/Prefabs/MRTK XR Rig.prefab
+++ b/org.mixedrealitytoolkit.input/Assets/Prefabs/MRTK XR Rig.prefab
@@ -378,6 +378,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 1a107350295baaf4489642caa92f05de, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  inputActionReferences:
+  - {fileID: -7613329581162844239, guid: 18c412191cdc9274897f101c7fd5316f, type: 3}
+  - {fileID: 3239510804178183174, guid: 18c412191cdc9274897f101c7fd5316f, type: 3}
 --- !u!1 &7735890427496681069
 GameObject:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
We want to ensure we're focused for input, as some runtimes continue reporting "tracked" while pose updates are paused. This is allowed, per-spec, as a "should": "Runtimes should make input actions inactive while the application is unfocused, and applications should react to an inactive input action by skipping rendering of that action's input avatar (depictions of hands or other tracked objects controlled by the user)."