### PR TITLE
Deprecate IHandedInteractor

### DIFF
--- a/org.mixedrealitytoolkit.core/CHANGELOG.md
+++ b/org.mixedrealitytoolkit.core/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Added
 
 * Added input action focus handling to disable controller/hand tracked state when the application goes out of focus. [PR #1039](https://github.com/MixedRealityToolkit/MixedRealityToolkit-Unity/pull/1039)
+* Added ToInteractorHandedness extension for XRNode. [PR #1042](https://github.com/MixedRealityToolkit/MixedRealityToolkit-Unity/pull/1042)
 
 ### Changed
 
@@ -16,6 +17,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Removed
 
 * Removed ITrackedInteractor, as it was supporting an unused codepath and there are better ways to get this data (like querying the attach transform). [PR #1044](https://github.com/MixedRealityToolkit/MixedRealityToolkit-Unity/pull/1044)
+
+### Deprecated
+
+* Deprecated IHandedInteractor, as its info is now queryable directly from IXRInteractor's handedness property. [PR #1042](https://github.com/MixedRealityToolkit/MixedRealityToolkit-Unity/pull/1042)
 
 ## [4.0.0-development.pre.1] - 2024-07-09
 

--- a/org.mixedrealitytoolkit.core/Interactors/IHandedInteractor.cs
+++ b/org.mixedrealitytoolkit.core/Interactors/IHandedInteractor.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Mixed Reality Toolkit Contributors
 // Licensed under the BSD 3-Clause
 
+using System;
 using UnityEngine.XR.Interaction.Toolkit.Interactors;
 
 namespace MixedReality.Toolkit
@@ -8,11 +9,13 @@ namespace MixedReality.Toolkit
     /// <summary>
     /// An interface that all interactors with the concept of handedness implement.
     /// </summary>
+    [Obsolete("Use handedness from IXRInteractor instead.")]
     public interface IHandedInteractor : IXRInteractor
     {
         /// <summary>
         /// Returns the Handedness of this interactor.
         /// </summary>
+        [Obsolete("Use handedness from IXRInteractor instead.")]
         public Handedness Handedness { get; }
     }
 }

--- a/org.mixedrealitytoolkit.core/Utilities/Extensions/HandednessExtensions.cs
+++ b/org.mixedrealitytoolkit.core/Utilities/Extensions/HandednessExtensions.cs
@@ -17,21 +17,12 @@ namespace MixedReality.Toolkit
         /// If Left, returns Right, if Right, returns Left otherwise returns None.
         /// Otherwise, returns None
         /// </remarks>
-        public static Handedness GetOppositeHandedness(this Handedness current)
+        public static Handedness GetOppositeHandedness(this Handedness current) => current switch
         {
-            if (current == Handedness.Left)
-            {
-                return Handedness.Right;
-            }
-            else if (current == Handedness.Right)
-            {
-                return Handedness.Left;
-            }
-            else
-            {
-                return Handedness.None;
-            }
-        }
+            Handedness.Left => Handedness.Right,
+            Handedness.Right => Handedness.Left,
+            _ => Handedness.None
+        };
 
         /// <summary>
         /// Checks whether or not the current <see cref="Handedness"/> value matches the specified value.
@@ -53,11 +44,11 @@ namespace MixedReality.Toolkit
         /// <returns>
         /// <see cref="XRNode"/> representing the specified <see cref="Handedness"/>, or <see langword="null"/>.
         /// </returns>
-        public static XRNode? ToXRNode(this Handedness hand)
+        public static XRNode? ToXRNode(this Handedness hand) => hand switch
         {
-            if (hand == Handedness.Left) { return XRNode.LeftHand; }
-            if (hand == Handedness.Right) { return XRNode.RightHand; }
-            return null;
-        }
+            Handedness.Left => XRNode.LeftHand,
+            Handedness.Right => XRNode.RightHand,
+            _ => null
+        };
     }
 }

--- a/org.mixedrealitytoolkit.core/Utilities/Extensions/InteractorHandednessExtensions.cs
+++ b/org.mixedrealitytoolkit.core/Utilities/Extensions/InteractorHandednessExtensions.cs
@@ -26,18 +26,12 @@ namespace MixedReality.Toolkit
         /// <summary>
         /// Gets the <see cref="XRNode"/> representing the specified <see cref="InteractorHandedness"/>. If the <see cref="InteractorHandedness"/>
         /// </summary>
-        public static XRNode ToXRNode(this InteractorHandedness hand, XRNode defaultValue = XRNode.RightHand)
+        public static XRNode ToXRNode(this InteractorHandedness hand, XRNode defaultValue = XRNode.RightHand) => hand switch
         {
-            switch (hand)
-            {
-                case InteractorHandedness.Left:
-                    return XRNode.LeftHand;
-                case InteractorHandedness.Right:
-                    return XRNode.RightHand;
-                default:
-                    return defaultValue;
-            }
-        }
+            InteractorHandedness.Left => XRNode.LeftHand,
+            InteractorHandedness.Right => XRNode.RightHand,
+            _ => defaultValue,
+        };
 
         /// <summary>
         /// Converts the <see cref="InteractorHandedness"/> to <see cref="Handedness"/>. If the <see cref="InteractorHandedness"/>
@@ -46,17 +40,11 @@ namespace MixedReality.Toolkit
         /// <param name="hand">The <see cref="InteractorHandedness"/> value for
         /// which the <see cref="Handedness"/> is requested.</param>
         /// <returns><see cref="Handedness"/> representing the specified <see cref="InteractorHandedness"/>.</returns>
-        public static Handedness ToHandedness(this InteractorHandedness hand)
+        public static Handedness ToHandedness(this InteractorHandedness hand) => hand switch
         {
-            switch (hand)
-            {
-                case InteractorHandedness.Left:
-                    return Handedness.Left;
-                case InteractorHandedness.Right:
-                    return Handedness.Right;
-                default:
-                    return Handedness.None;
-            }
-        }
+            InteractorHandedness.Left => Handedness.Left,
+            InteractorHandedness.Right => Handedness.Right,
+            _ => Handedness.None,
+        };
     }
 }

--- a/org.mixedrealitytoolkit.core/Utilities/Extensions/XRNodeExtensions.cs
+++ b/org.mixedrealitytoolkit.core/Utilities/Extensions/XRNodeExtensions.cs
@@ -21,20 +21,12 @@ namespace MixedReality.Toolkit
         /// This will return <see cref="Handedness.None"/> for XRNode values other than
         /// LeftHand or RightHand.
         /// </remarks>
-        public static Handedness ToHandedness(this XRNode node)
+        public static Handedness ToHandedness(this XRNode node) => node switch
         {
-            switch (node)
-            {
-                case XRNode.LeftHand:
-                    return Handedness.Left;
-
-                case XRNode.RightHand:
-                    return Handedness.Right;
-
-                default:
-                    return Handedness.None;
-            }
-        }
+            XRNode.LeftHand => Handedness.Left,
+            XRNode.RightHand => Handedness.Right,
+            _ => Handedness.None,
+        };
 
         /// <summary>
         /// Determine if the specified XRNode represents a hand.

--- a/org.mixedrealitytoolkit.core/Utilities/Extensions/XRNodeExtensions.cs
+++ b/org.mixedrealitytoolkit.core/Utilities/Extensions/XRNodeExtensions.cs
@@ -2,6 +2,7 @@
 // Licensed under the BSD 3-Clause
 
 using UnityEngine.XR;
+using UnityEngine.XR.Interaction.Toolkit.Interactors;
 
 namespace MixedReality.Toolkit
 {
@@ -26,6 +27,24 @@ namespace MixedReality.Toolkit
             XRNode.LeftHand => Handedness.Left,
             XRNode.RightHand => Handedness.Right,
             _ => Handedness.None,
+        };
+
+        /// <summary>
+        /// Returns the <see cref="InteractorHandedness"/> of the specified XRNode.
+        /// </summary>
+        /// <param name="node">The XRNode for which the <see cref="InteractorHandedness"/> is requested.</param>
+        /// <returns>
+        /// <see cref="InteractorHandedness"/> value representing the XRNode.
+        /// </returns>
+        /// <remarks>
+        /// This will return <see cref="InteractorHandedness.None"/> for XRNode values other than
+        /// LeftHand or RightHand.
+        /// </remarks>
+        public static InteractorHandedness ToInteractorHandedness(this XRNode node) => node switch
+        {
+            XRNode.LeftHand => InteractorHandedness.Left,
+            XRNode.RightHand => InteractorHandedness.Right,
+            _ => InteractorHandedness.None,
         };
 
         /// <summary>

--- a/org.mixedrealitytoolkit.input/Assets/Prefabs/MRTK LeftHand Controller.prefab
+++ b/org.mixedrealitytoolkit.input/Assets/Prefabs/MRTK LeftHand Controller.prefab
@@ -365,6 +365,7 @@ MonoBehaviour:
     rid: 0
   devicePoseSource:
     rid: 1
+  isHandednessMigrated: 1
   references:
     version: 2
     RefIds:
@@ -864,6 +865,7 @@ MonoBehaviour:
   m_PhysicsTriggerInteraction: 1
   trackedPoseDriver: {fileID: 3281803018082669919}
   modeManagedRoot: {fileID: 1948193615953854874}
+  isHandednessMigrated: 1
   pinchPoseSource:
     rid: 0
   references:
@@ -1295,6 +1297,7 @@ MonoBehaviour:
   modeManagedRoot: {fileID: 1948193615953854874}
   pokePoseSource:
     rid: 0
+  isHandednessMigrated: 1
   references:
     version: 2
     RefIds:
@@ -1731,6 +1734,7 @@ MonoBehaviour:
   dependentInteractor: {fileID: 0}
   stickyHoverThreshold: 0.5
   relaxationThreshold: 0.1
+  isHandednessMigrated: 1
   references:
     version: 2
     RefIds:

--- a/org.mixedrealitytoolkit.input/Assets/Prefabs/MRTK LeftHand Controller.prefab
+++ b/org.mixedrealitytoolkit.input/Assets/Prefabs/MRTK LeftHand Controller.prefab
@@ -365,7 +365,6 @@ MonoBehaviour:
     rid: 0
   devicePoseSource:
     rid: 1
-  isHandednessMigrated: 1
   references:
     version: 2
     RefIds:
@@ -865,7 +864,6 @@ MonoBehaviour:
   m_PhysicsTriggerInteraction: 1
   trackedPoseDriver: {fileID: 3281803018082669919}
   modeManagedRoot: {fileID: 1948193615953854874}
-  isHandednessMigrated: 1
   pinchPoseSource:
     rid: 0
   references:
@@ -1297,7 +1295,6 @@ MonoBehaviour:
   modeManagedRoot: {fileID: 1948193615953854874}
   pokePoseSource:
     rid: 0
-  isHandednessMigrated: 1
   references:
     version: 2
     RefIds:
@@ -1734,7 +1731,6 @@ MonoBehaviour:
   dependentInteractor: {fileID: 0}
   stickyHoverThreshold: 0.5
   relaxationThreshold: 0.1
-  isHandednessMigrated: 1
   references:
     version: 2
     RefIds:

--- a/org.mixedrealitytoolkit.input/CHANGELOG.md
+++ b/org.mixedrealitytoolkit.input/CHANGELOG.md
@@ -18,6 +18,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 * Updated the minimum editor version to 2022.3.6f1 [PR #1003](https://github.com/MixedRealityToolkit/MixedRealityToolkit-Unity/pull/1003)
 
+### Deprecated
+
+* Deprecated IHandedInteractor across the interactor implementations, as its info is now queryable directly from IXRInteractor's handedness property. [PR #1042](https://github.com/MixedRealityToolkit/MixedRealityToolkit-Unity/pull/1042)
+
 ## [4.0.0-development.pre.1] - 2024-07-16
 
 ### Added

--- a/org.mixedrealitytoolkit.input/Controllers/ArticulatedHandController.cs
+++ b/org.mixedrealitytoolkit.input/Controllers/ArticulatedHandController.cs
@@ -17,7 +17,7 @@ namespace MixedReality.Toolkit.Input
     /// This is able to support variable pinch select through the use of <see cref="HandsAggregatorSubsystem"/>.
     /// </remarks>
     [AddComponentMenu("MRTK/Input/XR Controller (Articulated Hand)")]
-    [Obsolete]
+    [Obsolete("ArticulatedHandController has been deprecated in version 4.0.0. Its functionality has been distributed into different components.")]
     public class ArticulatedHandController : ActionBasedController
     {
         #region Associated hand select values

--- a/org.mixedrealitytoolkit.input/InteractionModes/InteractionModeManager.cs
+++ b/org.mixedrealitytoolkit.input/InteractionModes/InteractionModeManager.cs
@@ -561,7 +561,7 @@ namespace MixedReality.Toolkit.Input
             GameObject interactorGroupObject = null;
 
             // For backwards compatibility, we will continue to support the obsolete "controller-based" interactors,
-            // and group based on "controller" partents.
+            // and group based on "controller" parents.
 #pragma warning disable CS0618 // xrController is obsolete
             if (interactor is XRBaseInputInteractor controllerInteractor &&
                 controllerInteractor.xrController != null)

--- a/org.mixedrealitytoolkit.input/Interactors/Gaze/GazeInteractor.cs
+++ b/org.mixedrealitytoolkit.input/Interactors/Gaze/GazeInteractor.cs
@@ -39,14 +39,7 @@ namespace MixedReality.Toolkit.Input
         {
             // Legacy controller-based interactors should return null, so the legacy controller-based logic in the
             // interaction mode manager is used instead.
-#pragma warning disable CS0618 // forceDeprecatedInput is obsolete
-            if (forceDeprecatedInput)
-            {
-                return null;
-            }
-#pragma warning restore CS0618 // forceDeprecatedInput is obsolete
-
-            return ModeManagedRoot;
+            return forceDeprecatedInput ? null : ModeManagedRoot;
         }
     }
 }

--- a/org.mixedrealitytoolkit.input/Interactors/GazePinch/GazePinchInteractor.cs
+++ b/org.mixedrealitytoolkit.input/Interactors/GazePinch/GazePinchInteractor.cs
@@ -201,8 +201,7 @@ namespace MixedReality.Toolkit.Input
         {
             get
             {
-                if (forceDeprecatedInput &&
-                    xrController is ArticulatedHandController handController)
+                if (forceDeprecatedInput)
                 {
                     return handController.HandNode.ToHandedness();
                 }

--- a/org.mixedrealitytoolkit.input/Interactors/GazePinch/GazePinchInteractor.cs
+++ b/org.mixedrealitytoolkit.input/Interactors/GazePinch/GazePinchInteractor.cs
@@ -21,8 +21,10 @@ namespace MixedReality.Toolkit.Input
     public class GazePinchInteractor :
         XRBaseInputInteractor,
         IGazePinchInteractor,
-        IHandedInteractor,
-        IModeManagedInteractor
+        IModeManagedInteractor,
+#pragma warning disable CS0618 // Type or member is obsolete
+        IHandedInteractor
+#pragma warning restore CS0618 // Type or member is obsolete
     {
         #region GazePinchInteractor
 

--- a/org.mixedrealitytoolkit.input/Interactors/GazePinch/GazePinchInteractor.cs
+++ b/org.mixedrealitytoolkit.input/Interactors/GazePinch/GazePinchInteractor.cs
@@ -22,8 +22,7 @@ namespace MixedReality.Toolkit.Input
         XRBaseInputInteractor,
         IGazePinchInteractor,
         IHandedInteractor,
-        IModeManagedInteractor,
-        ISerializationCallbackReceiver
+        IModeManagedInteractor
     {
         #region GazePinchInteractor
 
@@ -568,26 +567,6 @@ namespace MixedReality.Toolkit.Input
         }
 
         #endregion IModeManagedInteractor
-
-        #region ISerializationCallbackReceiver
-
-        [SerializeField, HideInInspector]
-        private bool isHandednessMigrated = false;
-
-        void ISerializationCallbackReceiver.OnBeforeSerialize() { }
-
-        void ISerializationCallbackReceiver.OnAfterDeserialize()
-        {
-#pragma warning disable CS0618 // Type or member is obsolete
-            if (!isHandednessMigrated && handedness == InteractorHandedness.None && (xrController is ArticulatedHandController handController))
-            {
-                handedness = handController.HandNode.ToInteractorHandedness();
-            }
-#pragma warning restore CS0618 // Type or member is obsolete
-            isHandednessMigrated = true;
-        }
-
-        #endregion ISerializationCallbackReceiver
 
         #region Private Methods
 

--- a/org.mixedrealitytoolkit.input/Interactors/GazePinch/GazePinchInteractor.cs
+++ b/org.mixedrealitytoolkit.input/Interactors/GazePinch/GazePinchInteractor.cs
@@ -201,14 +201,13 @@ namespace MixedReality.Toolkit.Input
         {
             get
             {
-                if (forceDeprecatedInput)
+                if (forceDeprecatedInput &&
+                    xrController is ArticulatedHandController handController)
                 {
-                    return (xrController is ArticulatedHandController handController) ? handController.HandNode.ToHandedness() : Handedness.None;
+                    return handController.HandNode.ToHandedness();
                 }
-                else
-                {
-                    return handedness.ToHandedness();
-                }
+
+                return handedness.ToHandedness();
             }
         }
 

--- a/org.mixedrealitytoolkit.input/Interactors/HandJointInteractor.cs
+++ b/org.mixedrealitytoolkit.input/Interactors/HandJointInteractor.cs
@@ -66,14 +66,13 @@ namespace MixedReality.Toolkit.Input
         {
             get
             {
-                if (forceDeprecatedInput)
+                if (forceDeprecatedInput &&
+                    xrController is ArticulatedHandController handController)
                 {
-                    return (xrController is ArticulatedHandController handController) ? handController.HandNode.ToHandedness() : Handedness.None;
+                    return handController.HandNode.ToHandedness();
                 }
-                else
-                {
-                    return handedness.ToHandedness();
-                }
+
+                return handedness.ToHandedness();
             }
         }
 

--- a/org.mixedrealitytoolkit.input/Interactors/HandJointInteractor.cs
+++ b/org.mixedrealitytoolkit.input/Interactors/HandJointInteractor.cs
@@ -18,8 +18,10 @@ namespace MixedReality.Toolkit.Input
     /// </summary>
     public abstract class HandJointInteractor :
         XRDirectInteractor,
-        IHandedInteractor,
-        IModeManagedInteractor
+        IModeManagedInteractor,
+#pragma warning disable CS0618 // Type or member is obsolete
+        IHandedInteractor
+#pragma warning restore CS0618 // Type or member is obsolete
     {
         #region Serialized Fields
 

--- a/org.mixedrealitytoolkit.input/Interactors/HandJointInteractor.cs
+++ b/org.mixedrealitytoolkit.input/Interactors/HandJointInteractor.cs
@@ -19,8 +19,7 @@ namespace MixedReality.Toolkit.Input
     public abstract class HandJointInteractor :
         XRDirectInteractor,
         IHandedInteractor,
-        IModeManagedInteractor,
-        ISerializationCallbackReceiver
+        IModeManagedInteractor
     {
         #region Serialized Fields
 
@@ -170,26 +169,6 @@ namespace MixedReality.Toolkit.Input
         }
 
         #endregion IModeManagedInteractor
-
-        #region ISerializationCallbackReceiver
-
-        [SerializeField, HideInInspector]
-        private bool isHandednessMigrated = false;
-
-        void ISerializationCallbackReceiver.OnBeforeSerialize() { }
-
-        void ISerializationCallbackReceiver.OnAfterDeserialize()
-        {
-#pragma warning disable CS0618 // Type or member is obsolete
-            if (!isHandednessMigrated && handedness == InteractorHandedness.None && (xrController is ArticulatedHandController handController))
-            {
-                handedness = handController.HandNode.ToInteractorHandedness();
-            }
-#pragma warning restore CS0618 // Type or member is obsolete
-            isHandednessMigrated = true;
-        }
-
-        #endregion ISerializationCallbackReceiver
 
         #region Unity Event Functions
 

--- a/org.mixedrealitytoolkit.input/Interactors/Poke/PokeInteractor.cs
+++ b/org.mixedrealitytoolkit.input/Interactors/Poke/PokeInteractor.cs
@@ -90,13 +90,11 @@ namespace MixedReality.Toolkit.Input
             }
 #pragma warning disable CS0612 // Type or member is obsolete
 #pragma warning restore CS0618 // Type or member is obsolete
-            else
+            else if (handedness != InteractorHandedness.None &&
+                (XRSubsystemHelpers.HandsAggregator?.TryGetNearInteractionPoint(handedness.ToXRNode(), out jointPose) ?? false))
             {
-                if (XRSubsystemHelpers.HandsAggregator?.TryGetNearInteractionPoint(handedness.ToXRNode(), out jointPose) ?? false)
-                {
-                    radius = jointPose.Radius;
-                    return true;
-                }
+                radius = jointPose.Radius;
+                return true;
             }
 
             radius = default;
@@ -153,7 +151,7 @@ namespace MixedReality.Toolkit.Input
             base.Start();
 
             // Try to get the <see cref="TrackedPoseDriver"> component from the parent if it hasn't been set yet
-            if (trackedPoseDriver == null) 
+            if (trackedPoseDriver == null)
             {
                 trackedPoseDriver = GetComponentInParent<TrackedPoseDriver>();
             }
@@ -213,7 +211,7 @@ namespace MixedReality.Toolkit.Input
                 }
 #pragma warning restore CS0618 // Type or member is obsolete
                 // If the interactor does not have a TrackedPoseDriver component then we cannot determine if it is hover active
-                else if (trackedPoseDriver == null) 
+                else if (trackedPoseDriver == null)
                 {
                     return false;
                 }
@@ -323,7 +321,7 @@ namespace MixedReality.Toolkit.Input
         {
             // Legacy controller-based interactors should return null, so the legacy controller-based logic in the
             // interaction mode manager is used instead.
-#pragma warning disable CS0618 // Type or member is obsolete 
+#pragma warning disable CS0618 // Type or member is obsolete
             if (forceDeprecatedInput)
             {
                 return null;

--- a/org.mixedrealitytoolkit.input/Interactors/Poke/PokeInteractor.cs
+++ b/org.mixedrealitytoolkit.input/Interactors/Poke/PokeInteractor.cs
@@ -22,7 +22,8 @@ namespace MixedReality.Toolkit.Input
         XRBaseInputInteractor,
         IPokeInteractor,
         IHandedInteractor,
-        IModeManagedInteractor
+        IModeManagedInteractor,
+        ISerializationCallbackReceiver
     {
         #region PokeInteractor
 
@@ -80,7 +81,6 @@ namespace MixedReality.Toolkit.Input
             HandJointPose jointPose = default;
 
 #pragma warning disable CS0618 // Type or member is obsolete
-#pragma warning disable CS0612 // Type or member is obsolete
             if (forceDeprecatedInput &&
                 xrController is ArticulatedHandController handController &&
                 (XRSubsystemHelpers.HandsAggregator?.TryGetNearInteractionPoint(handController.HandNode, out jointPose) ?? false))
@@ -88,7 +88,6 @@ namespace MixedReality.Toolkit.Input
                 radius = jointPose.Radius;
                 return true;
             }
-#pragma warning disable CS0612 // Type or member is obsolete
 #pragma warning restore CS0618 // Type or member is obsolete
             else if (handedness != InteractorHandedness.None &&
                 (XRSubsystemHelpers.HandsAggregator?.TryGetNearInteractionPoint(handedness.ToXRNode(), out jointPose) ?? false))
@@ -106,16 +105,15 @@ namespace MixedReality.Toolkit.Input
         #region IHandedInteractor
 
         /// <inheritdoc />
+        [Obsolete("Use handedness from IXRInteractor instead.")]
         Handedness IHandedInteractor.Handedness
         {
             get
             {
-#pragma warning disable CS0618 // Type or member is obsolete
                 if (forceDeprecatedInput)
                 {
                     return (xrController is ArticulatedHandController handController) ? handController.HandNode.ToHandedness() : Handedness.None;
                 }
-#pragma warning restore CS0618 // Type or member is obsolete
                 else
                 {
                     return handedness.ToHandedness();
@@ -315,21 +313,36 @@ namespace MixedReality.Toolkit.Input
         #endregion XRBaseInteractor
 
         #region IModeManagedInteractor
+
         /// <inheritdoc/>
         [Obsolete("This function is obsolete and will be removed in the next major release. Use ModeManagedRoot instead.")]
         public GameObject GetModeManagedController()
         {
             // Legacy controller-based interactors should return null, so the legacy controller-based logic in the
             // interaction mode manager is used instead.
+            return forceDeprecatedInput ? null : ModeManagedRoot;
+        }
+
+        #endregion IModeManagedInteractor
+
+        #region ISerializationCallbackReceiver
+
+        [SerializeField, HideInInspector]
+        private bool isHandednessMigrated = false;
+
+        void ISerializationCallbackReceiver.OnBeforeSerialize() { }
+
+        void ISerializationCallbackReceiver.OnAfterDeserialize()
+        {
 #pragma warning disable CS0618 // Type or member is obsolete
-            if (forceDeprecatedInput)
+            if (!isHandednessMigrated && handedness == InteractorHandedness.None && (xrController is ArticulatedHandController handController))
             {
-                return null;
+                handedness = handController.HandNode.ToInteractorHandedness();
             }
 #pragma warning restore CS0618 // Type or member is obsolete
-
-            return ModeManagedRoot;
+            isHandednessMigrated = true;
         }
-        #endregion IModeManagedInteractor
+
+        #endregion ISerializationCallbackReceiver
     }
 }

--- a/org.mixedrealitytoolkit.input/Interactors/Poke/PokeInteractor.cs
+++ b/org.mixedrealitytoolkit.input/Interactors/Poke/PokeInteractor.cs
@@ -22,8 +22,7 @@ namespace MixedReality.Toolkit.Input
         XRBaseInputInteractor,
         IPokeInteractor,
         IHandedInteractor,
-        IModeManagedInteractor,
-        ISerializationCallbackReceiver
+        IModeManagedInteractor
     {
         #region PokeInteractor
 
@@ -324,25 +323,5 @@ namespace MixedReality.Toolkit.Input
         }
 
         #endregion IModeManagedInteractor
-
-        #region ISerializationCallbackReceiver
-
-        [SerializeField, HideInInspector]
-        private bool isHandednessMigrated = false;
-
-        void ISerializationCallbackReceiver.OnBeforeSerialize() { }
-
-        void ISerializationCallbackReceiver.OnAfterDeserialize()
-        {
-#pragma warning disable CS0618 // Type or member is obsolete
-            if (!isHandednessMigrated && handedness == InteractorHandedness.None && (xrController is ArticulatedHandController handController))
-            {
-                handedness = handController.HandNode.ToInteractorHandedness();
-            }
-#pragma warning restore CS0618 // Type or member is obsolete
-            isHandednessMigrated = true;
-        }
-
-        #endregion ISerializationCallbackReceiver
     }
 }

--- a/org.mixedrealitytoolkit.input/Interactors/Poke/PokeInteractor.cs
+++ b/org.mixedrealitytoolkit.input/Interactors/Poke/PokeInteractor.cs
@@ -111,14 +111,13 @@ namespace MixedReality.Toolkit.Input
         {
             get
             {
-                if (forceDeprecatedInput)
+                if (forceDeprecatedInput &&
+                    xrController is ArticulatedHandController handController)
                 {
-                    return (xrController is ArticulatedHandController handController) ? handController.HandNode.ToHandedness() : Handedness.None;
+                    return handController.HandNode.ToHandedness();
                 }
-                else
-                {
-                    return handedness.ToHandedness();
-                }
+
+                return handedness.ToHandedness();
             }
         }
 

--- a/org.mixedrealitytoolkit.input/Interactors/Poke/PokeInteractor.cs
+++ b/org.mixedrealitytoolkit.input/Interactors/Poke/PokeInteractor.cs
@@ -21,8 +21,10 @@ namespace MixedReality.Toolkit.Input
     public class PokeInteractor :
         XRBaseInputInteractor,
         IPokeInteractor,
-        IHandedInteractor,
-        IModeManagedInteractor
+        IModeManagedInteractor,
+#pragma warning disable CS0618 // Type or member is obsolete
+        IHandedInteractor
+#pragma warning restore CS0618 // Type or member is obsolete
     {
         #region PokeInteractor
 

--- a/org.mixedrealitytoolkit.input/Interactors/Ray/MRTKRayInteractor.cs
+++ b/org.mixedrealitytoolkit.input/Interactors/Ray/MRTKRayInteractor.cs
@@ -147,14 +147,13 @@ namespace MixedReality.Toolkit.Input
         {
             get
             {
-                if (forceDeprecatedInput)
+                if (forceDeprecatedInput &&
+                    xrController is ArticulatedHandController handController)
                 {
-                    return (xrController is ArticulatedHandController handController) ? handController.HandNode.ToHandedness() : Handedness.None;
+                    return handController.HandNode.ToHandedness();
                 }
-                else
-                {
-                    return handedness.ToHandedness();
-                }
+
+                return handedness.ToHandedness();
             }
         }
 

--- a/org.mixedrealitytoolkit.input/Interactors/Ray/MRTKRayInteractor.cs
+++ b/org.mixedrealitytoolkit.input/Interactors/Ray/MRTKRayInteractor.cs
@@ -27,9 +27,11 @@ namespace MixedReality.Toolkit.Input
     public class MRTKRayInteractor :
         XRRayInteractor,
         IRayInteractor,
-        IHandedInteractor,
         IVariableSelectInteractor,
-        IModeManagedInteractor
+        IModeManagedInteractor,
+#pragma warning disable CS0618 // Type or member is obsolete
+        IHandedInteractor
+#pragma warning restore CS0618 // Type or member is obsolete
     {
         #region MRTKRayInteractor
 

--- a/org.mixedrealitytoolkit.input/Interactors/Ray/MRTKRayInteractor.cs
+++ b/org.mixedrealitytoolkit.input/Interactors/Ray/MRTKRayInteractor.cs
@@ -178,10 +178,8 @@ namespace MixedReality.Toolkit.Input
                 {
                     return selectInput.ReadValue();
                 }
-                else
-                {
-                    Debug.LogWarning($"Unable to determine SelectProgress of {name} because there is no Select Input Configuration set for this interactor.");
-                }
+
+                Debug.LogWarning($"Unable to determine SelectProgress of {name} because there is no Select Input Configuration set for this interactor.");
                 return 0;
             }
         }
@@ -263,7 +261,7 @@ namespace MixedReality.Toolkit.Input
                             xrController is ArticulatedHandController handController &&
                             (XRSubsystemHelpers.HandsAggregator?.TryGetPalmFacingAway(handController.HandNode, out isPalmFacingAway) ?? true))
                         {
-                                hoverActive &= isPalmFacingAway;
+                            hoverActive &= isPalmFacingAway;
                         }
 #pragma warning restore CS0612
 #pragma warning restore CS0618
@@ -345,7 +343,7 @@ namespace MixedReality.Toolkit.Input
         {
             // Legacy controller-based interactors should return null, so the legacy controller-based logic in the
             // interaction mode manager is used instead.
-#pragma warning disable CS0618 // Type or member is obsolete 
+#pragma warning disable CS0618 // Type or member is obsolete
             if (forceDeprecatedInput)
             {
                 return null;
@@ -363,7 +361,7 @@ namespace MixedReality.Toolkit.Input
             base.Start();
 
             // Try to get the TrackedPoseDriver component from the parent if it hasn't been set yet
-            if (trackedPoseDriver == null) 
+            if (trackedPoseDriver == null)
             {
                 trackedPoseDriver = GetComponentInParent<TrackedPoseDriver>();
             }

--- a/org.mixedrealitytoolkit.input/Interactors/Ray/MRTKRayInteractor.cs
+++ b/org.mixedrealitytoolkit.input/Interactors/Ray/MRTKRayInteractor.cs
@@ -29,8 +29,7 @@ namespace MixedReality.Toolkit.Input
         IRayInteractor,
         IHandedInteractor,
         IVariableSelectInteractor,
-        IModeManagedInteractor,
-        ISerializationCallbackReceiver
+        IModeManagedInteractor
     {
         #region MRTKRayInteractor
 
@@ -398,25 +397,5 @@ namespace MixedReality.Toolkit.Input
         }
 
         #endregion Unity Event Functions
-
-        #region ISerializationCallbackReceiver
-
-        [SerializeField, HideInInspector]
-        private bool isHandednessMigrated = false;
-
-        void ISerializationCallbackReceiver.OnBeforeSerialize() { }
-
-        void ISerializationCallbackReceiver.OnAfterDeserialize()
-        {
-#pragma warning disable CS0618 // Type or member is obsolete
-            if (!isHandednessMigrated && handedness == InteractorHandedness.None && (xrController is ArticulatedHandController handController))
-            {
-                handedness = handController.HandNode.ToInteractorHandedness();
-            }
-#pragma warning restore CS0618 // Type or member is obsolete
-            isHandednessMigrated = true;
-        }
-
-        #endregion ISerializationCallbackReceiver
     }
 }

--- a/org.mixedrealitytoolkit.input/package.json
+++ b/org.mixedrealitytoolkit.input/package.json
@@ -1,6 +1,6 @@
 {
   "name": "org.mixedrealitytoolkit.input",
-  "version": "4.0.0-development.pre.1",
+  "version": "4.0.0-development.pre.2",
   "description": "This package extends the XR Interaction Toolkit with custom interactors and controllers, hand-joint aggregation, and simulation subsystems. It seamlessly integrates with the Unity Input System.",
   "displayName": "MRTK Input",
   "msftFeatureCategory": "MRTK3",

--- a/org.mixedrealitytoolkit.uxcore/CHANGELOG.md
+++ b/org.mixedrealitytoolkit.uxcore/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 * StateVisualizer: Modified access modifiers of State, stateContainers and UpdateStateValue to protected internal to allow adding states through subclassing. [PR #926](https://github.com/MixedRealityToolkit/MixedRealityToolkit-Unity/pull/926)
 * Updated the minimum editor version to 2022.3.6f1 [PR #1003](https://github.com/MixedRealityToolkit/MixedRealityToolkit-Unity/pull/1003)
+* Updated InteractablePulse to work across all IXRInteractor implementations, instead of just MRTK-specific IHandedInteractor implementations. [PR #1042](https://github.com/MixedRealityToolkit/MixedRealityToolkit-Unity/pull/1042)
 
 ### Fixed
 

--- a/org.mixedrealitytoolkit.uxcore/Interop/CanvasProxyInteractor.cs
+++ b/org.mixedrealitytoolkit.uxcore/Interop/CanvasProxyInteractor.cs
@@ -34,7 +34,7 @@ namespace MixedReality.Toolkit.UX
         private bool isCancellingInteraction = false;
 
         /// <inheritdoc />
-        public GameObject ModeManagedRoot { get => gameObject; }
+        public GameObject ModeManagedRoot => gameObject;
 
         /// <inheritdoc />
         public void StartHover(IXRHoverInteractable target)

--- a/org.mixedrealitytoolkit.uxcore/Pulse/InteractablePulse.cs
+++ b/org.mixedrealitytoolkit.uxcore/Pulse/InteractablePulse.cs
@@ -4,6 +4,7 @@
 using Microsoft.MixedReality.GraphicsTools;
 using UnityEngine;
 using UnityEngine.XR.Interaction.Toolkit;
+using UnityEngine.XR.Interaction.Toolkit.Interactors;
 
 namespace MixedReality.Toolkit.UX
 {
@@ -50,10 +51,7 @@ namespace MixedReality.Toolkit.UX
 
         private void OnSelectEntered(SelectEnterEventArgs args)
         {
-            if (args.interactorObject is IHandedInteractor handedInteractor)
-            {
-                pulse.Pulse(handedInteractor.GetAttachTransform(Interactable).position, handedInteractor.Handedness == Handedness.Left);
-            }
+            pulse.Pulse(args.interactorObject.GetAttachTransform(Interactable).position, args.interactorObject.handedness == InteractorHandedness.Left);
         }
     }
 }

--- a/org.mixedrealitytoolkit.uxcore/package.json
+++ b/org.mixedrealitytoolkit.uxcore/package.json
@@ -1,6 +1,6 @@
 {
   "name": "org.mixedrealitytoolkit.uxcore",
-  "version": "4.0.0-development.pre.1",
+  "version": "4.0.0-development.pre.2",
   "description": "Core interaction and visualization scripts for building MR UI components. Intended to be consumed when building UX libraries. For pre-existing library of components see the UX Components package.",
   "displayName": "MRTK UX Core Scripts",
   "msftFeatureCategory": "MRTK3",


### PR DESCRIPTION
This is now duplicative to `IXRInteractor`'s `handedness`.

Also includes some style and formatting updates across interactors to match the rest of the repo.