### PR TITLE
Update synthetic hand readings

### DIFF
--- a/org.mixedrealitytoolkit.input/Assets/Default Configs/MRTKSyntheticHandsConfig.asset
+++ b/org.mixedrealitytoolkit.input/Assets/Default Configs/MRTKSyntheticHandsConfig.asset
@@ -49,7 +49,7 @@ MonoBehaviour:
       m_Interactions: 
       m_SingletonActionBindings: []
       m_Flags: 0
-    m_Reference: {fileID: -6131295136447488360, guid: 18c412191cdc9274897f101c7fd5316f, type: 3}
+    m_Reference: {fileID: -294446728694031702, guid: 18c412191cdc9274897f101c7fd5316f, type: 3}
   rightHandPosition:
     m_UseReference: 1
     m_Action:
@@ -85,4 +85,4 @@ MonoBehaviour:
       m_Interactions: 
       m_SingletonActionBindings: []
       m_Flags: 0
-    m_Reference: {fileID: 187161793506945269, guid: 18c412191cdc9274897f101c7fd5316f, type: 3}
+    m_Reference: {fileID: 2995356199736570127, guid: 18c412191cdc9274897f101c7fd5316f, type: 3}

--- a/org.mixedrealitytoolkit.input/CHANGELOG.md
+++ b/org.mixedrealitytoolkit.input/CHANGELOG.md
@@ -9,10 +9,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 * Added a project validation rule to ensure the Unity XR Hands subsystem is enabled in the OpenXR settings when the corresponding MRTK subsystem is enabled. [PR #973](https://github.com/MixedRealityToolkit/MixedRealityToolkit-Unity/pull/973)
 * Added support for Unity's com.unity.cloud.gltfast and com.unity.cloud.ktx packages when loading controller models. [PR #631](https://github.com/MixedRealityToolkit/MixedRealityToolkit-Unity/pull/631)
 * Added toggle for frame rate independent smoothing in camera simulation. [PR #1011](https://github.com/MixedRealityToolkit/MixedRealityToolkit-Unity/pull/1011)
+* Added implementation for the synthesized TriggerButton, accounting for animation smoothing. [PR #1043](https://github.com/MixedRealityToolkit/MixedRealityToolkit-Unity/pull/1043)
+* Added a "squeeze" alias for the grip states, to account for broader input action mapping support. [PR #1043](https://github.com/MixedRealityToolkit/MixedRealityToolkit-Unity/pull/1043)
 
 ### Fixed
 
 * Fixed controller model fallback visualization becoming stuck visible when hands became tracked after initialization. [PR #984](https://github.com/MixedRealityToolkit/MixedRealityToolkit-Unity/pull/984)
+
+### Changed
+
+* Remapped the synthetic hands config to read the float "select value" action instead of the bool "select" action, since it's read as a float. [PR #1043](https://github.com/MixedRealityToolkit/MixedRealityToolkit-Unity/pull/1043)
 
 ## [3.2.2] - 2024-09-18
 

--- a/org.mixedrealitytoolkit.input/Controllers/ArticulatedHandController.cs
+++ b/org.mixedrealitytoolkit.input/Controllers/ArticulatedHandController.cs
@@ -86,15 +86,8 @@ namespace MixedReality.Toolkit.Input
                 // If we still don't have an aggregator, then don't update selects.
                 if (XRSubsystemHelpers.HandsAggregator == null) { return; }
 
-                bool gotPinchData = XRSubsystemHelpers.HandsAggregator.TryGetPinchProgress(
-                    handNode,
-                    out bool isPinchReady,
-                    out bool isPinching,
-                    out float pinchAmount
-                );
-
                 // If we got pinch data, write it into our select interaction state.
-                if (gotPinchData)
+                if (XRSubsystemHelpers.HandsAggregator.TryGetPinchProgress(handNode, out bool isPinchReady, out _, out float pinchAmount))
                 {
                     // Workaround for missing select actions on devices without interaction profiles
                     // for hands, such as Varjo and Quest. Should be removed once we have universal

--- a/org.mixedrealitytoolkit.input/Simulation/Devices/MRTKSimulatedControllerState.cs
+++ b/org.mixedrealitytoolkit.input/Simulation/Devices/MRTKSimulatedControllerState.cs
@@ -60,7 +60,7 @@ namespace MixedReality.Toolkit.Input.Simulation
         [InputControl(name = nameof(XRSimulatedController.primaryTouch), usage = "PrimaryTouch", layout = "Button", bit = (uint)ControllerButton.PrimaryTouch)]
         [InputControl(name = nameof(XRSimulatedController.secondaryButton), usage = "SecondaryButton", layout = "Button", bit = (uint)ControllerButton.SecondaryButton)]
         [InputControl(name = nameof(XRSimulatedController.secondaryTouch), usage = "SecondaryTouch", layout = "Button", bit = (uint)ControllerButton.SecondaryTouch)]
-        [InputControl(name = nameof(XRSimulatedController.gripButton), usage = "GripButton", layout = "Button", bit = (uint)ControllerButton.GripButton, alias = "gripPressed")]
+        [InputControl(name = nameof(XRSimulatedController.gripButton), usage = "GripButton", layout = "Button", bit = (uint)ControllerButton.GripButton, aliases = new[] { "gripPressed", "squeezeClicked" })]
         [InputControl(name = nameof(XRSimulatedController.triggerButton), usage = "TriggerButton", layout = "Button", bit = (uint)ControllerButton.TriggerButton, alias = "triggerPressed")]
         [InputControl(name = nameof(XRSimulatedController.menuButton), usage = "MenuButton", layout = "Button", bit = (uint)ControllerButton.MenuButton)]
         [InputControl(name = nameof(XRSimulatedController.primary2DAxisClick), usage = "Primary2DAxisClick", layout = "Button", bit = (uint)ControllerButton.Primary2DAxisClick)]

--- a/org.mixedrealitytoolkit.input/Simulation/Devices/MRTKSimulatedControllerState.cs
+++ b/org.mixedrealitytoolkit.input/Simulation/Devices/MRTKSimulatedControllerState.cs
@@ -42,7 +42,7 @@ namespace MixedReality.Toolkit.Input.Simulation
         /// <summary>
         /// Represents the user's grip on the controller.
         /// </summary>
-        [InputControl(usage = "Grip", layout = "Axis")]
+        [InputControl(usage = "Grip", alias = "squeeze", layout = "Axis")]
         [FieldOffset(12)]
         public float grip;
 

--- a/org.mixedrealitytoolkit.input/Simulation/Devices/SimulatedController.cs
+++ b/org.mixedrealitytoolkit.input/Simulation/Devices/SimulatedController.cs
@@ -435,10 +435,7 @@ namespace MixedReality.Toolkit.Input.Simulation
                 // simulatedControllerState.primary2DAxis = controls.Primary2DAxis;
                 // simulatedControllerState.secondary2DAxis = controls.Secondary2DAxis;
 
-                // Note: if trigger button is activated, the joint synthesizer will instantly pinch, without smoothing.
-                // If smoothed pinch is desired, use controls.TriggerAxis.
                 simulatedControllerState.WithButton(ControllerButton.TriggerButton, controls.TriggerButton);
-
                 simulatedControllerState.WithButton(ControllerButton.GripButton, controls.GripButton);
 
                 // todo: "soon"

--- a/org.mixedrealitytoolkit.input/Simulation/InputSimulator.cs
+++ b/org.mixedrealitytoolkit.input/Simulation/InputSimulator.cs
@@ -314,11 +314,6 @@ namespace MixedReality.Toolkit.Input.Simulation
             set => rightControllerSettings = value;
         }
 
-        // Should we pass the trigger button straight through to the device?
-        // This will not smooth the trigger press; typically, we should
-        // modulate the trigger axis control ourselves for smooth pinch/unpinch.
-        private bool shouldUseTriggerButton = false;
-
         // TODO: Drive from inspector/simulator options.
         private float triggerSmoothTime = 0.1f;
 
@@ -556,14 +551,7 @@ namespace MixedReality.Toolkit.Input.Simulation
 #endif // LATER
 
                     // Buttons available to hands and controllers
-                    // Should we pass the trigger button straight through to the device?
-                    // This will not smooth the trigger press; typically, we should
-                    // modulate the trigger axis control ourselves for smooth pinch/unpinch,
-                    // and this is false.
-                    if (shouldUseTriggerButton)
-                    {
-                        controls.TriggerButton = ctrlSettings.TriggerButton.action.IsPressed();
-                    }
+                    controls.TriggerButton = controls.TriggerAxis >= InputSystem.settings.defaultButtonPressPoint;
                     controls.GripButton = ctrlSettings.GripButton.action.IsPressed();
 
                     if (ctrlSettings.SimulationMode == ControllerSimulationMode.MotionController)

--- a/org.mixedrealitytoolkit.input/Tests/Runtime/Utilities/InputTestUtilities.cs
+++ b/org.mixedrealitytoolkit.input/Tests/Runtime/Utilities/InputTestUtilities.cs
@@ -7,6 +7,7 @@
 using MixedReality.Toolkit.Input.Simulation;
 using System.Collections;
 using UnityEngine;
+using UnityEngine.InputSystem;
 
 #if UNITY_EDITOR
 using UnityEditor;
@@ -16,7 +17,7 @@ using HandshapeId = MixedReality.Toolkit.Input.HandshapeTypes.HandshapeId;
 
 namespace MixedReality.Toolkit.Input.Tests
 {
-    public class InputTestUtilities
+    public static class InputTestUtilities
     {
         private const string MRTKRigPrefabGuid = "4d7e2f87fefe0ba468719b15288b46e7";
         private static readonly string MRTKRigPrefabPath = AssetDatabase.GUIDToAssetPath(MRTKRigPrefabGuid);
@@ -297,6 +298,7 @@ namespace MixedReality.Toolkit.Input.Tests
                 );
                 float pinchAmount = Mathf.Lerp(startPinch, isPinching ? 1 : 0, t);
 
+                controls.TriggerButton = pinchAmount >= InputSystem.settings.defaultButtonPressPoint;
                 controls.TriggerAxis = pinchAmount;
                 switch (anchorPoint)
                 {


### PR DESCRIPTION
* Remaps the synthetic hands config to read the float "select value" action instead of the bool "select" action, since it's read as a float
* Finishes implementing the synthesized `TriggerButton`, accounting for animation smoothing
* Adds a "squeeze" alias for the grip states, to account for broader input action mapping support

All tests continue to pass
<img width="131" height="38" alt="{63A42338-7589-4213-AE25-D338D632C32A}" src="https://github.com/user-attachments/assets/a54c4c51-08e2-48c2-a22c-404caaad1de1" />
