### PR TITLE
Remove HandNode from HandModel

### DIFF
--- a/org.mixedrealitytoolkit.input/Assets/Prefabs/MRTK LeftHand Controller.prefab
+++ b/org.mixedrealitytoolkit.input/Assets/Prefabs/MRTK LeftHand Controller.prefab
@@ -1093,7 +1093,6 @@ MonoBehaviour:
   modelPrefab: {fileID: 1768293572455847265, guid: 2b468cc4fe6d2b44ebc53b958b38b91a, type: 3}
   modelParent: {fileID: 0}
   model: {fileID: 0}
-  handNode: 4
   selectInput:
     m_InputSourceMode: 3
     m_InputActionPerformed:

--- a/org.mixedrealitytoolkit.input/Assets/Prefabs/MRTK RightHand Controller.prefab
+++ b/org.mixedrealitytoolkit.input/Assets/Prefabs/MRTK RightHand Controller.prefab
@@ -292,10 +292,6 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 3239510804178183174, guid: 18c412191cdc9274897f101c7fd5316f, type: 3}
     - target: {fileID: 3853158803892222464, guid: 90f955d6c9d709448a0b1e29e1f9c046, type: 3}
-      propertyPath: handNode
-      value: 5
-      objectReference: {fileID: 0}
-    - target: {fileID: 3853158803892222464, guid: 90f955d6c9d709448a0b1e29e1f9c046, type: 3}
       propertyPath: modelPrefab
       value: 
       objectReference: {fileID: 3973969148631863464, guid: da93d751ddc0f64468dfc02f18d02d00, type: 3}

--- a/org.mixedrealitytoolkit.input/CHANGELOG.md
+++ b/org.mixedrealitytoolkit.input/CHANGELOG.md
@@ -18,6 +18,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 * Updated the minimum editor version to 2022.3.6f1 [PR #1003](https://github.com/MixedRealityToolkit/MixedRealityToolkit-Unity/pull/1003)
 
+### Removed
+
+* Removed HandNode property and field from HandModel, as it was largely unused. [PR #1045](https://github.com/MixedRealityToolkit/MixedRealityToolkit-Unity/pull/1045)
+
 ### Deprecated
 
 * Deprecated IHandedInteractor across the interactor implementations, as its info is now queryable directly from IXRInteractor's handedness property. [PR #1042](https://github.com/MixedRealityToolkit/MixedRealityToolkit-Unity/pull/1042)

--- a/org.mixedrealitytoolkit.input/Controllers/HandModel.cs
+++ b/org.mixedrealitytoolkit.input/Controllers/HandModel.cs
@@ -23,43 +23,31 @@ namespace MixedReality.Toolkit.Input
         /// <summary>
         /// The prefab of the model to show that will be automatically instantiated by this <see cref="MonoBehaviour"/>.
         /// </summary>
-        /// <remarks>Expected to be XRNode.LeftHand or XRNode.RightHand.</remarks>
         public Transform ModelPrefab
         {
             get => modelPrefab;
             set => modelPrefab = value;
         }
 
-        [SerializeField, Tooltip("The transform that is used as the parent for the model prefab when it is instantiated.  Will be set to a new child GameObject if None.")]
+        [SerializeField, Tooltip("The transform that is used as the parent for the model prefab when it is instantiated. Will be set to a new child GameObject if None.")]
         private Transform modelParent;
 
         /// <summary>
-        /// The <see cref="Transform"/> that is used as the parent for the model prefab when it is instantiated.  Will be set to a new child <see cref="GameObject"/> if None.
+        /// The <see cref="Transform"/> that is used as the parent for the model prefab when it is instantiated. Will be set to a new child <see cref="GameObject"/> if None.
         /// </summary>
-        /// <remarks>Expected to be XRNode.LeftHand or XRNode.RightHand.</remarks>
         public Transform ModelParent => modelParent;
 
-        [SerializeField, Tooltip("The instance of the controller model in the scene.  This can be set to an existing object instead of using Model Prefab.")]
+        [SerializeField, Tooltip("The instance of the controller model in the scene. This can be set to an existing object instead of using Model Prefab.")]
         private Transform model;
 
         /// <summary>
-        /// The instance of the model in the scene.  This can be set to an existing object instead of using Model Prefab.
+        /// The instance of the model in the scene. This can be set to an existing object instead of using Model Prefab.
         /// </summary>
-        /// <remarks>Expected to be XRNode.LeftHand or XRNode.RightHand.</remarks>
         public Transform Model => model;
 
         #endregion Properties
 
         #region Associated hand select values
-
-        [SerializeField, Tooltip("The XRNode associated with this Hand Controller. Expected to be XRNode.LeftHand or XRNode.RightHand.")]
-        private XRNode handNode;
-
-        /// <summary>
-        /// The <see cref="XRNode"/> associated with this Hand Model.
-        /// </summary>
-        /// <remarks>Expected to be XRNode.LeftHand or XRNode.RightHand.</remarks>
-        public XRNode HandNode => handNode;
 
         [SerializeField, Tooltip("The XRInputButtonReader representing selection values to be used by the hand model prefab when implementing ISelectInputVisualizer.")]
         private XRInputButtonReader selectInput;
@@ -77,17 +65,12 @@ namespace MixedReality.Toolkit.Input
         /// </summary>
         protected virtual void Start()
         {
-            if (!HandNode.Equals(XRNode.LeftHand) && !HandNode.Equals(XRNode.RightHand))
-            {
-                Debug.LogWarning("HandNode is not set to XRNode.LeftHand or XRNode.RightHand. HandNode is expected to be XRNode.LeftHand or XRNode.RightHand.");
-            }
-
             // Instantiate the model prefab if it is set
             if (ModelPrefab != null)
             {
                 model = Instantiate(ModelPrefab, ModelParent);
 
-                Debug.Assert(selectInput != null, $"The Select Input reader for {handNode} is not set and will not be used with the instantiated hand model.");
+                Debug.Assert(selectInput != null, $"The Select Input reader for {name} is not set and will not be used with the instantiated hand model.");
 
                 // Set the select input reader for the model if it implements ISelectInputVisualizer
                 if (selectInput != null && model != null && model.TryGetComponent(out ISelectInputVisualizer selectInputVisualizer))

--- a/org.mixedrealitytoolkit.input/Tests/Runtime/BasicInputTests.cs
+++ b/org.mixedrealitytoolkit.input/Tests/Runtime/BasicInputTests.cs
@@ -626,9 +626,6 @@ namespace MixedReality.Toolkit.Input.Tests
             var modelFieldInfo = fieldInfos.Where(fieldInfo => fieldInfo.Name.Equals("model")).ToArray();
             Assert.AreEqual(1, modelFieldInfo.Length, "HandModel is missing the 'model' field");
 
-            var handNodeFieldInfo = fieldInfos.Where(fieldInfo => fieldInfo.Name.Equals("handNode")).ToArray();
-            Assert.AreEqual(1, modelFieldInfo.Length, "HandModel is missing the 'handNode' field");
-
             var modelPrefabAccessorInfo = accessorsInfos.Where(accessorInfo => accessorInfo.Name.Equals("ModelPrefab")).ToArray();
             Assert.AreEqual(1, modelPrefabAccessorInfo.Length, "HandModel is missing the 'ModelPrefab' accessor");
 
@@ -637,9 +634,6 @@ namespace MixedReality.Toolkit.Input.Tests
 
             var modelAccessorInfo = accessorsInfos.Where(accessorInfo => accessorInfo.Name.Equals("Model")).ToArray();
             Assert.AreEqual(1, modelAccessorInfo.Length, "HandModel is missing the 'Model' accessor");
-
-            var handNodeAccessorInfo = accessorsInfos.Where(accessorInfo => accessorInfo.Name.Equals("HandNode")).ToArray();
-            Assert.AreEqual(1, handNodeAccessorInfo.Length, "HandModel is missing the 'HandNode' accessor");
 
             yield return null;
         }

--- a/org.mixedrealitytoolkit.input/Tests/Runtime/BasicInputTestsForControllerlessRig.cs
+++ b/org.mixedrealitytoolkit.input/Tests/Runtime/BasicInputTestsForControllerlessRig.cs
@@ -464,7 +464,6 @@ namespace MixedReality.Toolkit.Input.Tests
             var leftHandHandModels = leftHandGameObject.GetComponents<HandModel>();
             Assert.AreEqual(1, leftHandHandModels.Length);
             HandModel leftHandHandModel = leftHandHandModels[0];
-            Assert.AreEqual(XRNode.LeftHand, leftHandHandModel.HandNode);
             Assert.IsTrue(leftHandHandModel.Model.name.Equals(OpenXRLeftHandCloneName));
             Assert.AreEqual(leftHandHandModel.ModelParent.transform.parent, leftHandGameObject.transform);
             Assert.IsTrue(leftHandHandModel.ModelPrefab.name.Equals(OpenXRLeftHandName));
@@ -472,7 +471,6 @@ namespace MixedReality.Toolkit.Input.Tests
             var rigtHandHandModels = rightHandGameObject.GetComponents<HandModel>();
             Assert.AreEqual(1, rigtHandHandModels.Length);
             HandModel rightHandHandModel = rigtHandHandModels[0];
-            Assert.AreEqual(XRNode.RightHand, rightHandHandModel.HandNode);
             Assert.IsTrue(rightHandHandModel.Model.name.Equals(OpenXRRightHandCloneName));
             Assert.AreEqual(rightHandHandModel.ModelParent.transform.parent, rightHandHandModel.transform);
             Assert.IsTrue(rightHandHandModel.ModelPrefab.name.Equals(OpenXRRightHandName));
@@ -963,9 +961,6 @@ namespace MixedReality.Toolkit.Input.Tests
             var modelFieldInfo = fieldInfos.Where(fieldInfo => fieldInfo.Name.Equals("model")).ToArray();
             Assert.AreEqual(1, modelFieldInfo.Length, "HandModel is missing the 'model' field");
 
-            var handNodeFieldInfo = fieldInfos.Where(fieldInfo => fieldInfo.Name.Equals("handNode")).ToArray();
-            Assert.AreEqual(1, modelFieldInfo.Length, "HandModel is missing the 'handNode' field");
-
             var modelPrefabAccessorInfo = accessorsInfos.Where(accessorInfo => accessorInfo.Name.Equals("ModelPrefab")).ToArray();
             Assert.AreEqual(1, modelPrefabAccessorInfo.Length, "HandModel is missing the 'ModelPrefab' accessor");
 
@@ -974,9 +969,6 @@ namespace MixedReality.Toolkit.Input.Tests
 
             var modelAccessorInfo = accessorsInfos.Where(accessorInfo => accessorInfo.Name.Equals("Model")).ToArray();
             Assert.AreEqual(1, modelAccessorInfo.Length, "HandModel is missing the 'Model' accessor");
-
-            var handNodeAccessorInfo = accessorsInfos.Where(accessorInfo => accessorInfo.Name.Equals("HandNode")).ToArray();
-            Assert.AreEqual(1, handNodeAccessorInfo.Length, "HandModel is missing the 'HandNode' accessor");
 
             yield return null;
         }


### PR DESCRIPTION
This field was only used for a log, so I'm removing it for simplicity.