### PR TITLE
Update tests to follow existing MRTK test patterns

### DIFF
--- a/org.mixedrealitytoolkit.core/CHANGELOG.md
+++ b/org.mixedrealitytoolkit.core/CHANGELOG.md
@@ -4,6 +4,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## Unreleased
 
+## Changed
+
+* Updated tests to follow existing MRTK test patterns. [PR #1046](https://github.com/MixedRealityToolkit/MixedRealityToolkit-Unity/pull/1046)
+
 ### Fixed
 
 * Fixed broken project validation help link, for item 'MRTK3 profile may need to be assigned for the Standalone build target' (Issue #882) [PR #886](https://github.com/MixedRealityToolkit/MixedRealityToolkit-Unity/pull/886)

--- a/org.mixedrealitytoolkit.core/Tests/Runtime/InteractableEventRouterTests.cs
+++ b/org.mixedrealitytoolkit.core/Tests/Runtime/InteractableEventRouterTests.cs
@@ -4,6 +4,7 @@
 // Disable "missing XML comment" warning for tests. While nice to have, this documentation is not required.
 #pragma warning disable CS1591
 
+using MixedReality.Toolkit.Core.Tests;
 using MixedReality.Toolkit.Experimental;
 using NUnit.Framework;
 using System.Collections;
@@ -16,7 +17,7 @@ namespace MixedReality.Toolkit.UX.Runtime.Tests
     /// <summary>
     /// Tests for the <see cref="InteractableEventRouter"/> class.
     /// </summary>
-    public class InteractableEventRouterTests : MonoBehaviour
+    public class InteractableEventRouterTests : BaseRuntimeTests
     {
         private GameObject level0 = null;
         private GameObject interactorObject = null;
@@ -38,7 +39,7 @@ namespace MixedReality.Toolkit.UX.Runtime.Tests
 
         /// <summary>
         /// A cached reference to the <see cref="XRInteractionManager"/> in the scene.
-        /// Cleared during <see cref="Teardown"/> at the end of each test.
+        /// Cleared during <see cref="TearDown"/> at the end of each test.
         /// </summary>
         private XRInteractionManager CachedInteractionManager
         {
@@ -52,14 +53,13 @@ namespace MixedReality.Toolkit.UX.Runtime.Tests
             }
         }
 
-        [SetUp]
-        public void Init()
+        public override IEnumerator Setup()
         {
+            yield return base.Setup();
             CreateTestObjectsWithEventRouter();
         }
 
-        [TearDown]
-        public void Teardown()
+        public override IEnumerator TearDown()
         {
             if (level0 != null)
             {
@@ -80,6 +80,8 @@ namespace MixedReality.Toolkit.UX.Runtime.Tests
             level1_testInteractableParent = null;
             level2_statefulInteractableChild = null;
             level2_testInteractableChild = null;
+
+            yield return base.TearDown();
         }
 
         [UnityTest]
@@ -270,7 +272,7 @@ namespace MixedReality.Toolkit.UX.Runtime.Tests
         {
             var levelA = new GameObject("level a");
             var levelB = new GameObject("level b");
- 
+
             // Setup level b 
             levelB.AddComponent<StatefulInteractable>();
             var levelB_testInteractableParent = levelB.AddComponent<TestInteractableParent>();
@@ -302,7 +304,7 @@ namespace MixedReality.Toolkit.UX.Runtime.Tests
             Assert.AreEqual(1, levelB_testInteractableParent.ChildSelectExitedCount, "The child select exited event should have occurred once.");
 
 
-            Destroy(levelA);
+            Object.Destroy(levelA);
             level0 = null;
             level1 = null;
             level2 = null;
@@ -346,7 +348,7 @@ namespace MixedReality.Toolkit.UX.Runtime.Tests
             Assert.AreEqual(1, level2_testInteractableChild.ParentSelectExitedCount, "The parent select exited event should have occurred once.");
 
 
-            Destroy(levelA);
+            Object.Destroy(levelA);
             level0 = null;
             level1 = null;
             level2 = null;

--- a/org.mixedrealitytoolkit.input/CHANGELOG.md
+++ b/org.mixedrealitytoolkit.input/CHANGELOG.md
@@ -10,6 +10,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 * Added support for Unity's com.unity.cloud.gltfast and com.unity.cloud.ktx packages when loading controller models. [PR #631](https://github.com/MixedRealityToolkit/MixedRealityToolkit-Unity/pull/631)
 * Added toggle for frame rate independent smoothing in camera simulation. [PR #1011](https://github.com/MixedRealityToolkit/MixedRealityToolkit-Unity/pull/1011)
 
+## Changed
+
+* Updated tests to follow existing MRTK test patterns. [PR #1046](https://github.com/MixedRealityToolkit/MixedRealityToolkit-Unity/pull/1046)
+
 ### Fixed
 
 * Fixed controller model fallback visualization becoming stuck visible when hands became tracked after initialization. [PR #984](https://github.com/MixedRealityToolkit/MixedRealityToolkit-Unity/pull/984)

--- a/org.mixedrealitytoolkit.uxcomponents/Tests/Runtime/NonNativeKeyboardTests.cs
+++ b/org.mixedrealitytoolkit.uxcomponents/Tests/Runtime/NonNativeKeyboardTests.cs
@@ -9,7 +9,6 @@ using MixedReality.Toolkit.Input.Tests;
 using MixedReality.Toolkit.UX.Experimental;
 using NUnit.Framework;
 using System.Collections;
-using System.Threading.Tasks;
 using TMPro;
 using UnityEditor;
 using UnityEngine;
@@ -19,104 +18,106 @@ using HandshapeId = MixedReality.Toolkit.Input.HandshapeTypes.HandshapeId;
 
 namespace MixedReality.Toolkit.UX.Runtime.Tests
 {
-	/// <summary>
-	/// Tests for the Canvas Non-Native keyboard prefab. 
-	/// </summary>
-	public class NonNativeKeyboardTests : BaseRuntimeInputTests
-	{
-		// Keyboard/NonNativeKeyboard.prefab
-		private const string NonNativeKeyboardGuid = "74b589d1efab94a4cb70e4b5c22783f8";
-		private static readonly string NonNativeKeyboardPath = AssetDatabase.GUIDToAssetPath(NonNativeKeyboardGuid);
+    /// <summary>
+    /// Tests for the Canvas Non-Native keyboard prefab. 
+    /// </summary>
+    public class NonNativeKeyboardTests : BaseRuntimeInputTests
+    {
+        // Keyboard/NonNativeKeyboard.prefab
+        private const string NonNativeKeyboardGuid = "74b589d1efab94a4cb70e4b5c22783f8";
+        private static readonly string NonNativeKeyboardPath = AssetDatabase.GUIDToAssetPath(NonNativeKeyboardGuid);
 
-		private NonNativeKeyboard testKeyboard = null;
-		private KeyboardPreview keyboardPreview = null;
+        private NonNativeKeyboard testKeyboard = null;
+        private KeyboardPreview keyboardPreview = null;
 
-		[SetUp]
-		public void Init()
-		{
-			testKeyboard = InstantiatePrefab(NonNativeKeyboardPath).GetComponent<NonNativeKeyboard>();
+        public override IEnumerator Setup()
+        {
+            yield return base.Setup();
+            testKeyboard = InstantiatePrefab(NonNativeKeyboardPath).GetComponent<NonNativeKeyboard>();
             testKeyboard.transform.position = InputTestUtilities.InFrontOfUser(distanceFromHead: 2.0f);
             keyboardPreview = testKeyboard.Preview;
             testKeyboard.Open();
-		}
+        }
 
-		[TearDown]
-		public void Teardown()
-		{
-			Object.Destroy(testKeyboard);
-			// Wait for a frame to give Unity a change to actually destroy the object
-		}
+        public override IEnumerator TearDown()
+        {
+            Object.Destroy(testKeyboard);
+            // Wait for a frame to give Unity a change to actually destroy the object
+            yield return null;
+            Assert.IsTrue(testKeyboard == null);
+            yield return base.TearDown();
+        }
 
-		[UnityTest]
-		public IEnumerator TestNonNativeKeyboardInstantiate()
-		{
-			Assert.IsNotNull(testKeyboard, "NonNativeKeyboard component exists on prefab");
-			yield return null;
-		}
+        [UnityTest]
+        public IEnumerator TestNonNativeKeyboardInstantiate()
+        {
+            Assert.IsNotNull(testKeyboard, "NonNativeKeyboard component exists on prefab");
+            yield return null;
+        }
 
-		[UnityTest]
-		public IEnumerator TestNonnativeValueKey()
-		{
+        [UnityTest]
+        public IEnumerator TestNonnativeValueKey()
+        {
             yield return TypeString("q");
-			Assert.AreEqual("q", keyboardPreview.Text, "q", "Pressing key did not change text.");
-		}
+            Assert.AreEqual("q", keyboardPreview.Text, "q", "Pressing key did not change text.");
+        }
 
-		[UnityTest]
-		public IEnumerator TestNonnativeValueKeyShift()
-		{
-			NonNativeValueKey fKey = FindValueKey('f');
-			Assert.IsNotNull(fKey, "Unable to find the 'f' key.");
+        [UnityTest]
+        public IEnumerator TestNonnativeValueKeyShift()
+        {
+            NonNativeValueKey fKey = FindValueKey('f');
+            Assert.IsNotNull(fKey, "Unable to find the 'f' key.");
 
-			TMP_Text textMeshProText = fKey.gameObject.GetComponentInChildren<TMP_Text>();
-			Assert.AreEqual(fKey.CurrentValue, "f", "Current value is set correctly");
-			Assert.AreEqual(textMeshProText.text, "f", "TMP text is set correctly");
+            TMP_Text textMeshProText = fKey.gameObject.GetComponentInChildren<TMP_Text>();
+            Assert.AreEqual(fKey.CurrentValue, "f", "Current value is set correctly");
+            Assert.AreEqual(textMeshProText.text, "f", "TMP text is set correctly");
 
             yield return TypeFunctionKey(NonNativeFunctionKey.Function.Shift);
-			Assert.AreEqual(fKey.CurrentValue, "F", "Current value shifts correctly");
-			Assert.AreEqual(textMeshProText.text, "F", "TMP text shifts correctly");
+            Assert.AreEqual(fKey.CurrentValue, "F", "Current value shifts correctly");
+            Assert.AreEqual(textMeshProText.text, "F", "TMP text shifts correctly");
 
             yield return TypeFunctionKey(NonNativeFunctionKey.Function.Shift);
             Assert.AreEqual(fKey.CurrentValue, "f", "Current value is un-shifts correctly");
-			Assert.AreEqual(textMeshProText.text, "f", "TMP text un-shifts correctly");
-		}
+            Assert.AreEqual(textMeshProText.text, "f", "TMP text un-shifts correctly");
+        }
 
-		[UnityTest]
-		public IEnumerator TestNonnativeShiftFunctionKey()
-		{
+        [UnityTest]
+        public IEnumerator TestNonnativeShiftFunctionKey()
+        {
             yield return TypeString("m");
-			Assert.AreEqual("m", keyboardPreview.Text, "Value should be lower case to start with.");
+            Assert.AreEqual("m", keyboardPreview.Text, "Value should be lower case to start with.");
             yield return TypeString("M");
-			Assert.AreEqual("mM", keyboardPreview.Text, "Value should be upper case immediately after clicking shift key.");
+            Assert.AreEqual("mM", keyboardPreview.Text, "Value should be upper case immediately after clicking shift key.");
             yield return TypeString("m");
             Assert.AreEqual("mMm", keyboardPreview.Text, "Value should be lower case after shift key was consumed.");
-		}
+        }
 
-		[UnityTest]
-		public IEnumerator TestNonnativeSpaceFunctionKey()
+        [UnityTest]
+        public IEnumerator TestNonnativeSpaceFunctionKey()
         {
             yield return TypeString("a");
             yield return TypeFunctionKey(NonNativeFunctionKey.Function.Space);
             yield return TypeString("b");
 
-			Assert.AreEqual(keyboardPreview.Text, "a b", "The Space function key works.");
-			yield return null;
-		}
+            Assert.AreEqual(keyboardPreview.Text, "a b", "The Space function key works.");
+            yield return null;
+        }
 
-		[UnityTest]
-		public IEnumerator TestNonnativeEnterFunctionKey()
-		{
-			testKeyboard.SubmitOnEnter = false;
+        [UnityTest]
+        public IEnumerator TestNonnativeEnterFunctionKey()
+        {
+            testKeyboard.SubmitOnEnter = false;
 
             yield return TypeString("a");
             yield return TypeFunctionKey(NonNativeFunctionKey.Function.Enter);
             yield return TypeString("b");
 
-			Assert.AreEqual(keyboardPreview.Text, "a\nb", "The Enter function key works.");
-			yield return null;
-		}
+            Assert.AreEqual(keyboardPreview.Text, "a\nb", "The Enter function key works.");
+            yield return null;
+        }
 
-		[UnityTest]
-		public IEnumerator TestNonnativeTabFunctionKey()
+        [UnityTest]
+        public IEnumerator TestNonnativeTabFunctionKey()
         {
             yield return TypeString("a");
             yield return TypeFunctionKey(NonNativeFunctionKey.Function.Symbol);
@@ -125,13 +126,13 @@ namespace MixedReality.Toolkit.UX.Runtime.Tests
             yield return TypeString("b");
 
             Assert.AreEqual(keyboardPreview.Text, "a\tb", "The Tab function key works.");
-			yield return null;
-		}
+            yield return null;
+        }
 
-		[UnityTest]
-		public IEnumerator TestNonnativeAlphaSymbolFunctionKeys()
-		{
-			GameObject alphaKeysSection = testKeyboard.AlphaKeysSection;
+        [UnityTest]
+        public IEnumerator TestNonnativeAlphaSymbolFunctionKeys()
+        {
+            GameObject alphaKeysSection = testKeyboard.AlphaKeysSection;
             GameObject defaultBottomSection = testKeyboard.DefaultBottomKeysSection;
             GameObject symbolKeysSection = testKeyboard.SymbolKeysSection;
             GameObject emailSection = testKeyboard.EmailBottomKeysSection;
@@ -154,86 +155,86 @@ namespace MixedReality.Toolkit.UX.Runtime.Tests
             Assert.IsFalse(emailSection.activeInHierarchy, "Email keys should be hidden.");
 
             yield return null;
-		}
+        }
 
-		[UnityTest]
-		public IEnumerator TestNonnativePreviousNextFunctionKeys()
-		{
+        [UnityTest]
+        public IEnumerator TestNonnativePreviousNextFunctionKeys()
+        {
             yield return TypeString("ac");
             yield return TypeFunctionKey(NonNativeFunctionKey.Function.Previous);
             yield return TypeString("b");
 
-			Assert.AreEqual("abc", keyboardPreview.Text, "The Previous function failed to work.");
+            Assert.AreEqual("abc", keyboardPreview.Text, "The Previous function failed to work.");
 
 
             yield return TypeString("a");
             yield return TypeFunctionKey(NonNativeFunctionKey.Function.Next);
             yield return TypeString("a");
 
-			Assert.AreEqual("abaca", keyboardPreview.Text, "The Next function failed to work");
-		}
+            Assert.AreEqual("abaca", keyboardPreview.Text, "The Next function failed to work");
+        }
 
-		[UnityTest]
-		public IEnumerator TestNonnativeCloseFunctionKey()
-		{
-			NonNativeFunctionKey closeKey = FindFunctionKey(NonNativeFunctionKey.Function.Close);
-			testKeyboard.ProcessFunctionKeyPress(closeKey);
+        [UnityTest]
+        public IEnumerator TestNonnativeCloseFunctionKey()
+        {
+            NonNativeFunctionKey closeKey = FindFunctionKey(NonNativeFunctionKey.Function.Close);
+            testKeyboard.ProcessFunctionKeyPress(closeKey);
 
-			Assert.AreEqual(keyboardPreview.Text, "", "The input field is cleared.");
-			Assert.IsTrue(!testKeyboard.gameObject.activeInHierarchy, "The keyboard is inactive.");
-			yield return null;
-		}
+            Assert.AreEqual(keyboardPreview.Text, "", "The input field is cleared.");
+            Assert.IsTrue(!testKeyboard.gameObject.activeInHierarchy, "The keyboard is inactive.");
+            yield return null;
+        }
 
-		[UnityTest]
-		public IEnumerator TestNonnativeBackspaceFunctionKey()
+        [UnityTest]
+        public IEnumerator TestNonnativeBackspaceFunctionKey()
         {
             yield return TypeString("a");
             yield return TypeFunctionKey(NonNativeFunctionKey.Function.Backspace);
             yield return TypeString("b");
 
-			Assert.AreEqual(keyboardPreview.Text, "b", "The Tab function key works.");
-			testKeyboard.Open();
-			yield return null;
-		}
+            Assert.AreEqual(keyboardPreview.Text, "b", "The Tab function key works.");
+            testKeyboard.Open();
+            yield return null;
+        }
 
-		[UnityTest]
-		public IEnumerator TestNonnativeKeyboardSubmitOnEnter()
-		{
-			testKeyboard.SubmitOnEnter = true;
-			NonNativeFunctionKey enterKey = FindFunctionKey(NonNativeFunctionKey.Function.Enter);
-			testKeyboard.ProcessFunctionKeyPress(enterKey);
+        [UnityTest]
+        public IEnumerator TestNonnativeKeyboardSubmitOnEnter()
+        {
+            testKeyboard.SubmitOnEnter = true;
+            NonNativeFunctionKey enterKey = FindFunctionKey(NonNativeFunctionKey.Function.Enter);
+            testKeyboard.ProcessFunctionKeyPress(enterKey);
 
-			Assert.AreEqual(keyboardPreview.Text, "", "The input field is cleared.");
-			Assert.IsTrue(!testKeyboard.gameObject.activeInHierarchy, "The keyboard is inactive.");
-			yield return null;
-		}
+            Assert.AreEqual(keyboardPreview.Text, "", "The input field is cleared.");
+            Assert.IsTrue(!testKeyboard.gameObject.activeInHierarchy, "The keyboard is inactive.");
+            yield return null;
+        }
 
-		[UnityTest]
-		public IEnumerator TestNonnativeKeyboardCloseOnInactivity()
-		{
-			testKeyboard.CloseOnInactivity = true;
-			testKeyboard.CloseOnInactivityTime = .01f;
+        [UnityTest]
+        public IEnumerator TestNonnativeKeyboardCloseOnInactivity()
+        {
+            testKeyboard.CloseOnInactivity = true;
+            testKeyboard.CloseOnInactivityTime = .01f;
 
             yield return TypeString("a");
             yield return new WaitForSeconds(0.05f);
             yield return RuntimeTestUtilities.WaitForUpdates();
 
             Assert.AreEqual(keyboardPreview.Text, "", "The input field is cleared.");
-			Assert.IsTrue(!testKeyboard.gameObject.activeInHierarchy, "The keyboard is inactive.");
-		}
+            Assert.IsTrue(!testKeyboard.gameObject.activeInHierarchy, "The keyboard is inactive.");
+        }
 
-		[UnityTest]
-		public IEnumerator TestNonnativeValueKeyPressKeyWithHand()
-		{
-			TestHand hand = new TestHand(Handedness.Right);
-			Vector3 initialHandPosition = InputTestUtilities.InFrontOfUser(new Vector3(0.05f, -0.05f, 0.3f)); // orient hand so far interaction ray will hit button
-			yield return hand.Show(initialHandPosition);
+        [UnityTest]
+        public IEnumerator TestNonnativeValueKeyPressKeyWithHand()
+        {
+            TestHand hand = new TestHand(Handedness.Right);
+            Vector3 initialHandPosition = InputTestUtilities.InFrontOfUser(new Vector3(0.05f, -0.05f, 0.3f)); // orient hand so far interaction ray will hit button
+            yield return hand.Show(initialHandPosition);
             yield return RuntimeTestUtilities.WaitForUpdates();
 
             string text = "hello";
             yield return TypeStringWithHand(hand, text);
             Assert.AreEqual(text, keyboardPreview.Text, "Hand entered string did not work correctly.");
-		}
+        }
 
         [UnityTest]
         public IEnumerator TestKeyboardPreviewWithLeftToRightPreviewText()
@@ -258,7 +259,7 @@ namespace MixedReality.Toolkit.UX.Runtime.Tests
             yield return TypeString(testString1);
             Assert.AreEqual(testString1, keyboardPreview.PreviewText.text, "Label text did not update.");
 
-            var newLabelPosition1  = keyboardPreview.PreviewText.rectTransform.localPosition;
+            var newLabelPosition1 = keyboardPreview.PreviewText.rectTransform.localPosition;
             Assert.IsTrue(newLabelPosition1 == startLabelPosition, "Label transform should not have moved, as nothing should have scrolled off.");
 
             var newCursorPosition1 = keyboardPreview.PreviewCaret.localPosition;
@@ -434,35 +435,35 @@ namespace MixedReality.Toolkit.UX.Runtime.Tests
             yield return RuntimeTestUtilities.WaitForUpdates();
         }
 
-		private NonNativeValueKey FindValueKey(char value)
-		{
-			NonNativeValueKey[] keys = testKeyboard.gameObject.GetComponentsInChildren<NonNativeValueKey>(true);
-			foreach (NonNativeValueKey key in keys)
-			{
-				if (key.isActiveAndEnabled &&
+        private NonNativeValueKey FindValueKey(char value)
+        {
+            NonNativeValueKey[] keys = testKeyboard.gameObject.GetComponentsInChildren<NonNativeValueKey>(true);
+            foreach (NonNativeValueKey key in keys)
+            {
+                if (key.isActiveAndEnabled &&
                     !string.IsNullOrEmpty(key.CurrentValue) &&
                     char.ToUpperInvariant(key.CurrentValue[0]) == char.ToUpperInvariant(value)) return key;
-			}
-			return null;
-		}
+            }
+            return null;
+        }
 
-		private NonNativeFunctionKey FindFunctionKey(NonNativeFunctionKey.Function function)
-		{
-			NonNativeFunctionKey[] keys = testKeyboard.gameObject.GetComponentsInChildren<NonNativeFunctionKey>(true);
-			foreach (NonNativeFunctionKey key in keys)
-			{
-				if (key.isActiveAndEnabled && key.KeyFunction == function) return key;
-			}
-			return null;
-		}
+        private NonNativeFunctionKey FindFunctionKey(NonNativeFunctionKey.Function function)
+        {
+            NonNativeFunctionKey[] keys = testKeyboard.gameObject.GetComponentsInChildren<NonNativeFunctionKey>(true);
+            foreach (NonNativeFunctionKey key in keys)
+            {
+                if (key.isActiveAndEnabled && key.KeyFunction == function) return key;
+            }
+            return null;
+        }
 
-		private GameObject InstantiatePrefab(string prefabPath)
-		{
-			Object pressableButtonPrefab = AssetDatabase.LoadAssetAtPath(prefabPath, typeof(Object));
-			GameObject testGO = Object.Instantiate(pressableButtonPrefab) as GameObject;
+        private GameObject InstantiatePrefab(string prefabPath)
+        {
+            Object pressableButtonPrefab = AssetDatabase.LoadAssetAtPath(prefabPath, typeof(Object));
+            GameObject testGO = Object.Instantiate(pressableButtonPrefab) as GameObject;
 
-			return testGO;
-		}
-	}
+            return testGO;
+        }
+    }
 }
 #pragma warning restore CS1591

--- a/org.mixedrealitytoolkit.uxcomponents/Tests/Runtime/ScrollableTests.cs
+++ b/org.mixedrealitytoolkit.uxcomponents/Tests/Runtime/ScrollableTests.cs
@@ -30,21 +30,24 @@ namespace MixedReality.Toolkit.UX.Runtime.Tests
         bool firstPressableButtonClicked;
         Vector2 startScrollPosition;
 
-        [SetUp]
-        public void Init()
+        public override IEnumerator Setup()
         {
+            yield return base.Setup();
             firstPressableButtonClicked = false;
             startScrollPosition = Vector2.zero;
             hand = new TestHand(Handedness.Right);
         }
 
-        [TearDown]
-        public void Teardown()
+        public override IEnumerator TearDown()
         {
             if (scrollObject != null)
             {
                 Object.Destroy(scrollObject);
+                // Wait for a frame to give Unity a change to actually destroy the object
+                yield return null;
+                Assert.IsTrue(scrollObject == null);
             }
+            yield return base.TearDown();
         }
 
         [UnityTest]
@@ -311,7 +314,7 @@ namespace MixedReality.Toolkit.UX.Runtime.Tests
 
         private IEnumerator ShowHand()
         {
-            Vector3 initialHandPosition = InputTestUtilities.InFrontOfUser(new Vector3(0.05f, -0.05f, 0.3f)); 
+            Vector3 initialHandPosition = InputTestUtilities.InFrontOfUser(new Vector3(0.05f, -0.05f, 0.3f));
             yield return hand.Show(initialHandPosition);
             yield return RuntimeTestUtilities.WaitForUpdates();
         }
@@ -326,7 +329,7 @@ namespace MixedReality.Toolkit.UX.Runtime.Tests
 
         private void SetEnableOnPressableButtons(GameObject container, bool enable)
         {
-           if (container != null)
+            if (container != null)
             {
                 PressableButton[] pressableButtons = container.GetComponentsInChildren<PressableButton>();
                 foreach (PressableButton pressableButton in pressableButtons)

--- a/org.mixedrealitytoolkit.uxcore/CHANGELOG.md
+++ b/org.mixedrealitytoolkit.uxcore/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Changed
 
 * StateVisualizer: Modified access modifiers of State, stateContainers and UpdateStateValue to protected internal to allow adding states through subclassing. [PR #926](https://github.com/MixedRealityToolkit/MixedRealityToolkit-Unity/pull/926)
+* Updated tests to follow existing MRTK test patterns. [PR #1046](https://github.com/MixedRealityToolkit/MixedRealityToolkit-Unity/pull/1046)
 
 ### Fixed
 

--- a/org.mixedrealitytoolkit.uxcore/Tests/Runtime/KeyboardPreviewTests.cs
+++ b/org.mixedrealitytoolkit.uxcore/Tests/Runtime/KeyboardPreviewTests.cs
@@ -4,9 +4,9 @@
 // Disable "missing XML comment" warning for tests. While nice to have, this documentation is not required.
 #pragma warning disable CS1591
 
-using System.Collections;
 using MixedReality.Toolkit.Input.Tests;
 using NUnit.Framework;
+using System.Collections;
 using UnityEngine;
 using UnityEngine.TestTools;
 
@@ -22,9 +22,9 @@ namespace MixedReality.Toolkit.UX.Runtime.Tests
         /// <summary>
         /// Initialize the keyboard tests by creating a game object with a <see cref="KeyboardPreview"/> component.
         /// </summary>
-        [SetUp]
-        public void Init()
+        public override IEnumerator Setup()
         {
+            yield return base.Setup();
             GameObject obj = new GameObject("KeyboardPreview");
             obj.AddComponent<Canvas>();
             obj.SetActive(false);
@@ -34,10 +34,13 @@ namespace MixedReality.Toolkit.UX.Runtime.Tests
         /// <summary>
         /// Clean-up the keyboard tests by destroying the game object with the <see cref="KeyboardPreview"/> component.
         /// </summary>
-        [TearDown]
-        public void Teardown()
+        public override IEnumerator TearDown()
         {
             Object.Destroy(keyboardPreview);
+            // Wait for a frame to give Unity a change to actually destroy the object
+            yield return null;
+            Assert.IsTrue(keyboardPreview == null);
+            yield return base.TearDown();
         }
 
         /// <summary>

--- a/org.mixedrealitytoolkit.uxcore/Tests/Runtime/NonNativeKeyboardTests.cs
+++ b/org.mixedrealitytoolkit.uxcore/Tests/Runtime/NonNativeKeyboardTests.cs
@@ -4,10 +4,10 @@
 // Disable "missing XML comment" warning for tests. While nice to have, this documentation is not required.
 #pragma warning disable CS1591
 
-using System.Collections;
 using MixedReality.Toolkit.Input.Tests;
 using MixedReality.Toolkit.UX.Experimental;
 using NUnit.Framework;
+using System.Collections;
 using TMPro;
 using UnityEngine;
 using UnityEngine.TestTools;
@@ -26,9 +26,9 @@ namespace MixedReality.Toolkit.UX.Runtime.Tests
         /// Initialize the non-native keyboard tests by creating a game object with a <see cref="NonNativeKeyboard"/> component,
         /// and then opening this component.
         /// </summary>
-        [SetUp]
-        public void Init()
+        public override IEnumerator Setup()
         {
+            yield return base.Setup();
             GameObject obj = new GameObject("Keyboard");
             obj.AddComponent<Canvas>();
             obj.SetActive(false);
@@ -39,10 +39,13 @@ namespace MixedReality.Toolkit.UX.Runtime.Tests
         /// <summary>
         /// Clean-up the non-native keyboard tests by destroying the game object with the <see cref="NonNativeKeyboard"/> component.
         /// </summary>
-        [TearDown]
-        public void Teardown()
+        public override IEnumerator TearDown()
         {
             Object.Destroy(keyboard);
+            // Wait for a frame to give Unity a change to actually destroy the object
+            yield return null;
+            Assert.IsTrue(keyboard == null);
+            yield return base.TearDown();
         }
 
         /// <summary>
@@ -57,7 +60,7 @@ namespace MixedReality.Toolkit.UX.Runtime.Tests
             StatefulInteractable interactable = keyQ.gameObject.GetComponentInChildren<StatefulInteractable>();
             interactable.OnClicked.Invoke();
 
-            Assert.AreEqual(keyboard.Text.Substring(0,1), "q", "Pressing key changes InputField text.");
+            Assert.AreEqual(keyboard.Text.Substring(0, 1), "q", "Pressing key changes InputField text.");
 
             yield return null;
         }
@@ -207,7 +210,7 @@ namespace MixedReality.Toolkit.UX.Runtime.Tests
             keyObj.SetActive(false);
             keyObj.AddComponent<Button>();
 
-            if(statefulInteractable)
+            if (statefulInteractable)
             {
                 keyObj.AddComponent<StatefulInteractable>();
             }

--- a/org.mixedrealitytoolkit.uxcore/Tests/Runtime/VirtualizedScrollRectListTests.cs
+++ b/org.mixedrealitytoolkit.uxcore/Tests/Runtime/VirtualizedScrollRectListTests.cs
@@ -4,11 +4,11 @@
 // Disable "missing XML comment" warning for tests. While nice to have, this documentation is not required.
 #pragma warning disable CS1591
 
-using System.Collections;
-using System.Linq;
 using MixedReality.Toolkit.Input.Tests;
 using MixedReality.Toolkit.UX.Experimental;
 using NUnit.Framework;
+using System.Collections;
+using System.Linq;
 using UnityEditor;
 using UnityEngine;
 using UnityEngine.TestTools;
@@ -57,13 +57,16 @@ namespace MixedReality.Toolkit.UX.Runtime.Tests
             go.transform.name = wordSet2[i % wordSet2.Length];
         }
 
-        [TearDown]
-        public void Teardown()
+        public override IEnumerator TearDown()
         {
             if (virtualizedScrollRectList != null)
             {
                 Object.Destroy(virtualizedScrollRectList);
+                // Wait for a frame to give Unity a change to actually destroy the object
+                yield return null;
+                Assert.IsTrue(virtualizedScrollRectList == null);
             }
+            yield return base.TearDown();
         }
 
         [UnityTest]


### PR DESCRIPTION
* Updated InteractableEventRouterTests to inherit from BaseRuntimeTests, to use the built-in setup and teardown methods
* Updated other test files to properly override the BaseRuntimeTests setup and teardown methods instead of redefining them

All tests continue to pass: 
<img width="131" height="35" alt="{97BF84F9-4CBA-4E5B-81CA-D9AEAF8B74EA}" src="https://github.com/user-attachments/assets/8ce669a7-2b74-4aa6-99ec-756ca4290aaa" />
