### PR TITLE
Clarify newly obsolete code due to XRI3 refactor

### DIFF
--- a/org.mixedrealitytoolkit.core/Interactors/IModeManagedInteractor.cs
+++ b/org.mixedrealitytoolkit.core/Interactors/IModeManagedInteractor.cs
@@ -16,7 +16,7 @@ namespace MixedReality.Toolkit
         /// Returns the GameObject that this interactor belongs to. This GameObject is governed by the
         /// interaction mode manager and is assigned an interaction mode. This GameObject represents the 'controller' that this interactor belongs to.
         /// </summary>
-        [Obsolete("This function is obsolete and will be removed in the next major release. Use ModeManagedRoot instead.")]
+        [Obsolete("This function has been deprecated in version 4.0.0 and will be removed in the next major release. Use ModeManagedRoot instead.")]
         public GameObject GetModeManagedController();
 
         /// <summary>

--- a/org.mixedrealitytoolkit.core/Utilities/ControllerLookup.cs
+++ b/org.mixedrealitytoolkit.core/Utilities/ControllerLookup.cs
@@ -13,7 +13,7 @@ namespace MixedReality.Toolkit
     /// </summary>
     [DisallowMultipleComponent]
     [AddComponentMenu("MRTK/Core/Controller Lookup")]
-    [Obsolete("Deprecated, please use MixedReality.Toolkit.Input.TrackedPoseDriverLookup instead.")]
+    [Obsolete("ControllerLookup has been deprecated in version 4.0.0. Please use MixedReality.Toolkit.Input.TrackedPoseDriverLookup instead.")]
     public class ControllerLookup : MonoBehaviour
     {
         // Gaze

--- a/org.mixedrealitytoolkit.input/Controllers/ActionBasedControllerWithFallbacks.cs
+++ b/org.mixedrealitytoolkit.input/Controllers/ActionBasedControllerWithFallbacks.cs
@@ -19,7 +19,7 @@ namespace MixedReality.Toolkit.Input
     /// state will have no position and no rotation data. In this case, the controller may want to fallback to head pose.
     /// </remarks>
     [AddComponentMenu("MRTK/Input/XR Controller (Action-based with Fallbacks)")]
-    [Obsolete("Deprecated, please use MixedReality.Toolkit.Input.TrackedPoseDriverWithFallback")]
+    [Obsolete("ActionBasedControllerWithFallbacks has been deprecated in version 4.0.0. Please use MixedReality.Toolkit.Input.TrackedPoseDriverWithFallback")]
     public class ActionBasedControllerWithFallbacks : ActionBasedController
     {
         #region Fallback actions values

--- a/org.mixedrealitytoolkit.input/Controllers/ArticulatedHandController.cs
+++ b/org.mixedrealitytoolkit.input/Controllers/ArticulatedHandController.cs
@@ -17,7 +17,7 @@ namespace MixedReality.Toolkit.Input
     /// This is able to support variable pinch select through the use of <see cref="HandsAggregatorSubsystem"/>.
     /// </remarks>
     [AddComponentMenu("MRTK/Input/XR Controller (Articulated Hand)")]
-    [Obsolete]
+    [Obsolete("ArticulatedHandController has been deprecated in version 4.0.0. Its functionality has been distributed into different components.")]
     public class ArticulatedHandController : ActionBasedController
     {
         #region Associated hand select values

--- a/org.mixedrealitytoolkit.input/InteractionModes/FlatScreenModeDetector.cs
+++ b/org.mixedrealitytoolkit.input/InteractionModes/FlatScreenModeDetector.cs
@@ -4,9 +4,7 @@
 using System;
 using System.Collections.Generic;
 using UnityEngine;
-using UnityEngine.InputSystem.XR;
 using UnityEngine.Serialization;
-using UnityEngine.XR;
 
 namespace MixedReality.Toolkit.Input
 {
@@ -23,7 +21,7 @@ namespace MixedReality.Toolkit.Input
 
         public InteractionMode ModeOnDetection => flatScreenInteractionMode;
 
-        [Obsolete("Deprecated, please use MixedReality.Toolkit.Input.TrackedPoseDriverLookup instead.")]
+        [Obsolete("This field has been deprecated in version 4.0.0. Please use MixedReality.Toolkit.Input.TrackedPoseDriverLookup instead.")]
         protected ControllerLookup controllerLookup = null;
 
         protected TrackedPoseDriverLookup trackedPoseDriverLookup = null;
@@ -40,22 +38,22 @@ namespace MixedReality.Toolkit.Input
             trackedPoseDriverLookup = ComponentCache<TrackedPoseDriverLookup>.FindFirstActiveInstance();
         }
 
-        /// <inheritdoc /> 
-        [Obsolete("This function is obsolete and will be removed in a future version. Please use GetInteractorGroups instead.")]
+        /// <inheritdoc />
+        [Obsolete("This function has been deprecated in version 4.0.0 and will be removed in a future version. Please use GetInteractorGroups instead.")]
         public List<GameObject> GetControllers() => GetInteractorGroups();
 
-        /// <inheritdoc /> 
+        /// <inheritdoc />
         public List<GameObject> GetInteractorGroups() => interactorGroups;
 
         public bool IsModeDetected()
         {
             // Flat screen mode is only active if the Left and Right Hands aren't being tracked
-            #pragma warning disable CS0618 // Type or member is obsolete
+#pragma warning disable CS0618 // Type or member is obsolete
             if (controllerLookup != null)
             {
                 return !controllerLookup.LeftHandController.currentControllerState.inputTrackingState.HasPositionAndRotation() && !controllerLookup.RightHandController.currentControllerState.inputTrackingState.HasPositionAndRotation();
             }
-            #pragma warning restore CS0618
+#pragma warning restore CS0618
             else if (trackedPoseDriverLookup != null)
             {
                 return !trackedPoseDriverLookup.LeftHandTrackedPoseDriver.GetInputTrackingState().HasPositionAndRotation() &&

--- a/org.mixedrealitytoolkit.input/InteractionModes/IInteractionModeDetector.cs
+++ b/org.mixedrealitytoolkit.input/InteractionModes/IInteractionModeDetector.cs
@@ -4,8 +4,6 @@
 using System;
 using System.Collections.Generic;
 using UnityEngine;
-using UnityEngine.XR.Interaction.Toolkit;
-
 
 namespace MixedReality.Toolkit.Input
 {
@@ -32,7 +30,7 @@ namespace MixedReality.Toolkit.Input
         /// Get a list of the <see cref="GameObject"/> instances which represent the controllers that this interaction mode detector has jurisdiction over.
         /// </summary>
         /// <returns>The list of the <see cref="GameObject"/> instances which represent the controllers that this interaction mode detector has jurisdiction over.</returns>
-        [Obsolete("This function is obsolete and will be removed in a future version. Please use GetInteractorGroups instead.")]
+        [Obsolete("This function has been deprecated in version 4.0.0 and will be removed in a future version. Please use GetInteractorGroups instead.")]
         List<GameObject> GetControllers();
 
         /// <summary>

--- a/org.mixedrealitytoolkit.input/InteractionModes/InteractionDetector.cs
+++ b/org.mixedrealitytoolkit.input/InteractionModes/InteractionDetector.cs
@@ -110,11 +110,11 @@ namespace MixedReality.Toolkit.Input
         [Tooltip("List of GameObjects which represent the interactor groups that this interaction mode detector has jurisdiction over. Interaction modes will be set on all specified groups.")]
         private List<GameObject> interactorGroups;
 
-        /// <inheritdoc /> 
-        [Obsolete("This function is obsolete and will be removed in a future version. Please use GetInteractorGroups instead.")]
+        /// <inheritdoc />
+        [Obsolete("This function has been deprecated in version 4.0.0 and will be removed in a future version. Please use GetInteractorGroups instead.")]
         public List<GameObject> GetControllers() => GetInteractorGroups();
 
-        /// <inheritdoc /> 
+        /// <inheritdoc />
         public List<GameObject> GetInteractorGroups() => interactorGroups;
 
         /// <inheritdoc />

--- a/org.mixedrealitytoolkit.input/InteractionModes/InteractionModeManager.cs
+++ b/org.mixedrealitytoolkit.input/InteractionModes/InteractionModeManager.cs
@@ -556,7 +556,7 @@ namespace MixedReality.Toolkit.Input
             GameObject interactorGroupObject = null;
 
             // For backwards compatibility, we will continue to support the obsolete "controller-based" interactors,
-            // and group based on "controller" partents.
+            // and group based on "controller" parents.
 #pragma warning disable CS0618 // xrController is obsolete
             if (interactor is XRBaseInputInteractor controllerInteractor &&
                 controllerInteractor.xrController != null)

--- a/org.mixedrealitytoolkit.input/InteractionModes/InteractionModeManager.cs
+++ b/org.mixedrealitytoolkit.input/InteractionModes/InteractionModeManager.cs
@@ -11,8 +11,6 @@ using UnityEngine.Serialization;
 using UnityEngine.XR.Interaction.Toolkit;
 using UnityEngine.XR.Interaction.Toolkit.Interactors;
 
-using TrackedPoseDriver = UnityEngine.InputSystem.XR.TrackedPoseDriver;
-
 namespace MixedReality.Toolkit.Input
 {
     /// <summary>
@@ -72,7 +70,7 @@ namespace MixedReality.Toolkit.Input
         /// <summary>
         /// Editor only function for initializing the Interaction Mode Manager with the existing XR controllers in the scene
         /// </summary>
-        [Obsolete("This method is obsolete. Please use InitializeInteractorGroups instead.")]
+        [Obsolete("This method has been deprecated in version 4.0.0. Please use InitializeInteractorGroups instead.")]
         public void InitializeControllers()
         {
             foreach (XRBaseController xrController in FindObjectUtility.FindObjectsByType<XRBaseController>())
@@ -436,13 +434,10 @@ namespace MixedReality.Toolkit.Input
                 {
                     List<GameObject> groups = detector.GetInteractorGroups();
 
-                    // For backwards compatibility, we will continue to support the obsolete "GetControllers()" function.
-                    if (groups == null)
-                    {
 #pragma warning disable CS0618 // GetControllers is obsolete
-                        groups = detector.GetControllers();
+                    // For backwards compatibility, we will continue to support the obsolete "GetControllers()" function.
+                    groups ??= detector.GetControllers();
 #pragma warning restore CS0618 // GetControllers is obsolete
-                    }
 
                     foreach (GameObject group in groups)
                     {

--- a/org.mixedrealitytoolkit.input/InteractionModes/ProximityDetector.cs
+++ b/org.mixedrealitytoolkit.input/InteractionModes/ProximityDetector.cs
@@ -41,7 +41,7 @@ namespace MixedReality.Toolkit.Input
         private List<GameObject> interactorGroups;
 
         /// <inheritdoc /> 
-        [Obsolete("This function is obsolete and will be removed in a future version. Please use GetInteractorGroups instead.")]
+        [Obsolete("This function has been deprecated in version 4.0.0 and will be removed in a future version. Please use GetInteractorGroups instead.")]
         public List<GameObject> GetControllers() => GetInteractorGroups();
 
         /// <inheritdoc /> 

--- a/org.mixedrealitytoolkit.input/Interactors/Gaze/GazeInteractor.cs
+++ b/org.mixedrealitytoolkit.input/Interactors/Gaze/GazeInteractor.cs
@@ -34,19 +34,12 @@ namespace MixedReality.Toolkit.Input
         }
 
         /// <inheritdoc/>
-        [Obsolete("This function is obsolete and will be removed in the next major release. Use ModeManagedRoot instead.")]
+        [Obsolete("This function has been deprecated in version 4.0.0 and will be removed in the next major release. Use ModeManagedRoot instead.")]
         public GameObject GetModeManagedController()
         {
             // Legacy controller-based interactors should return null, so the legacy controller-based logic in the
             // interaction mode manager is used instead.
-#pragma warning disable CS0618 // forceDeprecatedInput is obsolete
-            if (forceDeprecatedInput)
-            {
-                return null;
-            }
-#pragma warning restore CS0618 // forceDeprecatedInput is obsolete
-
-            return ModeManagedRoot;
+            return forceDeprecatedInput ? null : ModeManagedRoot;
         }
     }
 }

--- a/org.mixedrealitytoolkit.input/Interactors/GazePinch/GazePinchInteractor.cs
+++ b/org.mixedrealitytoolkit.input/Interactors/GazePinch/GazePinchInteractor.cs
@@ -56,7 +56,7 @@ namespace MixedReality.Toolkit.Input
 
         [SerializeField]
         [Tooltip("The hand controller used to get the selection progress values")]
-        [Obsolete("Deprecated, please use this.TrackedPoseDriver instead.")]
+        [Obsolete("This field has been deprecated in version 4.0.0. Please use this.TrackedPoseDriver instead.")]
         private ArticulatedHandController handController;
 
         /// <summary>
@@ -327,11 +327,11 @@ namespace MixedReality.Toolkit.Input
 
         /// <summary>
         /// Given the specified interactable, this computes and applies the relevant
-        /// position and rotation to the attach transform. 
+        /// position and rotation to the attach transform.
         /// </summary>
         /// <remarks>
-        /// If there is currently an active selection, the attach transform is computed 
-        /// as an offset from selected object, where the offset vector is a function of 
+        /// If there is currently an active selection, the attach transform is computed
+        /// as an offset from selected object, where the offset vector is a function of
         /// the centroid between all currently participating <see cref="GazePinchInteractor"/>
         /// objects. This models ray-like manipulations, but with virtual attach offsets
         /// from object, modeled from the relationship between each participating hand.
@@ -485,7 +485,7 @@ namespace MixedReality.Toolkit.Input
             interactorLocalAttachPoint = Quaternion.Inverse(noRollRay) * (virtualAttachTransform - aimPose.position);
 
             // Record the distance from the controller to the body of the user, to use as reference for subsequent
-            // distance measurements. 
+            // distance measurements.
             bodyDistanceOnSelect = PoseUtilities.GetDistanceToBody(aimPose);
         }
 
@@ -568,21 +568,16 @@ namespace MixedReality.Toolkit.Input
         #endregion ITrackedInteractor
 
         #region IModeManagedInteractor
+
         /// <inheritdoc/>
-        [Obsolete("This function is obsolete and will be removed in the next major release. Use ModeManagedRoot instead.")]
+        [Obsolete("This function has been deprecated in version 4.0.0 and will be removed in the next major release. Use ModeManagedRoot instead.")]
         public GameObject GetModeManagedController()
         {
             // Legacy controller-based interactors should return null, so the legacy controller-based logic in the
             // interaction mode manager is used instead.
-#pragma warning disable CS0618 // Type or member is obsolete 
-            if (forceDeprecatedInput)
-            {
-                return null;
-            }
-#pragma warning restore CS0618 // Type or member is obsolete
-
-            return ModeManagedRoot;
+            return forceDeprecatedInput ? null : ModeManagedRoot;
         }
+
         #endregion IModeManagedInteractor
 
         #region Private Methods

--- a/org.mixedrealitytoolkit.input/Interactors/HandJointInteractor.cs
+++ b/org.mixedrealitytoolkit.input/Interactors/HandJointInteractor.cs
@@ -158,21 +158,16 @@ namespace MixedReality.Toolkit.Input
         #endregion XRBaseInputInteractor
 
         #region IModeManagedInteractor
+
         /// <inheritdoc/>
-        [Obsolete("This function is obsolete and will be removed in the next major release. Use ModeManagedRoot instead.")]
+        [Obsolete("This function has been deprecated in version 4.0.0 and will be removed in the next major release. Use ModeManagedRoot instead.")]
         public GameObject GetModeManagedController()
         {
             // Legacy controller-based interactors should return null, so the legacy controller-based logic in the
             // interaction mode manager is used instead.
-#pragma warning disable CS0618 // Type or member is obsolete 
-            if (forceDeprecatedInput)
-            {
-                return null;
-            }
-#pragma warning restore CS0618 // Type or member is obsolete
-
-            return ModeManagedRoot;
+            return forceDeprecatedInput ? null : ModeManagedRoot;
         }
+
         #endregion IModeManagedInteractor
 
         #region Unity Event Functions

--- a/org.mixedrealitytoolkit.input/Interactors/Poke/PokeInteractor.cs
+++ b/org.mixedrealitytoolkit.input/Interactors/Poke/PokeInteractor.cs
@@ -326,21 +326,16 @@ namespace MixedReality.Toolkit.Input
         #endregion ITrackedInteractor
 
         #region IModeManagedInteractor
+
         /// <inheritdoc/>
-        [Obsolete("This function is obsolete and will be removed in the next major release. Use ModeManagedRoot instead.")]
+        [Obsolete("This function has been deprecated in version 4.0.0 and will be removed in the next major release. Use ModeManagedRoot instead.")]
         public GameObject GetModeManagedController()
         {
             // Legacy controller-based interactors should return null, so the legacy controller-based logic in the
             // interaction mode manager is used instead.
-#pragma warning disable CS0618 // Type or member is obsolete 
-            if (forceDeprecatedInput)
-            {
-                return null;
-            }
-#pragma warning restore CS0618 // Type or member is obsolete
-
-            return ModeManagedRoot;
+            return forceDeprecatedInput ? null : ModeManagedRoot;
         }
+
         #endregion IModeManagedInteractor
     }
 }

--- a/org.mixedrealitytoolkit.input/Interactors/Ray/MRTKRayInteractor.cs
+++ b/org.mixedrealitytoolkit.input/Interactors/Ray/MRTKRayInteractor.cs
@@ -348,21 +348,16 @@ namespace MixedReality.Toolkit.Input
         #endregion XRBaseInteractor
 
         #region IModeManagedInteractor
+
         /// <inheritdoc/>
-        [Obsolete("This function is obsolete and will be removed in the next major release. Use ModeManagedRoot instead.")]
+        [Obsolete("This function has been deprecated in version 4.0.0 and will be removed in the next major release. Use ModeManagedRoot instead.")]
         public GameObject GetModeManagedController()
         {
             // Legacy controller-based interactors should return null, so the legacy controller-based logic in the
             // interaction mode manager is used instead.
-#pragma warning disable CS0618 // Type or member is obsolete 
-            if (forceDeprecatedInput)
-            {
-                return null;
-            }
-#pragma warning restore CS0618 // Type or member is obsolete
-
-            return ModeManagedRoot;
+            return forceDeprecatedInput ? null : ModeManagedRoot;
         }
+
         #endregion IModeManagedInteractor
 
         #region Unity Event Functions

--- a/org.mixedrealitytoolkit.input/Utilities/PoseSource/FallbackCompositePoseSource.cs
+++ b/org.mixedrealitytoolkit.input/Utilities/PoseSource/FallbackCompositePoseSource.cs
@@ -11,17 +11,12 @@ namespace MixedReality.Toolkit.Input
     /// which successfully returns a pose.
     /// </summary>
     [Serializable]
-    public class FallbackCompositePoseSource : IPoseSource, ISerializationCallbackReceiver
+    public class FallbackCompositePoseSource : IPoseSource
     {
         [SerializeReference]
         [InterfaceSelector]
         [Tooltip("An ordered list of pose sources to query.")]
         private IPoseSource[] poseSourceList;
-
-        [SerializeField]
-        [Tooltip("An ordered list of pose sources to query.")]
-        [Obsolete, HideInInspector]
-        private PoseSourceWrapper[] poseSources;
 
         /// <summary>
         /// An ordered list of pose sources to query.
@@ -45,34 +40,6 @@ namespace MixedReality.Toolkit.Input
 
             pose = Pose.identity;
             return false;
-        }
-
-        [Obsolete]
-        void ISerializationCallbackReceiver.OnAfterDeserialize()
-        {
-            if (poseSources != null && poseSources.Length > 0)
-            {
-                poseSourceList = new IPoseSource[poseSources.Length];
-
-                for (int i = 0; i < poseSources.Length; i++)
-                {
-                    PoseSourceWrapper poseSource = poseSources[i];
-                    poseSourceList[i] = poseSource.source;
-                }
-
-                poseSources = null;
-            }
-        }
-
-        void ISerializationCallbackReceiver.OnBeforeSerialize() { }
-
-        [Serializable, Obsolete]
-        private struct PoseSourceWrapper
-        {
-            [SerializeReference]
-            [InterfaceSelector]
-            [Tooltip("The pose source we are trying to get the pose of")]
-            public IPoseSource source;
         }
     }
 }

--- a/org.mixedrealitytoolkit.input/Visualizers/RiggedHandVisualizer/RiggedHandMeshVisualizer.cs
+++ b/org.mixedrealitytoolkit.input/Visualizers/RiggedHandVisualizer/RiggedHandMeshVisualizer.cs
@@ -93,7 +93,7 @@ namespace MixedReality.Toolkit.Input
         private List<XRDisplaySubsystem> displaySubsystems = new List<XRDisplaySubsystem>();
 
         // The XRController that is used to determine the pinch strength (i.e., select value!)
-        [Obsolete("This field is obsolete and will be removed in a future version. Use the SelectInput property instead.")]
+        [Obsolete("This field has been deprecated in version 4.0.0 and will be removed in a future version. Use the SelectInput property instead.")]
         private XRBaseController controller;
 
         // The actual, physical, rigged joints that drive the skinned mesh.

--- a/org.mixedrealitytoolkit.spatialmanipulation/BoundsControl/BoundsHandleInteractable.cs
+++ b/org.mixedrealitytoolkit.spatialmanipulation/BoundsControl/BoundsHandleInteractable.cs
@@ -13,7 +13,7 @@ namespace MixedReality.Toolkit.SpatialManipulation
     /// Scale handles subclass this to implement custom occlusion + reorientation logic.
     /// </summary>
     [AddComponentMenu("MRTK/Spatial Manipulation/Bounds Handle Interactable")]
-    public class BoundsHandleInteractable : StatefulInteractable, ISnapInteractable, ISerializationCallbackReceiver
+    public class BoundsHandleInteractable : StatefulInteractable, ISnapInteractable
     {
         private BoundsControl boundsControlRoot;
 
@@ -56,41 +56,6 @@ namespace MixedReality.Toolkit.SpatialManipulation
         [SerializeField]
         [Tooltip("Maximum lossy scale for the handle. Only applicable if ScaleAdjustType is Advanced.")]
         private float maxLossyScale = 4f;
-
-        #region Handling Obsolete Properties
-
-        // A temporary variable used to migrate instances of BoundsHandleInteractable to use the scaleMaintainType property
-        // instead of the serialized field maintainGlobalSize.
-        // TODO: Remove this after some time to ensure users have successfully migrated.
-        [SerializeField, HideInInspector]
-        private bool migratedSuccessfully = false;
-
-        [SerializeField, HideInInspector]
-        private bool maintainGlobalSize = true;
-
-        /// <summary>
-        /// Should the handle maintain its global size, even as the object changes size?
-        /// </summary>
-        [Obsolete("Use ScaleMaintainType instead.")]
-        public bool MaintainGlobalSize
-        {
-            get => scaleMaintainType == ScaleMaintainType.GlobalSize;
-            set => scaleMaintainType = value ? ScaleMaintainType.GlobalSize : ScaleMaintainType.FixedScale;
-        }
-
-        public void OnBeforeSerialize() { }
-
-        public void OnAfterDeserialize()
-        {
-            // Only update the scaleMaintainType if it hasn't been set and the old property was not migrated yet
-            if (!migratedSuccessfully && scaleMaintainType == ScaleMaintainType.GlobalSize)
-            {
-                scaleMaintainType = maintainGlobalSize ? ScaleMaintainType.GlobalSize : ScaleMaintainType.FixedScale;
-                migratedSuccessfully = true;
-            }
-        }
-
-        #endregion Handling Obsolete Properties
 
         #endregion Bounds Handle Scaling
 

--- a/org.mixedrealitytoolkit.spatialmanipulation/Solvers/Solver.cs
+++ b/org.mixedrealitytoolkit.spatialmanipulation/Solvers/Solver.cs
@@ -17,13 +17,13 @@ namespace MixedReality.Toolkit.SpatialManipulation
     [HelpURL("https://docs.microsoft.com/windows/mixed-reality/mrtk-unity/features/ux-building-blocks/solvers/solver")]
     public abstract class Solver : MonoBehaviour
     {
-        [Obsolete("Deprecated, please use MixedReality.Toolkit.Input.TrackedPoseDriverLookup instead.")]
+        [Obsolete("This field has been deprecated in version 4.0.0. Please use MixedReality.Toolkit.Input.TrackedPoseDriverLookup instead.")]
         private static ControllerLookup controllerLookup;
 
         /// <summary>
         /// Get the <see cref="Toolkit.ControllerLookup">ControllerLookup</see> that will be used all application <see cref="Solver"/> objects.
         /// </summary>
-        [Obsolete("Deprecated, please use MixedReality.Toolkit.Input.TrackedPoseDriverLookup instead.")]
+        [Obsolete("This property has been deprecated in version 4.0.0. Please use MixedReality.Toolkit.Input.TrackedPoseDriverLookup instead.")]
         protected static ControllerLookup ControllerLookup => controllerLookup;
 
         private static TrackedPoseDriverLookup trackedPoseDriverLookup;

--- a/org.mixedrealitytoolkit.uxcore/Interop/CanvasProxyInteractor.cs
+++ b/org.mixedrealitytoolkit.uxcore/Interop/CanvasProxyInteractor.cs
@@ -112,7 +112,7 @@ namespace MixedReality.Toolkit.UX
                 }
             }
         }
-        
+
         /// <inheritdoc />
         public override void GetValidTargets(List<IXRInteractable> targets)
         {
@@ -151,7 +151,7 @@ namespace MixedReality.Toolkit.UX
         public override bool isHoverActive => base.isHoverActive && !isCancellingInteraction;
 
         /// <inheritdoc />
-        [Obsolete("This function is obsolete and will be removed in the next major release. Use ModeManagedRoot instead.")]
+        [Obsolete("This function has been deprecated in version 4.0.0 and will be removed in the next major release. Use ModeManagedRoot instead.")]
         public GameObject GetModeManagedController() => ModeManagedRoot;
     }
 }


### PR DESCRIPTION
Updates the new `Obsolete` messages to clarify the version it was deprecated in.
Also removes some stale `Obsolete` code paths from 3.x.