### PR TITLE
Add #defines for glTFast API deprecation

### DIFF
--- a/org.mixedrealitytoolkit.input/MRTK.Input.asmdef
+++ b/org.mixedrealitytoolkit.input/MRTK.Input.asmdef
@@ -36,9 +36,24 @@
             "define": "GLTFAST_PRESENT"
         },
         {
+            "name": "com.unity.cloud.gltfast",
+            "expression": "6.11",
+            "define": "GLTFAST_6_11_OR_NEWER"
+        },
+        {
             "name": "com.atteneder.gltfast",
             "expression": "",
             "define": "GLTFAST_PRESENT"
+        },
+        {
+            "name": "com.atteneder.gltfast",
+            "expression": "6.11",
+            "define": "GLTFAST_6_11_OR_NEWER"
+        },
+        {
+            "name": "com.atteneder.gltfast",
+            "expression": "5",
+            "define": "GLTFAST_5_0_OR_NEWER"
         },
         {
             "name": "com.unity.xr.management",

--- a/org.mixedrealitytoolkit.input/Visualizers/ControllerVisualizer/ControllerModelLoader.cs
+++ b/org.mixedrealitytoolkit.input/Visualizers/ControllerVisualizer/ControllerModelLoader.cs
@@ -105,9 +105,21 @@ namespace MixedReality.Toolkit.Input
 
             // Finally try to create a GameObject from the model data
             GltfImport gltf = new GltfImport();
-            bool success = await gltf.LoadGltfBinary(modelStream);
             gltfGameObject = new GameObject(modelKey.ToString());
-            if (success && await gltf.InstantiateMainSceneAsync(gltfGameObject.transform))
+
+            if (
+#if GLTFAST_6_11_OR_NEWER
+                await gltf.Load(modelStream)
+#else
+                await gltf.LoadGltfBinary(modelStream)
+#endif
+                &&
+#if GLTFAST_5_0_OR_NEWER
+                await gltf.InstantiateMainSceneAsync(gltfGameObject.transform)
+#else
+                gltf.InstantiateMainScene(gltfGameObject.transform)
+#endif
+                )
             {
                 // After all the awaits, double check that another task didn't finish earlier
                 if (controllerModelDictionary.TryGetValue(modelKey, out GameObject existingGameObject) && existingGameObject != null)


### PR DESCRIPTION
I was a bit overzealous in #631 in migrating to newer APIs in this package without properly checking for their addition or removal. This change fixes that!