### PR TITLE
Add a test for multiple/single selection of StatefulInteractable and its various modes

### DIFF
--- a/org.mixedrealitytoolkit.input/CHANGELOG.md
+++ b/org.mixedrealitytoolkit.input/CHANGELOG.md
@@ -4,6 +4,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## Unreleased
 
+### Added
+
+* Added a test for multiple/single selection of `StatefulInteractable` and its various modes. [PR #1069](https://github.com/MixedRealityToolkit/MixedRealityToolkit-Unity/pull/1069)
+
 ### Changed
 
 * Reserialized MRTK XR Rig prefab to remove stale serialized fields. [PR #1110](https://github.com/MixedRealityToolkit/MixedRealityToolkit-Unity/pull/1110)
@@ -49,7 +53,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
-* Fixed missing [CanEditMultipleObject] attributes as per Bug 573 [PR #698](https://github.com/MixedRealityToolkit/MixedRealityToolkit-Unity/pull/698)
+* Fixed missing \[CanEditMultipleObject\] attributes as per Bug 573 [PR #698](https://github.com/MixedRealityToolkit/MixedRealityToolkit-Unity/pull/698)
 * Add logic to account for a bound but untracked interaction profile. [PR #704](https://github.com/MixedRealityToolkit/MixedRealityToolkit-Unity/pull/704)
 * Reduced package description to support for UPM package publishing in the Unity Asset Store.
 * Ensures the simulated input sources hold their state (including gestures) when their toggle state is locked on. [PR #705](https://github.com/MixedRealityToolkit/MixedRealityToolkit-Unity/pull/705)

--- a/org.mixedrealitytoolkit.input/Tests/Runtime/BasicInputTests.cs
+++ b/org.mixedrealitytoolkit.input/Tests/Runtime/BasicInputTests.cs
@@ -318,6 +318,7 @@ namespace MixedReality.Toolkit.Input.Tests
         [UnityTest]
         public IEnumerator TestStatefulInteractableSelectMode(
             [Values(InteractableSelectMode.Single, InteractableSelectMode.Multiple)] InteractableSelectMode selectMode,
+            [Values(true, false)] bool triggerOnRelease,
             [Values(true, false)] bool releaseInSelectOrder)
         {
             GameObject cube = GameObject.CreatePrimitive(PrimitiveType.Cube);
@@ -328,17 +329,28 @@ namespace MixedReality.Toolkit.Input.Tests
             bool isSelected = false;
             bool selectEntered = false;
             bool selectExited = false;
+            int clickCount = 0;
+
+            void ResetState()
+            {
+                selectEntered = false;
+                selectExited = false;
+                clickCount = 0;
+            }
 
             // For this test, we won't use poke or grab selection
             interactable.DisableInteractorType(typeof(PokeInteractor));
             interactable.DisableInteractorType(typeof(GrabInteractor));
             interactable.selectMode = selectMode;
+            interactable.TriggerOnRelease = triggerOnRelease;
 
-            interactable.firstSelectEntered.AddListener((SelectEnterEventArgs) => { isSelected = true; });
-            interactable.lastSelectExited.AddListener((SelectEnterEventArgs) => { isSelected = false; });
+            interactable.firstSelectEntered.AddListener((_) => isSelected = true);
+            interactable.lastSelectExited.AddListener((_) => isSelected = false);
 
-            interactable.selectEntered.AddListener((SelectEnterEventArgs) => { selectEntered = true; });
-            interactable.selectExited.AddListener((SelectEnterEventArgs) => { selectExited = true; });
+            interactable.selectEntered.AddListener((_) => selectEntered = true);
+            interactable.selectExited.AddListener((_) => selectExited = true);
+
+            interactable.OnClicked.AddListener(() => clickCount++);
 
             // Introduce the first hand
             var rightHand = new TestHand(Handedness.Right);
@@ -385,9 +397,10 @@ namespace MixedReality.Toolkit.Input.Tests
                           "StatefulInteractable should have had a select enter.");
             Assert.IsFalse(selectExited,
                            "StatefulInteractable should not have had a select exit.");
+            Assert.AreEqual(triggerOnRelease ? 0 : 1, clickCount);
 
             // Reset to continue testing
-            selectEntered = false;
+            ResetState();
 
             // Release the first hand to deselect the cube
             yield return rightHand.SetHandshape(HandshapeId.Open);
@@ -404,9 +417,10 @@ namespace MixedReality.Toolkit.Input.Tests
                            "StatefulInteractable should not have had a select enter.");
             Assert.IsTrue(selectExited,
                           "StatefulInteractable should have had a select exit.");
+            Assert.AreEqual(triggerOnRelease ? 1 : 0, clickCount);
 
             // Reset to continue testing
-            selectExited = false;
+            ResetState();
 
             // Introduce the second hand
             var leftHand = new TestHand(Handedness.Left);
@@ -448,9 +462,10 @@ namespace MixedReality.Toolkit.Input.Tests
                           "StatefulInteractable should have had a select enter.");
             Assert.IsFalse(selectExited,
                            "StatefulInteractable should not have had a select exit.");
+            Assert.AreEqual(triggerOnRelease ? 0 : 1, clickCount);
 
             // Reset to continue testing
-            selectEntered = false;
+            ResetState();
 
             // Pinch the second hand to select the cube
             yield return leftHand.SetHandshape(HandshapeId.Pinch);
@@ -464,9 +479,6 @@ namespace MixedReality.Toolkit.Input.Tests
             Assert.IsTrue(selectEntered,
                           "StatefulInteractable should have had a select enter.");
 
-            // Reset to continue testing
-            selectEntered = false;
-
             // Both hands are pinching, so we check the select state based on the mode
             switch (selectMode)
             {
@@ -475,19 +487,22 @@ namespace MixedReality.Toolkit.Input.Tests
                                   "StatefulInteractable should only have 1 selecting interactor.");
                     Assert.IsTrue(selectExited,
                                   "StatefulInteractable should have had a select exit.");
-                    // Reset to continue testing
-                    selectExited = false;
+                    Assert.AreEqual(1, clickCount);
                     break;
                 case InteractableSelectMode.Multiple:
                     Assert.IsTrue(interactable.interactorsSelecting.Count == 2,
                                   "StatefulInteractable should have 2 selecting interactors.");
                     Assert.IsFalse(selectExited,
                                    "StatefulInteractable should not have had a select exit.");
+                    Assert.AreEqual(0, clickCount);
                     break;
                 default:
                     Assert.Fail($"Unhandled {nameof(InteractableSelectMode)}={selectMode}");
                     break;
             }
+
+            // Reset to continue testing
+            ResetState();
 
             TestHand firstReleasedHand;
             TestHand secondReleasedHand;
@@ -524,8 +539,7 @@ namespace MixedReality.Toolkit.Input.Tests
                                "StatefulInteractable should not be selected.");
                 Assert.IsTrue(selectExited,
                                "StatefulInteractable should have had a select exit.");
-                // Reset to continue testing
-                selectExited = false;
+                Assert.AreEqual(triggerOnRelease ? 1 : 0, clickCount);
             }
             // The first hand was no longer selecting in Single mode
             // If we're releasing in the same order we selected,
@@ -540,13 +554,12 @@ namespace MixedReality.Toolkit.Input.Tests
                               "StatefulInteractable should only have 1 selecting interactor.");
                 Assert.IsTrue(isSelected,
                               "StatefulInteractable should be selected.");
+                Assert.AreEqual(0, clickCount);
 
                 if (selectMode == InteractableSelectMode.Multiple)
                 {
                     Assert.IsTrue(selectExited,
                                   "StatefulInteractable should have had a select exit.");
-                    // Reset to continue testing
-                    selectExited = false;
                 }
                 else
                 {
@@ -555,6 +568,9 @@ namespace MixedReality.Toolkit.Input.Tests
                                    "StatefulInteractable should not have had a select exit.");
                 }
             }
+
+            // Reset to continue testing
+            ResetState();
 
             // Release the last hand to deselect the cube
             yield return secondReleasedHand.SetHandshape(HandshapeId.Open);
@@ -579,9 +595,11 @@ namespace MixedReality.Toolkit.Input.Tests
             {
                 Assert.IsTrue(selectExited,
                               "StatefulInteractable should have had a select exit.");
-                // Reset to continue testing
-                selectExited = false;
+                Assert.AreEqual(triggerOnRelease ? 1 : 0, clickCount);
             }
+
+            // Reset to continue testing
+            ResetState();
 
             yield return RuntimeTestUtilities.WaitForUpdates();
         }

--- a/org.mixedrealitytoolkit.input/Tests/Runtime/BasicInputTests.cs
+++ b/org.mixedrealitytoolkit.input/Tests/Runtime/BasicInputTests.cs
@@ -315,6 +315,277 @@ namespace MixedReality.Toolkit.Input.Tests
             Assert.IsTrue(interactable.IsGazePinchHovered);
         }
 
+        [UnityTest]
+        public IEnumerator TestStatefulInteractableSelectMode(
+            [Values(InteractableSelectMode.Single, InteractableSelectMode.Multiple)] InteractableSelectMode selectMode,
+            [Values(true, false)] bool releaseInSelectOrder)
+        {
+            GameObject cube = GameObject.CreatePrimitive(PrimitiveType.Cube);
+            StatefulInteractable interactable = cube.AddComponent<StatefulInteractable>();
+            cube.transform.position = InputTestUtilities.InFrontOfUser(new Vector3(0.2f, 0.2f, 0.5f));
+            cube.transform.localScale = Vector3.one * 0.1f;
+
+            bool isSelected = false;
+            bool selectEntered = false;
+            bool selectExited = false;
+
+            // For this test, we won't use poke or grab selection
+            interactable.DisableInteractorType(typeof(PokeInteractor));
+            interactable.DisableInteractorType(typeof(GrabInteractor));
+            interactable.selectMode = selectMode;
+
+            interactable.firstSelectEntered.AddListener((SelectEnterEventArgs) => { isSelected = true; });
+            interactable.lastSelectExited.AddListener((SelectEnterEventArgs) => { isSelected = false; });
+
+            interactable.selectEntered.AddListener((SelectEnterEventArgs) => { selectEntered = true; });
+            interactable.selectExited.AddListener((SelectEnterEventArgs) => { selectExited = true; });
+
+            // Introduce the first hand
+            var rightHand = new TestHand(Handedness.Right);
+            yield return rightHand.Show(InputTestUtilities.InFrontOfUser(0.4f));
+            yield return RuntimeTestUtilities.WaitForUpdates();
+
+            Assert.IsFalse(interactable.IsRayHovered,
+                           "StatefulInteractable was already RayHovered.");
+            Assert.IsFalse(interactable.isHovered,
+                           "StatefulInteractable was already hovered.");
+
+            // Aim the first hand to hover the cube
+            yield return rightHand.AimAt(cube.transform.position);
+            yield return RuntimeTestUtilities.WaitForUpdates();
+            Assert.IsTrue(interactable.IsRayHovered,
+                          "StatefulInteractable did not get RayHovered.");
+            Assert.IsTrue(interactable.isHovered,
+                          "StatefulInteractable did not get hovered.");
+
+            Assert.IsTrue(interactable.HoveringRayInteractors.Count == 1,
+                          "StatefulInteractable should only have 1 hovering RayInteractor.");
+            Assert.IsTrue(interactable.interactorsHovering.Count == 1,
+                          "StatefulInteractable should only have 1 hovering interactor.");
+
+            Assert.IsFalse(isSelected,
+                          "StatefulInteractable should not be selected.");
+            Assert.IsFalse(selectEntered,
+                          "StatefulInteractable should not have had a select enter.");
+            Assert.IsFalse(selectExited,
+                          "StatefulInteractable should not have had a select exit.");
+
+            // Pinch the first hand to select the cube
+            yield return rightHand.SetHandshape(HandshapeId.Pinch);
+            yield return RuntimeTestUtilities.WaitForUpdates();
+            Assert.IsTrue(interactable.IsRaySelected,
+                          "StatefulInteractable did not get RaySelected.");
+            Assert.IsTrue(interactable.isSelected,
+                          "StatefulInteractable did not get selected.");
+            Assert.IsTrue(interactable.interactorsSelecting.Count == 1,
+                          "StatefulInteractable should only have 1 selecting interactor.");
+            Assert.IsTrue(isSelected,
+                          "StatefulInteractable did not get selected.");
+            Assert.IsTrue(selectEntered,
+                          "StatefulInteractable should have had a select enter.");
+            Assert.IsFalse(selectExited,
+                           "StatefulInteractable should not have had a select exit.");
+
+            // Reset to continue testing
+            selectEntered = false;
+
+            // Release the first hand to deselect the cube
+            yield return rightHand.SetHandshape(HandshapeId.Open);
+            yield return RuntimeTestUtilities.WaitForUpdates();
+            Assert.IsFalse(interactable.IsRaySelected,
+                           "StatefulInteractable did not get de-RaySelected.");
+            Assert.IsFalse(interactable.isSelected,
+                           "StatefulInteractable did not get deselected.");
+            Assert.IsTrue(interactable.interactorsSelecting.Count == 0,
+                          "StatefulInteractable should not have any selecting interactors.");
+            Assert.IsFalse(isSelected,
+                           "StatefulInteractable should not be selected.");
+            Assert.IsFalse(selectEntered,
+                           "StatefulInteractable should not have had a select enter.");
+            Assert.IsTrue(selectExited,
+                          "StatefulInteractable should have had a select exit.");
+
+            // Reset to continue testing
+            selectExited = false;
+
+            // Introduce the second hand
+            var leftHand = new TestHand(Handedness.Left);
+            yield return leftHand.Show(InputTestUtilities.InFrontOfUser(0.4f));
+            yield return RuntimeTestUtilities.WaitForUpdates();
+
+            // Aim the second hand to hover the cube
+            yield return leftHand.AimAt(cube.transform.position);
+            yield return RuntimeTestUtilities.WaitForUpdates();
+            Assert.IsTrue(interactable.IsRayHovered,
+                          "StatefulInteractable did not stay RayHovered.");
+            Assert.IsTrue(interactable.isHovered,
+                          "StatefulInteractable did not stay hovered.");
+
+            Assert.IsTrue(interactable.HoveringRayInteractors.Count == 2,
+                          "StatefulInteractable should have 2 hovering RayInteractors.");
+            Assert.IsTrue(interactable.interactorsHovering.Count == 2,
+                          "StatefulInteractable should have 2 hovering interactors.");
+
+            Assert.IsFalse(isSelected,
+                           "StatefulInteractable should not be selected.");
+            Assert.IsFalse(selectEntered,
+                           "StatefulInteractable should not have had a select enter.");
+            Assert.IsFalse(selectExited,
+                           "StatefulInteractable should not have had a select exit.");
+
+            // Pinch the first hand to select the cube
+            yield return rightHand.SetHandshape(HandshapeId.Pinch);
+            yield return RuntimeTestUtilities.WaitForUpdates();
+            Assert.IsTrue(interactable.IsRaySelected,
+                          "StatefulInteractable did not get RaySelected.");
+            Assert.IsTrue(interactable.isSelected,
+                          "StatefulInteractable did not get selected.");
+            Assert.IsTrue(interactable.interactorsSelecting.Count == 1,
+                          "StatefulInteractable should only have 1 selecting interactor.");
+            Assert.IsTrue(isSelected,
+                          "StatefulInteractable did not get selected.");
+            Assert.IsTrue(selectEntered,
+                          "StatefulInteractable should have had a select enter.");
+            Assert.IsFalse(selectExited,
+                           "StatefulInteractable should not have had a select exit.");
+
+            // Reset to continue testing
+            selectEntered = false;
+
+            // Pinch the second hand to select the cube
+            yield return leftHand.SetHandshape(HandshapeId.Pinch);
+            yield return RuntimeTestUtilities.WaitForUpdates();
+            Assert.IsTrue(interactable.IsRaySelected,
+                          "StatefulInteractable did not stay RaySelected.");
+            Assert.IsTrue(interactable.isSelected,
+                          "StatefulInteractable did not stay selected.");
+            Assert.IsTrue(isSelected,
+                          "StatefulInteractable did not stay selected.");
+            Assert.IsTrue(selectEntered,
+                          "StatefulInteractable should have had a select enter.");
+
+            // Reset to continue testing
+            selectEntered = false;
+
+            // Both hands are pinching, so we check the select state based on the mode
+            switch (selectMode)
+            {
+                case InteractableSelectMode.Single:
+                    Assert.IsTrue(interactable.interactorsSelecting.Count == 1,
+                                  "StatefulInteractable should only have 1 selecting interactor.");
+                    Assert.IsTrue(selectExited,
+                                  "StatefulInteractable should have had a select exit.");
+                    // Reset to continue testing
+                    selectExited = false;
+                    break;
+                case InteractableSelectMode.Multiple:
+                    Assert.IsTrue(interactable.interactorsSelecting.Count == 2,
+                                  "StatefulInteractable should have 2 selecting interactors.");
+                    Assert.IsFalse(selectExited,
+                                   "StatefulInteractable should not have had a select exit.");
+                    break;
+                default:
+                    Assert.Fail($"Unhandled {nameof(InteractableSelectMode)}={selectMode}");
+                    break;
+            }
+
+            TestHand firstReleasedHand;
+            TestHand secondReleasedHand;
+            if (releaseInSelectOrder)
+            {
+                firstReleasedHand = rightHand;
+                secondReleasedHand = leftHand;
+            }
+            else
+            {
+                firstReleasedHand = leftHand;
+                secondReleasedHand = rightHand;
+            }
+
+            // Release a hand to deselect the cube
+            yield return firstReleasedHand.SetHandshape(HandshapeId.Open);
+            yield return RuntimeTestUtilities.WaitForUpdates();
+
+            Assert.IsFalse(selectEntered,
+                           "StatefulInteractable should not have had a select enter.");
+
+            // The first hand was no longer selecting in Single mode
+            // If we're releasing in the reverse order we selected,
+            // releasing the second pinch should release the select fully
+            if (!releaseInSelectOrder && selectMode == InteractableSelectMode.Single)
+            {
+                Assert.IsFalse(interactable.IsRaySelected,
+                               "StatefulInteractable did not get de-RaySelected.");
+                Assert.IsFalse(interactable.isSelected,
+                               "StatefulInteractable did not get deselected.");
+                Assert.IsTrue(interactable.interactorsSelecting.Count == 0,
+                               "StatefulInteractable should not have any selecting interactors.");
+                Assert.IsFalse(isSelected,
+                               "StatefulInteractable should not be selected.");
+                Assert.IsTrue(selectExited,
+                               "StatefulInteractable should have had a select exit.");
+                // Reset to continue testing
+                selectExited = false;
+            }
+            // The first hand was no longer selecting in Single mode
+            // If we're releasing in the same order we selected,
+            // we should still be selected regardless of the mode
+            else
+            {
+                Assert.IsTrue(interactable.IsRaySelected,
+                              "StatefulInteractable did not stay RaySelected.");
+                Assert.IsTrue(interactable.isSelected,
+                              "StatefulInteractable did not stay selected.");
+                Assert.IsTrue(interactable.interactorsSelecting.Count == 1,
+                              "StatefulInteractable should only have 1 selecting interactor.");
+                Assert.IsTrue(isSelected,
+                              "StatefulInteractable should be selected.");
+
+                if (selectMode == InteractableSelectMode.Multiple)
+                {
+                    Assert.IsTrue(selectExited,
+                                  "StatefulInteractable should have had a select exit.");
+                    // Reset to continue testing
+                    selectExited = false;
+                }
+                else
+                {
+                    // This select exit happened when the second hand pinched, releasing the first
+                    Assert.IsFalse(selectExited,
+                                   "StatefulInteractable should not have had a select exit.");
+                }
+            }
+
+            // Release the last hand to deselect the cube
+            yield return secondReleasedHand.SetHandshape(HandshapeId.Open);
+            yield return RuntimeTestUtilities.WaitForUpdates();
+            Assert.IsFalse(interactable.IsRaySelected,
+                           "StatefulInteractable did not get de-RaySelected.");
+            Assert.IsFalse(interactable.isSelected,
+                           "StatefulInteractable did not get deselected.");
+            Assert.IsTrue(interactable.interactorsSelecting.Count == 0,
+                           "StatefulInteractable should not have any selecting interactors.");
+            Assert.IsFalse(isSelected,
+                           "StatefulInteractable should not be selected.");
+            Assert.IsFalse(selectEntered,
+                           "StatefulInteractable should not have had a select enter.");
+
+            if (!releaseInSelectOrder && selectMode == InteractableSelectMode.Single)
+            {
+                Assert.IsFalse(selectExited,
+                               "StatefulInteractable should not have had a select exit.");
+            }
+            else
+            {
+                Assert.IsTrue(selectExited,
+                              "StatefulInteractable should have had a select exit.");
+                // Reset to continue testing
+                selectExited = false;
+            }
+
+            yield return RuntimeTestUtilities.WaitForUpdates();
+        }
+
         /// <summary>
         /// A dummy interactor used to test basic selection/toggle logic.
         /// </summary>


### PR DESCRIPTION
Tests pass!
<img width="144" height="38" alt="{09E13013-B969-46FB-B4D2-3FBB12B1B25C}" src="https://github.com/user-attachments/assets/0d57c87a-fd69-4af4-9d69-ad40488ae588" />

| _Release in same order_ | First hand select | Second hand select | First hand release | Second hand release |
|--------|--------|--------|--------|--------|
| **Single**, **triggerOnRelease** | No click | Click | No click | Click |
| **Single**, **!triggerOnRelease** | Click | Click | No click | No click |
| **Multiple**, **triggerOnRelease** | No click | No click | No click | Click
| **Multiple**, **!triggerOnRelease** | Click | No click | No click | No click |

| _Release in reverse order_ | First hand select | Second hand select | Second hand release | First hand release |
|--------|--------|--------|--------|--------|
| **Single**, **triggerOnRelease** | No click | Click | Click | No click |
| **Single**, **!triggerOnRelease** | Click | Click | No click | No click |
| **Multiple**, **triggerOnRelease** | No click | No click | No click | Click |
| **Multiple**, **!triggerOnRelease** | Click | No click | No click | No click |