### PR TITLE
Fix build warning in MRTKHandsAggregatorSubsystem

### DIFF
--- a/org.mixedrealitytoolkit.input/CHANGELOG.md
+++ b/org.mixedrealitytoolkit.input/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 * Fixed "leaked managed shell" issue in `InteractionModeManager`. [PR #1096](https://github.com/MixedRealityToolkit/MixedRealityToolkit-Unity/pull/1096)
 * Fixed `EyeCalibrationChecker` build issue on UWP when the Mixed Reality OpenXR Plugin wasn't installed. [PR #1106](https://github.com/MixedRealityToolkit/MixedRealityToolkit-Unity/pull/1106)
+* Fixed `MRTKHandsAggregatorSubsystem` not reusing local structs that it claimed to be reusing, which was causing a build warning. [PR #1072](https://github.com/MixedRealityToolkit/MixedRealityToolkit-Unity/pull/1072)
 
 ## [3.3.0] - 2025-11-12
 

--- a/org.mixedrealitytoolkit.input/Subsystems/HandsAggregator/MRTKHandsAggregatorSubsystem.cs
+++ b/org.mixedrealitytoolkit.input/Subsystems/HandsAggregator/MRTKHandsAggregatorSubsystem.cs
@@ -259,7 +259,7 @@ namespace MixedReality.Toolkit.Input
                 gotData &= TryGetJoint(TrackedHandJoint.IndexTip, handNode, out HandJointPose indexPose);
                 gotData &= TryGetJoint(TrackedHandJoint.Palm, handNode, out HandJointPose palmPose);
 
-                HandJointPose pinchPointPose = handNode == XRNode.LeftHand ? leftPinchPose : rightPinchPose;
+                ref HandJointPose pinchPointPose = ref (handNode == XRNode.LeftHand ? ref leftPinchPose : ref rightPinchPose);
 
                 // Stabilize the pinch pose by a weighted average between the thumb and index.
                 // A true average (50% thumb, 50% index) is too unstable for precise manipulation.


### PR DESCRIPTION
Actually reuse these structs via ref