### PR TITLE
Improve Font Icon Set name assignment

### DIFF
--- a/UnityProjects/MRTKDevTemplate/Assets/Prefabs/SampleSceneHelper/SampleSceneHandMenu.prefab
+++ b/UnityProjects/MRTKDevTemplate/Assets/Prefabs/SampleSceneHelper/SampleSceneHandMenu.prefab
@@ -1538,7 +1538,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7245587814888172855, guid: c6b351a67ceb69140b199996bbbea156, type: 3}
       propertyPath: currentIconName
-      value: Icon 59
+      value: Chevron Left
       objectReference: {fileID: 0}
     - target: {fileID: 7594107385585372191, guid: c6b351a67ceb69140b199996bbbea156, type: 3}
       propertyPath: m_IsActive
@@ -2147,7 +2147,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7245587814888172855, guid: c6b351a67ceb69140b199996bbbea156, type: 3}
       propertyPath: currentIconName
-      value: Icon 60
+      value: Chevron Right
       objectReference: {fileID: 0}
     - target: {fileID: 7594107385585372191, guid: c6b351a67ceb69140b199996bbbea156, type: 3}
       propertyPath: m_IsActive

--- a/org.mixedrealitytoolkit.standardassets/CHANGELOG.md
+++ b/org.mixedrealitytoolkit.standardassets/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## Unreleased
+
+### Changed
+
+* Updated icon names in MRTK_FluentIconSet.asset and Selawik-Semibold-MRTKIcons.asset to be more descriptive. [PR #1077](https://github.com/MixedRealityToolkit/MixedRealityToolkit-Unity/pull/1077)
+
 ## [3.2.1] - 2025-11-12
 
 ### Fixed

--- a/org.mixedrealitytoolkit.standardassets/Fonts/Selawik-Semibold-MRTKIcons.asset
+++ b/org.mixedrealitytoolkit.standardassets/Fonts/Selawik-Semibold-MRTKIcons.asset
@@ -14,52 +14,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   glyphIconsByName:
     entries:
-    - key: Icon 137
-      value: 63518
-    - key: Icon 136
-      value: 63357
-    - key: Icon 135
-      value: 63323
-    - key: Icon 134
-      value: 63252
-    - key: Icon 133
-      value: 63248
-    - key: Icon 132
-      value: 63146
-    - key: Icon 131
-      value: 63130
-    - key: Icon 130
-      value: 63120
-    - key: Icon 129
-      value: 63104
-    - key: Icon 128
-      value: 63074
-    - key: Icon 127
-      value: 63033
-    - key: Icon 126
-      value: 63022
-    - key: Icon 125
-      value: 63019
-    - key: Icon 124
-      value: 62991
-    - key: Icon 123
-      value: 62984
-    - key: Icon 122
-      value: 62982
-    - key: Icon 121
-      value: 62980
-    - key: Icon 120
-      value: 62978
-    - key: Icon 119
-      value: 62950
-    - key: Icon 118
-      value: 62945
-    - key: Icon 117
-      value: 62910
     - key: Icon 116
       value: 62893
-    - key: Icon 115
-      value: 62889
     - key: Icon 114
       value: 62858
     - key: Icon 113
@@ -70,56 +26,22 @@ MonoBehaviour:
       value: 62828
     - key: Icon 110
       value: 62822
-    - key: Icon 109
-      value: 62817
     - key: Icon 108
       value: 62815
-    - key: Icon 107
-      value: 62810
-    - key: Icon 106
-      value: 62807
-    - key: Icon 105
-      value: 62785
-    - key: Icon 104
-      value: 62727
-    - key: Icon 103
-      value: 62713
-    - key: Icon 102
-      value: 62700
-    - key: Icon 101
-      value: 62693
-    - key: Icon 100
-      value: 62679
-    - key: Icon 99
-      value: 62649
     - key: Icon 98
       value: 62632
-    - key: Icon 97
-      value: 62628
     - key: Icon 96
       value: 62624
-    - key: Icon 95
-      value: 62601
-    - key: Icon 94
-      value: 62593
-    - key: Icon 93
-      value: 62591
     - key: Icon 92
       value: 62586
     - key: Icon 91
       value: 62578
     - key: Icon 90
       value: 62555
-    - key: Icon 89
-      value: 62489
     - key: Icon 88
       value: 62476
-    - key: Icon 87
-      value: 62450
     - key: Icon 86
       value: 62433
-    - key: Icon 85
-      value: 62430
     - key: Icon 84
       value: 62427
     - key: Icon 83
@@ -128,24 +50,14 @@ MonoBehaviour:
       value: 62329
     - key: Icon 81
       value: 62326
-    - key: Icon 80
-      value: 62318
-    - key: Icon 79
-      value: 62314
-    - key: Icon 78
-      value: 62303
     - key: Icon 77
       value: 62298
-    - key: Icon 76
-      value: 62285
     - key: Icon 75
       value: 62277
     - key: Icon 74
       value: 62274
     - key: Icon 73
       value: 62269
-    - key: Icon 72
-      value: 62267
     - key: Icon 71
       value: 62240
     - key: Icon 70
@@ -164,78 +76,32 @@ MonoBehaviour:
       value: 62178
     - key: Icon 63
       value: 62174
-    - key: Icon 62
-      value: 62166
-    - key: Icon 61
-      value: 62135
-    - key: Icon 60
-      value: 62129
-    - key: Icon 59
-      value: 62123
-    - key: Icon 58
-      value: 62116
-    - key: Icon 57
-      value: 62101
     - key: Icon 56
       value: 62087
-    - key: Icon 55
-      value: 62061
     - key: Icon 54
       value: 62059
-    - key: Icon 53
-      value: 62037
-    - key: Icon 52
-      value: 62024
     - key: Icon 51
       value: 61972
     - key: Icon 50
       value: 61967
-    - key: Icon 49
-      value: 61942
     - key: Icon 48
       value: 61923
-    - key: Icon 47
-      value: 61919
     - key: Icon 46
       value: 61877
-    - key: Icon 45
-      value: 61866
-    - key: Icon 44
-      value: 61852
     - key: Icon 43
       value: 61835
-    - key: Icon 42
-      value: 61826
-    - key: Icon 41
-      value: 61810
     - key: Icon 40
       value: 61801
-    - key: Icon 39
-      value: 61788
-    - key: Icon 38
-      value: 61769
     - key: Icon 37
       value: 61760
-    - key: Icon 36
-      value: 61758
-    - key: Icon 35
-      value: 61752
     - key: Icon 34
       value: 61733
     - key: Icon 33
       value: 61731
-    - key: Icon 32
-      value: 61721
-    - key: Icon 31
-      value: 61717
     - key: Icon 30
       value: 61709
-    - key: Icon 29
-      value: 61706
     - key: Icon 28
       value: 60390
-    - key: Icon 27
-      value: 60235
     - key: Icon 26
       value: 60227
     - key: Icon 25
@@ -246,18 +112,8 @@ MonoBehaviour:
       value: 59532
     - key: Icon 22
       value: 59531
-    - key: Icon 21
-      value: 59529
-    - key: Icon 20
-      value: 59527
     - key: Icon 19
       value: 59526
-    - key: Icon 18
-      value: 59525
-    - key: Icon 17
-      value: 59524
-    - key: Icon 16
-      value: 59523
     - key: Icon 15
       value: 59522
     - key: Icon 14
@@ -266,37 +122,180 @@ MonoBehaviour:
       value: 59519
     - key: Icon 12
       value: 59518
-    - key: Icon 11
-      value: 59517
-    - key: Icon 10
-      value: 59512
-    - key: Icon 9
-      value: 59511
-    - key: Icon 8
-      value: 59508
-    - key: Icon 7
-      value: 59476
-    - key: Icon 6
-      value: 59461
     - key: Icon 2
       value: 59416
     - key: Icon 3
       value: 59440
-    - key: Icon 4
-      value: 59456
     - key: Icon 1
       value: 59407
-    - key: Icon 5
-      value: 59460
-    - key: Icon 138
-      value: 63520
-    - key: Icon 139
-      value: 63565
-    - key: Icon 140
-      value: 63594
-    - key: Icon 141
-      value: 63703
     - key: Icon 142
       value: 63742
+    - key: Add Favorite
+      value: 63252
+    - key: Favorite
+      value: 63248
+    - key: Settings
+      value: 63146
+    - key: Send
+      value: 63130
+    - key: Search
+      value: 63120
+    - key: Save
+      value: 63104
+    - key: Question Mark
+      value: 63033
+    - key: Play
+      value: 62982
+    - key: Play Circle
+      value: 62984
+    - key: Brightness
+      value: 59456
+    - key: Unpin
+      value: 62980
+    - key: Pin
+      value: 62978
+    - key: Devices
+      value: 62950
+    - key: Phone
+      value: 62945
+    - key: Person
+      value: 62910
+    - key: Block
+      value: 63022
+    - key: Print
+      value: 63019
+    - key: Stop Circle
+      value: 63323
+    - key: Bluetooth
+      value: 61919
+    - key: Calendar
+      value: 59460
+    - key: Record Circle
+      value: 63074
+    - key: Paste
+      value: 62166
+    - key: Camera
+      value: 62037
+    - key: Add
+      value: 61706
+    - key: Home
+      value: 62593
+    - key: Mute
+      value: 60235
+    - key: Power Button
+      value: 62991
+    - key: Link
+      value: 62693
+    - key: Mic Off
+      value: 62785
+    - key: Lightbulb
+      value: 62679
+    - key: People
+      value: 62889
+    - key: Visibility Off
+      value: 59512
+    - key: Movie
+      value: 62810
+    - key: Thumb Up
+      value: 63518
+    - key: Location On
+      value: 62713
+    - key: Refresh
+      value: 61758
+    - key: Location Off
+      value: 59523
+    - key: Thumb Down
+      value: 63520
+    - key: Videocam
+      value: 63565
+    - key: Undo
+      value: 63703
+    - key: Tag
+      value: 63357
+    - key: Menu
+      value: 62817
+    - key: More Vertical
+      value: 62807
+    - key: Mail
+      value: 62727
+    - key: Delete
+      value: 62285
+    - key: Attach
+      value: 61866
+    - key: Chevron Up
+      value: 62135
+    - key: Chevron Right
+      value: 62129
+    - key: Chevron Left
+      value: 62123
+    - key: Chevron Down
+      value: 62116
+    - key: Arrow Up
+      value: 61852
+    - key: Arrow Right
+      value: 61826
+    - key: Arrow Left
+      value: 61788
+    - key: Arrow Down
+      value: 61769
+    - key: More Horizontal
+      value: 59529
+    - key: Mic
+      value: 59527
+    - key: Apps
+      value: 59517
+    - key: Repeat
+      value: 61810
+    - key: Unlock
+      value: 59525
+    - key: Lock
+      value: 59524
+    - key: Cast
+      value: 62061
+    - key: Visibility On
+      value: 59511
+    - key: Erase
+      value: 59508
+    - key: Clipboard
+      value: 59476
+    - key: History
+      value: 62591
+    - key: Folder
+      value: 62489
+    - key: Edit
+      value: 62430
+    - key: Check
+      value: 62101
+    - key: Call End
+      value: 62024
+    - key: List
+      value: 61752
+    - key: Call
+      value: 59461
+    - key: Bookmark
+      value: 61942
+    - key: Notifications Off
+      value: 61721
+    - key: Notifications
+      value: 61717
+    - key: Keyboard
+      value: 62649
+    - key: Info
+      value: 62628
+    - key: Warning
+      value: 63594
+    - key: Error
+      value: 62450
+    - key: Photo
+      value: 62601
+    - key: Dialpad
+      value: 62303
+    - key: Close
+      value: 62314
+    - key: Cancel
+      value: 62318
+    - key: Cut
+      value: 62267
   iconFontAsset: {fileID: 11400000, guid: 533bdd8d5c92b52448ee2ecf7bd828a4, type: 2}
   optionalEditorMaterial: {fileID: 0}
+  fontIconSetDefinition: {fileID: 11400000, guid: e63daff880b56ed439a2e852b6e6993a, type: 2}

--- a/org.mixedrealitytoolkit.standardassets/Fonts/Selawik-Semibold-MRTKIcons.asset
+++ b/org.mixedrealitytoolkit.standardassets/Fonts/Selawik-Semibold-MRTKIcons.asset
@@ -104,8 +104,6 @@ MonoBehaviour:
       value: 60390
     - key: Icon 26
       value: 60227
-    - key: Icon 25
-      value: 59977
     - key: Icon 24
       value: 59846
     - key: Icon 23
@@ -148,8 +146,6 @@ MonoBehaviour:
       value: 62982
     - key: Play Circle
       value: 62984
-    - key: Brightness
-      value: 59456
     - key: Unpin
       value: 62980
     - key: Pin
@@ -196,16 +192,12 @@ MonoBehaviour:
       value: 59512
     - key: Movie
       value: 62810
-    - key: Thumb Up
-      value: 63518
     - key: Location On
       value: 62713
     - key: Refresh
       value: 61758
     - key: Location Off
       value: 59523
-    - key: Thumb Down
-      value: 63520
     - key: Videocam
       value: 63565
     - key: Undo
@@ -296,6 +288,16 @@ MonoBehaviour:
       value: 62318
     - key: Cut
       value: 62267
+    - key: Icon 62700
+      value: 62700
+    - key: Thumb Down
+      value: 63518
+    - key: Thumb Up
+      value: 63520
+    - key: Brightness
+      value: 59456
+    - key: Save As
+      value: 59977
   iconFontAsset: {fileID: 11400000, guid: 533bdd8d5c92b52448ee2ecf7bd828a4, type: 2}
   optionalEditorMaterial: {fileID: 0}
   fontIconSetDefinition: {fileID: 11400000, guid: e63daff880b56ed439a2e852b6e6993a, type: 2}

--- a/org.mixedrealitytoolkit.standardassets/Fonts/Selawik-Semibold-MRTKIcons.asset
+++ b/org.mixedrealitytoolkit.standardassets/Fonts/Selawik-Semibold-MRTKIcons.asset
@@ -14,82 +14,6 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   glyphIconsByName:
     entries:
-    - key: Icon 110
-      value: 62822
-    - key: Icon 108
-      value: 62815
-    - key: Icon 86
-      value: 62433
-    - key: Icon 83
-      value: 62343
-    - key: Icon 82
-      value: 62329
-    - key: Icon 81
-      value: 62326
-    - key: Icon 77
-      value: 62298
-    - key: Icon 75
-      value: 62277
-    - key: Icon 74
-      value: 62274
-    - key: Icon 73
-      value: 62269
-    - key: Icon 71
-      value: 62240
-    - key: Icon 70
-      value: 62233
-    - key: Icon 69
-      value: 62229
-    - key: Icon 68
-      value: 62208
-    - key: Icon 67
-      value: 62198
-    - key: Icon 66
-      value: 62194
-    - key: Icon 65
-      value: 62181
-    - key: Icon 64
-      value: 62178
-    - key: Icon 63
-      value: 62174
-    - key: Icon 56
-      value: 62087
-    - key: Icon 54
-      value: 62059
-    - key: Icon 51
-      value: 61972
-    - key: Icon 50
-      value: 61967
-    - key: Icon 48
-      value: 61923
-    - key: Icon 46
-      value: 61877
-    - key: Icon 43
-      value: 61835
-    - key: Icon 40
-      value: 61801
-    - key: Icon 37
-      value: 61760
-    - key: Icon 34
-      value: 61733
-    - key: Icon 33
-      value: 61731
-    - key: Icon 28
-      value: 60390
-    - key: Icon 26
-      value: 60227
-    - key: Icon 24
-      value: 59846
-    - key: Icon 23
-      value: 59532
-    - key: Icon 22
-      value: 59531
-    - key: Icon 19
-      value: 59526
-    - key: Icon 13
-      value: 59519
-    - key: Icon 12
-      value: 59518
     - key: Add Favorite
       value: 63252
     - key: Favorite
@@ -150,8 +74,6 @@ MonoBehaviour:
       value: 62785
     - key: Lightbulb
       value: 62679
-    - key: People
-      value: 62889
     - key: Visibility Off
       value: 59512
     - key: Movie
@@ -178,8 +100,6 @@ MonoBehaviour:
       value: 62807
     - key: Mail
       value: 62727
-    - key: Delete
-      value: 62285
     - key: Attach
       value: 61866
     - key: Chevron Up
@@ -248,8 +168,6 @@ MonoBehaviour:
       value: 62450
     - key: Photo
       value: 62601
-    - key: Dialpad
-      value: 62303
     - key: Close
       value: 62314
     - key: Cancel
@@ -294,10 +212,84 @@ MonoBehaviour:
       value: 61709
     - key: Book
       value: 63742
+    - key: Group
+      value: 62889
+    - key: Newspaper
+      value: 62822
+    - key: My Location
+      value: 62815
+    - key: Doc
+      value: 62329
+    - key: Zoom
+      value: 62181
+    - key: Move
+      value: 61801
+    - key: Mobile
+      value: 61733
     - key: Save As
       value: 59977
-    - key: Icon 62700
-      value: 62700
+    - key: Music
+      value: 59531
+    - key: Music Mute
+      value: 59532
+    - key: Circle
+      value: 59846
+    - key: Sound
+      value: 60227
+    - key: Vertical List
+      value: 61967
+    - key: Horizontal List
+      value: 61972
+    - key: Swap Vert
+      value: 61835
+    - key: Reset
+      value: 61760
+    - key: Add Tab
+      value: 60390
+    - key: Hand Right
+      value: 59519
+    - key: Write Mail
+      value: 59526
+    - key: Uniform Grid
+      value: 61731
+    - key: Layout Grid
+      value: 61923
+    - key: Tab
+      value: 61877
+    - key: Edit Doc
+      value: 62343
+    - key: Open In New
+      value: 62194
+    - key: Shopping Cart
+      value: 62059
+    - key: Messenger
+      value: 62087
+    - key: Message
+      value: 62208
+    - key: Color Palette
+      value: 62198
+    - key: Alarm
+      value: 62178
+    - key: Exit
+      value: 62233
+    - key: User
+      value: 62240
+    - key: Bar Chart
+      value: 62274
+    - key: Pie Chart
+      value: 62277
+    - key: Line Chart
+      value: 62269
+    - key: Layout 2
+      value: 62326
+    - key: Smiley
+      value: 62433
+    - key: Time
+      value: 62174
+    - key: Draft
+      value: 62229
+    - key: Pan
+      value: 59518
   iconFontAsset: {fileID: 11400000, guid: 533bdd8d5c92b52448ee2ecf7bd828a4, type: 2}
   optionalEditorMaterial: {fileID: 0}
   fontIconSetDefinition: {fileID: 11400000, guid: e63daff880b56ed439a2e852b6e6993a, type: 2}

--- a/org.mixedrealitytoolkit.standardassets/Fonts/Selawik-Semibold-MRTKIcons.asset
+++ b/org.mixedrealitytoolkit.standardassets/Fonts/Selawik-Semibold-MRTKIcons.asset
@@ -14,36 +14,12 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   glyphIconsByName:
     entries:
-    - key: Icon 116
-      value: 62893
-    - key: Icon 114
-      value: 62858
-    - key: Icon 113
-      value: 62856
-    - key: Icon 112
-      value: 62831
-    - key: Icon 111
-      value: 62828
     - key: Icon 110
       value: 62822
     - key: Icon 108
       value: 62815
-    - key: Icon 98
-      value: 62632
-    - key: Icon 96
-      value: 62624
-    - key: Icon 92
-      value: 62586
-    - key: Icon 91
-      value: 62578
-    - key: Icon 90
-      value: 62555
-    - key: Icon 88
-      value: 62476
     - key: Icon 86
       value: 62433
-    - key: Icon 84
-      value: 62427
     - key: Icon 83
       value: 62343
     - key: Icon 82
@@ -98,8 +74,6 @@ MonoBehaviour:
       value: 61733
     - key: Icon 33
       value: 61731
-    - key: Icon 30
-      value: 61709
     - key: Icon 28
       value: 60390
     - key: Icon 26
@@ -112,22 +86,10 @@ MonoBehaviour:
       value: 59531
     - key: Icon 19
       value: 59526
-    - key: Icon 15
-      value: 59522
-    - key: Icon 14
-      value: 59521
     - key: Icon 13
       value: 59519
     - key: Icon 12
       value: 59518
-    - key: Icon 2
-      value: 59416
-    - key: Icon 3
-      value: 59440
-    - key: Icon 1
-      value: 59407
-    - key: Icon 142
-      value: 63742
     - key: Add Favorite
       value: 63252
     - key: Favorite
@@ -146,6 +108,8 @@ MonoBehaviour:
       value: 62982
     - key: Play Circle
       value: 62984
+    - key: Brightness
+      value: 59456
     - key: Unpin
       value: 62980
     - key: Pin
@@ -192,12 +156,16 @@ MonoBehaviour:
       value: 59512
     - key: Movie
       value: 62810
+    - key: Thumb Up
+      value: 63518
     - key: Location On
       value: 62713
     - key: Refresh
       value: 61758
     - key: Location Off
       value: 59523
+    - key: Thumb Down
+      value: 63520
     - key: Videocam
       value: 63565
     - key: Undo
@@ -288,16 +256,48 @@ MonoBehaviour:
       value: 62318
     - key: Cut
       value: 62267
-    - key: Icon 62700
-      value: 62700
-    - key: Thumb Down
-      value: 63518
-    - key: Thumb Up
-      value: 63520
-    - key: Brightness
-      value: 59456
+    - key: Add Group
+      value: 62893
+    - key: Language
+      value: 62555
+    - key: Globe
+      value: 62427
+    - key: Flag Outline
+      value: 62476
+    - key: Heart Outline
+      value: 62586
+    - key: Exclamation Point
+      value: 62624
+    - key: Settings Sliders
+      value: 62856
+    - key: Headphones
+      value: 62578
+    - key: Remove Location
+      value: 59522
+    - key: Add Location
+      value: 59521
+    - key: Cached
+      value: 59440
+    - key: Pen Tip
+      value: 62632
+    - key: Show Chart
+      value: 59416
+    - key: Grid View
+      value: 59407
+    - key: Hierarchy
+      value: 62858
+    - key: Add Note
+      value: 62831
+    - key: Sticky Note
+      value: 62828
+    - key: Add Circle
+      value: 61709
+    - key: Book
+      value: 63742
     - key: Save As
       value: 59977
+    - key: Icon 62700
+      value: 62700
   iconFontAsset: {fileID: 11400000, guid: 533bdd8d5c92b52448ee2ecf7bd828a4, type: 2}
   optionalEditorMaterial: {fileID: 0}
   fontIconSetDefinition: {fileID: 11400000, guid: e63daff880b56ed439a2e852b6e6993a, type: 2}

--- a/org.mixedrealitytoolkit.standardassets/Fonts/Selawik-Semibold-MRTKIcons.asset
+++ b/org.mixedrealitytoolkit.standardassets/Fonts/Selawik-Semibold-MRTKIcons.asset
@@ -14,290 +14,290 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   glyphIconsByName:
     entries:
-    - key: Add Favorite
-      value: 63252
-    - key: Favorite
-      value: 63248
-    - key: Settings
-      value: 63146
-    - key: Send
-      value: 63130
-    - key: Search
-      value: 63120
-    - key: Save
-      value: 63104
-    - key: Question Mark
-      value: 63033
-    - key: Play
-      value: 62982
-    - key: Play Circle
-      value: 62984
-    - key: Brightness
-      value: 59456
-    - key: Unpin
-      value: 62980
-    - key: Pin
-      value: 62978
-    - key: Devices
-      value: 62950
-    - key: Phone
-      value: 62945
-    - key: Person
-      value: 62910
-    - key: Block
-      value: 63022
-    - key: Print
-      value: 63019
-    - key: Stop Circle
-      value: 63323
-    - key: Bluetooth
-      value: 61919
-    - key: Calendar
-      value: 59460
-    - key: Record Circle
-      value: 63074
-    - key: Paste
-      value: 62166
-    - key: Camera
-      value: 62037
-    - key: Add
-      value: 61706
-    - key: Home
-      value: 62593
-    - key: Mute
-      value: 60235
-    - key: Power Button
-      value: 62991
-    - key: Link
-      value: 62693
-    - key: Mic Off
-      value: 62785
-    - key: Lightbulb
-      value: 62679
-    - key: Visibility Off
-      value: 59512
-    - key: Movie
-      value: 62810
-    - key: Thumb Up
-      value: 63518
-    - key: Location On
-      value: 62713
-    - key: Refresh
-      value: 61758
-    - key: Location Off
-      value: 59523
-    - key: Thumb Down
-      value: 63520
-    - key: Videocam
-      value: 63565
-    - key: Undo
-      value: 63703
-    - key: Tag
-      value: 63357
-    - key: Menu
-      value: 62817
-    - key: More Vertical
-      value: 62807
-    - key: Mail
-      value: 62727
-    - key: Attach
-      value: 61866
-    - key: Chevron Up
-      value: 62135
-    - key: Chevron Right
-      value: 62129
-    - key: Chevron Left
-      value: 62123
-    - key: Chevron Down
-      value: 62116
-    - key: Arrow Up
-      value: 61852
-    - key: Arrow Right
-      value: 61826
-    - key: Arrow Left
-      value: 61788
-    - key: Arrow Down
-      value: 61769
-    - key: More Horizontal
-      value: 59529
-    - key: Mic
-      value: 59527
-    - key: Apps
-      value: 59517
-    - key: Repeat
-      value: 61810
-    - key: Unlock
-      value: 59525
-    - key: Lock
-      value: 59524
-    - key: Cast
-      value: 62061
-    - key: Visibility On
-      value: 59511
-    - key: Erase
-      value: 59508
-    - key: Clipboard
-      value: 59476
-    - key: History
-      value: 62591
-    - key: Folder
-      value: 62489
-    - key: Edit
-      value: 62430
-    - key: Check
-      value: 62101
-    - key: Call End
-      value: 62024
-    - key: List
-      value: 61752
-    - key: Call
-      value: 59461
-    - key: Bookmark
-      value: 61942
-    - key: Notifications Off
-      value: 61721
-    - key: Notifications
-      value: 61717
-    - key: Keyboard
-      value: 62649
-    - key: Info
-      value: 62628
-    - key: Warning
-      value: 63594
-    - key: Error
-      value: 62450
-    - key: Photo
-      value: 62601
-    - key: Close
-      value: 62314
-    - key: Cancel
-      value: 62318
-    - key: Cut
-      value: 62267
-    - key: Add Group
-      value: 62893
-    - key: Language
-      value: 62555
-    - key: Globe
-      value: 62427
-    - key: Flag Outline
-      value: 62476
-    - key: Heart Outline
-      value: 62586
-    - key: Exclamation Point
-      value: 62624
-    - key: Settings Sliders
-      value: 62856
-    - key: Headphones
-      value: 62578
-    - key: Remove Location
-      value: 59522
-    - key: Add Location
-      value: 59521
-    - key: Cached
-      value: 59440
-    - key: Pen Tip
-      value: 62632
-    - key: Show Chart
-      value: 59416
     - key: Grid View
       value: 59407
-    - key: Hierarchy
-      value: 62858
-    - key: Add Note
-      value: 62831
-    - key: Sticky Note
-      value: 62828
-    - key: Add Circle
-      value: 61709
-    - key: Book
-      value: 63742
-    - key: Group
-      value: 62889
-    - key: Newspaper
-      value: 62822
-    - key: My Location
-      value: 62815
-    - key: Doc
-      value: 62329
-    - key: Zoom
-      value: 62181
-    - key: Move
-      value: 61801
-    - key: Mobile
-      value: 61733
-    - key: Save As
-      value: 59977
+    - key: Show Chart
+      value: 59416
+    - key: Cached
+      value: 59440
+    - key: Brightness
+      value: 59456
+    - key: Calendar
+      value: 59460
+    - key: Call
+      value: 59461
+    - key: Clipboard
+      value: 59476
+    - key: Erase
+      value: 59508
+    - key: Visibility On
+      value: 59511
+    - key: Visibility Off
+      value: 59512
+    - key: Apps
+      value: 59517
+    - key: Pan
+      value: 59518
+    - key: Hand Left
+      value: 59519
+    - key: Add Location
+      value: 59521
+    - key: Remove Location
+      value: 59522
+    - key: Location Off
+      value: 59523
+    - key: Lock
+      value: 59524
+    - key: Unlock
+      value: 59525
+    - key: Write Mail
+      value: 59526
+    - key: Mic
+      value: 59527
+    - key: More Horizontal
+      value: 59529
     - key: Music
       value: 59531
     - key: Music Mute
       value: 59532
     - key: Circle
       value: 59846
+    - key: Save As
+      value: 59977
     - key: Sound
       value: 60227
+    - key: Mute
+      value: 60235
+    - key: Add Tab
+      value: 60390
+    - key: Add
+      value: 61706
+    - key: Add Circle
+      value: 61709
+    - key: Notifications
+      value: 61717
+    - key: Notifications Off
+      value: 61721
+    - key: Uniform Grid
+      value: 61731
+    - key: Mobile
+      value: 61733
+    - key: List
+      value: 61752
+    - key: Refresh
+      value: 61758
+    - key: Reset
+      value: 61760
+    - key: Arrow Down
+      value: 61769
+    - key: Arrow Left
+      value: 61788
+    - key: Move
+      value: 61801
+    - key: Repeat
+      value: 61810
+    - key: Arrow Right
+      value: 61826
+    - key: Swap Vert
+      value: 61835
+    - key: Arrow Up
+      value: 61852
+    - key: Attach
+      value: 61866
+    - key: Tab
+      value: 61877
+    - key: Bluetooth
+      value: 61919
+    - key: Layout Grid
+      value: 61923
+    - key: Bookmark
+      value: 61942
     - key: Vertical List
       value: 61967
     - key: Horizontal List
       value: 61972
-    - key: Swap Vert
-      value: 61835
-    - key: Reset
-      value: 61760
-    - key: Add Tab
-      value: 60390
-    - key: Write Mail
-      value: 59526
-    - key: Uniform Grid
-      value: 61731
-    - key: Layout Grid
-      value: 61923
-    - key: Tab
-      value: 61877
-    - key: Edit Doc
-      value: 62343
-    - key: Open In New
-      value: 62194
+    - key: Call End
+      value: 62024
+    - key: Camera
+      value: 62037
     - key: Shopping Cart
       value: 62059
+    - key: Cast
+      value: 62061
     - key: Messenger
       value: 62087
-    - key: Message
-      value: 62208
-    - key: Color Palette
-      value: 62198
+    - key: Check
+      value: 62101
+    - key: Chevron Down
+      value: 62116
+    - key: Chevron Left
+      value: 62123
+    - key: Chevron Right
+      value: 62129
+    - key: Chevron Up
+      value: 62135
+    - key: Paste
+      value: 62166
+    - key: Time
+      value: 62174
     - key: Alarm
       value: 62178
+    - key: Zoom
+      value: 62181
+    - key: Open In New
+      value: 62194
+    - key: Color Palette
+      value: 62198
+    - key: Message
+      value: 62208
+    - key: Draft
+      value: 62229
     - key: Exit
       value: 62233
     - key: User
       value: 62240
+    - key: Cut
+      value: 62267
+    - key: Line Chart
+      value: 62269
     - key: Bar Chart
       value: 62274
     - key: Pie Chart
       value: 62277
-    - key: Line Chart
-      value: 62269
-    - key: Layout 2
-      value: 62326
-    - key: Smiley
-      value: 62433
-    - key: Time
-      value: 62174
-    - key: Draft
-      value: 62229
-    - key: Pan
-      value: 59518
-    - key: Hand Left
-      value: 59519
-    - key: Icon 62298
-      value: 62298
-    - key: Icon 62700
-      value: 62700
     - key: Delete
       value: 62285
+    - key: Icon 62298
+      value: 62298
     - key: Dialpad
       value: 62303
+    - key: Close
+      value: 62314
+    - key: Cancel
+      value: 62318
+    - key: Layout 2
+      value: 62326
+    - key: Doc
+      value: 62329
+    - key: Edit Doc
+      value: 62343
+    - key: Globe
+      value: 62427
+    - key: Edit
+      value: 62430
+    - key: Smiley
+      value: 62433
+    - key: Error
+      value: 62450
+    - key: Flag Outline
+      value: 62476
+    - key: Folder
+      value: 62489
+    - key: Language
+      value: 62555
+    - key: Headphones
+      value: 62578
+    - key: Heart Outline
+      value: 62586
+    - key: History
+      value: 62591
+    - key: Home
+      value: 62593
+    - key: Photo
+      value: 62601
+    - key: Exclamation Point
+      value: 62624
+    - key: Info
+      value: 62628
+    - key: Pen Tip
+      value: 62632
+    - key: Keyboard
+      value: 62649
+    - key: Lightbulb
+      value: 62679
+    - key: Link
+      value: 62693
+    - key: Icon 62700
+      value: 62700
+    - key: Location On
+      value: 62713
+    - key: Mail
+      value: 62727
+    - key: Mic Off
+      value: 62785
+    - key: More Vertical
+      value: 62807
+    - key: Movie
+      value: 62810
+    - key: My Location
+      value: 62815
+    - key: Menu
+      value: 62817
+    - key: Newspaper
+      value: 62822
+    - key: Sticky Note
+      value: 62828
+    - key: Add Note
+      value: 62831
+    - key: Settings Sliders
+      value: 62856
+    - key: Hierarchy
+      value: 62858
+    - key: Group
+      value: 62889
+    - key: Add Group
+      value: 62893
+    - key: Person
+      value: 62910
+    - key: Phone
+      value: 62945
+    - key: Devices
+      value: 62950
+    - key: Pin
+      value: 62978
+    - key: Unpin
+      value: 62980
+    - key: Play
+      value: 62982
+    - key: Play Circle
+      value: 62984
+    - key: Power Button
+      value: 62991
+    - key: Print
+      value: 63019
+    - key: Block
+      value: 63022
+    - key: Question Mark
+      value: 63033
+    - key: Record Circle
+      value: 63074
+    - key: Save
+      value: 63104
+    - key: Search
+      value: 63120
+    - key: Send
+      value: 63130
+    - key: Settings
+      value: 63146
+    - key: Favorite
+      value: 63248
+    - key: Add Favorite
+      value: 63252
+    - key: Stop Circle
+      value: 63323
+    - key: Tag
+      value: 63357
+    - key: Thumb Up
+      value: 63518
+    - key: Thumb Down
+      value: 63520
+    - key: Videocam
+      value: 63565
+    - key: Warning
+      value: 63594
+    - key: Undo
+      value: 63703
+    - key: Book
+      value: 63742
   iconFontAsset: {fileID: 11400000, guid: 533bdd8d5c92b52448ee2ecf7bd828a4, type: 2}
   optionalEditorMaterial: {fileID: 0}
   fontIconSetDefinition: {fileID: 11400000, guid: e63daff880b56ed439a2e852b6e6993a, type: 2}

--- a/org.mixedrealitytoolkit.standardassets/Fonts/Selawik-Semibold-MRTKIcons.asset
+++ b/org.mixedrealitytoolkit.standardassets/Fonts/Selawik-Semibold-MRTKIcons.asset
@@ -246,8 +246,6 @@ MonoBehaviour:
       value: 61760
     - key: Add Tab
       value: 60390
-    - key: Hand Right
-      value: 59519
     - key: Write Mail
       value: 59526
     - key: Uniform Grid
@@ -290,6 +288,16 @@ MonoBehaviour:
       value: 62229
     - key: Pan
       value: 59518
+    - key: Hand Left
+      value: 59519
+    - key: Icon 62298
+      value: 62298
+    - key: Icon 62700
+      value: 62700
+    - key: Delete
+      value: 62285
+    - key: Dialpad
+      value: 62303
   iconFontAsset: {fileID: 11400000, guid: 533bdd8d5c92b52448ee2ecf7bd828a4, type: 2}
   optionalEditorMaterial: {fileID: 0}
   fontIconSetDefinition: {fileID: 11400000, guid: e63daff880b56ed439a2e852b6e6993a, type: 2}

--- a/org.mixedrealitytoolkit.standardassets/Icons/MRTK_FluentIconSet.asset
+++ b/org.mixedrealitytoolkit.standardassets/Icons/MRTK_FluentIconSet.asset
@@ -14,52 +14,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   glyphIconsByName:
     entries:
-    - key: Icon 137
-      value: 63518
-    - key: Icon 136
-      value: 63357
-    - key: Icon 135
-      value: 63323
-    - key: Icon 134
-      value: 63252
-    - key: Icon 133
-      value: 63248
-    - key: Icon 132
-      value: 63146
-    - key: Icon 131
-      value: 63130
-    - key: Icon 130
-      value: 63120
-    - key: Icon 129
-      value: 63104
-    - key: Icon 128
-      value: 63074
-    - key: Icon 127
-      value: 63033
-    - key: Icon 126
-      value: 63022
-    - key: Icon 125
-      value: 63019
-    - key: Icon 124
-      value: 62991
-    - key: Icon 123
-      value: 62984
-    - key: Icon 122
-      value: 62982
-    - key: Icon 121
-      value: 62980
-    - key: Icon 120
-      value: 62978
-    - key: Icon 119
-      value: 62950
-    - key: Icon 118
-      value: 62945
-    - key: Icon 117
-      value: 62910
     - key: Icon 116
       value: 62893
-    - key: Icon 115
-      value: 62889
     - key: Icon 114
       value: 62858
     - key: Icon 113
@@ -70,56 +26,24 @@ MonoBehaviour:
       value: 62828
     - key: Icon 110
       value: 62822
-    - key: Icon 109
-      value: 62817
     - key: Icon 108
       value: 62815
-    - key: Icon 107
-      value: 62810
-    - key: Icon 106
-      value: 62807
-    - key: Icon 105
-      value: 62785
-    - key: Icon 104
-      value: 62727
-    - key: Icon 103
-      value: 62713
     - key: Icon 102
       value: 62700
-    - key: Icon 101
-      value: 62693
-    - key: Icon 100
-      value: 62679
-    - key: Icon 99
-      value: 62649
     - key: Icon 98
       value: 62632
-    - key: Icon 97
-      value: 62628
     - key: Icon 96
       value: 62624
-    - key: Icon 95
-      value: 62601
-    - key: Icon 94
-      value: 62593
-    - key: Icon 93
-      value: 62591
     - key: Icon 92
       value: 62586
     - key: Icon 91
       value: 62578
     - key: Icon 90
       value: 62555
-    - key: Icon 89
-      value: 62489
     - key: Icon 88
       value: 62476
-    - key: Icon 87
-      value: 62450
     - key: Icon 86
       value: 62433
-    - key: Icon 85
-      value: 62430
     - key: Icon 84
       value: 62427
     - key: Icon 83
@@ -128,24 +52,14 @@ MonoBehaviour:
       value: 62329
     - key: Icon 81
       value: 62326
-    - key: Icon 80
-      value: 62318
-    - key: Icon 79
-      value: 62314
-    - key: Icon 78
-      value: 62303
     - key: Icon 77
       value: 62298
-    - key: Icon 76
-      value: 62285
     - key: Icon 75
       value: 62277
     - key: Icon 74
       value: 62274
     - key: Icon 73
       value: 62269
-    - key: Icon 72
-      value: 62267
     - key: Icon 71
       value: 62240
     - key: Icon 70
@@ -164,100 +78,42 @@ MonoBehaviour:
       value: 62178
     - key: Icon 63
       value: 62174
-    - key: Icon 62
-      value: 62166
-    - key: Icon 61
-      value: 62135
-    - key: Icon 60
-      value: 62129
-    - key: Icon 59
-      value: 62123
-    - key: Icon 58
-      value: 62116
-    - key: Icon 57
-      value: 62101
     - key: Icon 56
       value: 62087
-    - key: Icon 55
-      value: 62061
     - key: Icon 54
       value: 62059
-    - key: Icon 53
-      value: 62037
-    - key: Icon 52
-      value: 62024
     - key: Icon 51
       value: 61972
     - key: Icon 50
       value: 61967
-    - key: Icon 49
-      value: 61942
     - key: Icon 48
       value: 61923
-    - key: Icon 47
-      value: 61919
     - key: Icon 46
       value: 61877
-    - key: Icon 45
-      value: 61866
-    - key: Icon 44
-      value: 61852
     - key: Icon 43
       value: 61835
-    - key: Icon 42
-      value: 61826
-    - key: Icon 41
-      value: 61810
     - key: Icon 40
       value: 61801
-    - key: Icon 39
-      value: 61788
-    - key: Icon 38
-      value: 61769
     - key: Icon 37
       value: 61760
-    - key: Icon 36
-      value: 61758
-    - key: Icon 35
-      value: 61752
     - key: Icon 34
       value: 61733
     - key: Icon 33
       value: 61731
-    - key: Icon 32
-      value: 61721
-    - key: Icon 31
-      value: 61717
     - key: Icon 30
       value: 61709
-    - key: Icon 29
-      value: 61706
     - key: Icon 28
       value: 60390
-    - key: Icon 27
-      value: 60235
     - key: Icon 26
       value: 60227
-    - key: Icon 25
-      value: 59977
     - key: Icon 24
       value: 59846
     - key: Icon 23
       value: 59532
     - key: Icon 22
       value: 59531
-    - key: Icon 21
-      value: 59529
-    - key: Icon 20
-      value: 59527
     - key: Icon 19
       value: 59526
-    - key: Icon 18
-      value: 59525
-    - key: Icon 17
-      value: 59524
-    - key: Icon 16
-      value: 59523
     - key: Icon 15
       value: 59522
     - key: Icon 14
@@ -266,37 +122,182 @@ MonoBehaviour:
       value: 59519
     - key: Icon 12
       value: 59518
-    - key: Icon 11
-      value: 59517
-    - key: Icon 10
-      value: 59512
-    - key: Icon 9
-      value: 59511
-    - key: Icon 8
-      value: 59508
-    - key: Icon 7
-      value: 59476
-    - key: Icon 6
-      value: 59461
     - key: Icon 2
       value: 59416
     - key: Icon 3
       value: 59440
-    - key: Icon 4
-      value: 59456
     - key: Icon 1
       value: 59407
-    - key: Icon 5
-      value: 59460
-    - key: Icon 138
-      value: 63520
-    - key: Icon 139
-      value: 63565
-    - key: Icon 140
-      value: 63594
-    - key: Icon 141
-      value: 63703
     - key: Icon 142
       value: 63742
+    - key: Brightness
+      value: 59456
+    - key: Calendar
+      value: 59460
+    - key: Call
+      value: 59461
+    - key: Clipboard
+      value: 59476
+    - key: Erase
+      value: 59508
+    - key: Visibility On
+      value: 59511
+    - key: Visibility Off
+      value: 59512
+    - key: Apps
+      value: 59517
+    - key: Location Off
+      value: 59523
+    - key: Lock
+      value: 59524
+    - key: Unlock
+      value: 59525
+    - key: Mic
+      value: 59527
+    - key: More Horizontal
+      value: 59529
+    - key: Save As
+      value: 59977
+    - key: Mute
+      value: 60235
+    - key: Add
+      value: 61706
+    - key: Notifications
+      value: 61717
+    - key: Notifications Off
+      value: 61721
+    - key: List
+      value: 61752
+    - key: Refresh
+      value: 61758
+    - key: Arrow Down
+      value: 61769
+    - key: Arrow Left
+      value: 61788
+    - key: Repeat
+      value: 61810
+    - key: Arrow Right
+      value: 61826
+    - key: Arrow Up
+      value: 61852
+    - key: Attach
+      value: 61866
+    - key: Bluetooth
+      value: 61919
+    - key: Bookmark
+      value: 61942
+    - key: Call End
+      value: 62024
+    - key: Camera
+      value: 62037
+    - key: Cast
+      value: 62061
+    - key: Check
+      value: 62101
+    - key: Chevron Down
+      value: 62116
+    - key: Chevron Left
+      value: 62123
+    - key: Chevron Right
+      value: 62129
+    - key: Chevron Up
+      value: 62135
+    - key: Paste
+      value: 62166
+    - key: Cut
+      value: 62267
+    - key: Delete
+      value: 62285
+    - key: Dialpad
+      value: 62303
+    - key: Close
+      value: 62314
+    - key: Cancel
+      value: 62318
+    - key: Edit
+      value: 62430
+    - key: Error
+      value: 62450
+    - key: Folder
+      value: 62489
+    - key: History
+      value: 62591
+    - key: Home
+      value: 62593
+    - key: Photo
+      value: 62601
+    - key: Info
+      value: 62628
+    - key: Keyboard
+      value: 62649
+    - key: Lightbulb
+      value: 62679
+    - key: Link
+      value: 62693
+    - key: Location On
+      value: 62713
+    - key: Mail
+      value: 62727
+    - key: Mic Off
+      value: 62785
+    - key: More Vertical
+      value: 62807
+    - key: Movie
+      value: 62810
+    - key: Menu
+      value: 62817
+    - key: People
+      value: 62889
+    - key: Person
+      value: 62910
+    - key: Phone
+      value: 62945
+    - key: Devices
+      value: 62950
+    - key: Pin
+      value: 62978
+    - key: Unpin
+      value: 62980
+    - key: Play
+      value: 62982
+    - key: Play Circle
+      value: 62984
+    - key: Power Button
+      value: 62991
+    - key: Print
+      value: 63019
+    - key: Block
+      value: 63022
+    - key: Question Mark
+      value: 63033
+    - key: Record Circle
+      value: 63074
+    - key: Save
+      value: 63104
+    - key: Search
+      value: 63120
+    - key: Send
+      value: 63130
+    - key: Settings
+      value: 63146
+    - key: Favorite
+      value: 63248
+    - key: Add Favorite
+      value: 63252
+    - key: Stop Circle
+      value: 63323
+    - key: Tag
+      value: 63357
+    - key: Thumb Down
+      value: 63518
+    - key: Thumb Up
+      value: 63520
+    - key: Videocam
+      value: 63565
+    - key: Warning
+      value: 63594
+    - key: Undo
+      value: 63703
   iconFontAsset: {fileID: 11400000, guid: 9b0d0ee11ff70b04d901a29b519cbaa0, type: 2}
   optionalEditorMaterial: {fileID: 0}
+  fontIconSetDefinition: {fileID: 11400000, guid: e63daff880b56ed439a2e852b6e6993a, type: 2}

--- a/org.mixedrealitytoolkit.standardassets/Icons/MRTK_FluentIconSet.asset
+++ b/org.mixedrealitytoolkit.standardassets/Icons/MRTK_FluentIconSet.asset
@@ -14,38 +14,14 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   glyphIconsByName:
     entries:
-    - key: Icon 116
-      value: 62893
-    - key: Icon 114
-      value: 62858
-    - key: Icon 113
-      value: 62856
-    - key: Icon 112
-      value: 62831
-    - key: Icon 111
-      value: 62828
     - key: Icon 110
       value: 62822
     - key: Icon 108
       value: 62815
     - key: Icon 102
       value: 62700
-    - key: Icon 98
-      value: 62632
-    - key: Icon 96
-      value: 62624
-    - key: Icon 92
-      value: 62586
-    - key: Icon 91
-      value: 62578
-    - key: Icon 90
-      value: 62555
-    - key: Icon 88
-      value: 62476
     - key: Icon 86
       value: 62433
-    - key: Icon 84
-      value: 62427
     - key: Icon 83
       value: 62343
     - key: Icon 82
@@ -100,8 +76,6 @@ MonoBehaviour:
       value: 61733
     - key: Icon 33
       value: 61731
-    - key: Icon 30
-      value: 61709
     - key: Icon 28
       value: 60390
     - key: Icon 26
@@ -114,22 +88,10 @@ MonoBehaviour:
       value: 59531
     - key: Icon 19
       value: 59526
-    - key: Icon 15
-      value: 59522
-    - key: Icon 14
-      value: 59521
     - key: Icon 13
       value: 59519
     - key: Icon 12
       value: 59518
-    - key: Icon 2
-      value: 59416
-    - key: Icon 3
-      value: 59440
-    - key: Icon 1
-      value: 59407
-    - key: Icon 142
-      value: 63742
     - key: Brightness
       value: 59456
     - key: Calendar
@@ -298,6 +260,44 @@ MonoBehaviour:
       value: 63594
     - key: Undo
       value: 63703
+    - key: Grid View
+      value: 59407
+    - key: Show Chart
+      value: 59416
+    - key: Cached
+      value: 59440
+    - key: Add Location
+      value: 59521
+    - key: Remove Location
+      value: 59522
+    - key: Add Circle
+      value: 61709
+    - key: Headphones
+      value: 62578
+    - key: Heart Outline
+      value: 62586
+    - key: Exclamation Point
+      value: 62624
+    - key: Flag Outline
+      value: 62476
+    - key: Globe
+      value: 62427
+    - key: Language
+      value: 62555
+    - key: Sticky Note
+      value: 62828
+    - key: Book
+      value: 63742
+    - key: Add Group
+      value: 62893
+    - key: Hierarchy
+      value: 62858
+    - key: Settings Sliders
+      value: 62856
+    - key: Add Note
+      value: 62831
+    - key: Pen Tip
+      value: 62632
   iconFontAsset: {fileID: 11400000, guid: 9b0d0ee11ff70b04d901a29b519cbaa0, type: 2}
   optionalEditorMaterial: {fileID: 0}
   fontIconSetDefinition: {fileID: 11400000, guid: e63daff880b56ed439a2e852b6e6993a, type: 2}

--- a/org.mixedrealitytoolkit.standardassets/Icons/MRTK_FluentIconSet.asset
+++ b/org.mixedrealitytoolkit.standardassets/Icons/MRTK_FluentIconSet.asset
@@ -14,10 +14,12 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   glyphIconsByName:
     entries:
-    - key: Icon 102
-      value: 62700
-    - key: Icon 77
-      value: 62298
+    - key: Grid View
+      value: 59407
+    - key: Show Chart
+      value: 59416
+    - key: Cached
+      value: 59440
     - key: Brightness
       value: 59456
     - key: Calendar
@@ -34,52 +36,96 @@ MonoBehaviour:
       value: 59512
     - key: Apps
       value: 59517
+    - key: Pan
+      value: 59518
+    - key: Hand Left
+      value: 59519
+    - key: Add Location
+      value: 59521
+    - key: Remove Location
+      value: 59522
     - key: Location Off
       value: 59523
     - key: Lock
       value: 59524
     - key: Unlock
       value: 59525
+    - key: Write Mail
+      value: 59526
     - key: Mic
       value: 59527
     - key: More Horizontal
       value: 59529
+    - key: Music
+      value: 59531
+    - key: Music Mute
+      value: 59532
+    - key: Circle
+      value: 59846
     - key: Save As
       value: 59977
+    - key: Sound
+      value: 60227
     - key: Mute
       value: 60235
+    - key: Add Tab
+      value: 60390
     - key: Add
       value: 61706
+    - key: Add Circle
+      value: 61709
     - key: Notifications
       value: 61717
     - key: Notifications Off
       value: 61721
+    - key: Uniform Grid
+      value: 61731
+    - key: Mobile
+      value: 61733
     - key: List
       value: 61752
     - key: Refresh
       value: 61758
+    - key: Reset
+      value: 61760
     - key: Arrow Down
       value: 61769
     - key: Arrow Left
       value: 61788
+    - key: Move
+      value: 61801
     - key: Repeat
       value: 61810
     - key: Arrow Right
       value: 61826
+    - key: Swap Vert
+      value: 61835
     - key: Arrow Up
       value: 61852
     - key: Attach
       value: 61866
+    - key: Tab
+      value: 61877
     - key: Bluetooth
       value: 61919
+    - key: Layout Grid
+      value: 61923
     - key: Bookmark
       value: 61942
+    - key: Vertical List
+      value: 61967
+    - key: Horizontal List
+      value: 61972
     - key: Call End
       value: 62024
     - key: Camera
       value: 62037
+    - key: Shopping Cart
+      value: 62059
     - key: Cast
       value: 62061
+    - key: Messenger
+      value: 62087
     - key: Check
       value: 62101
     - key: Chevron Down
@@ -92,36 +138,86 @@ MonoBehaviour:
       value: 62135
     - key: Paste
       value: 62166
+    - key: Time
+      value: 62174
+    - key: Alarm
+      value: 62178
+    - key: Zoom
+      value: 62181
+    - key: Open In New
+      value: 62194
+    - key: Color Palette
+      value: 62198
+    - key: Message
+      value: 62208
+    - key: Draft
+      value: 62229
+    - key: Exit
+      value: 62233
+    - key: User
+      value: 62240
     - key: Cut
       value: 62267
+    - key: Line Chart
+      value: 62269
+    - key: Bar Chart
+      value: 62274
+    - key: Pie Chart
+      value: 62277
     - key: Delete
       value: 62285
+    - key: Icon 77
+      value: 62298
     - key: Dialpad
       value: 62303
     - key: Close
       value: 62314
     - key: Cancel
       value: 62318
+    - key: Layout 2
+      value: 62326
+    - key: Doc
+      value: 62329
+    - key: Edit Doc
+      value: 62343
+    - key: Globe
+      value: 62427
     - key: Edit
       value: 62430
+    - key: Smiley
+      value: 62433
     - key: Error
       value: 62450
+    - key: Flag Outline
+      value: 62476
     - key: Folder
       value: 62489
+    - key: Language
+      value: 62555
+    - key: Headphones
+      value: 62578
+    - key: Heart Outline
+      value: 62586
     - key: History
       value: 62591
     - key: Home
       value: 62593
     - key: Photo
       value: 62601
+    - key: Exclamation Point
+      value: 62624
     - key: Info
       value: 62628
+    - key: Pen Tip
+      value: 62632
     - key: Keyboard
       value: 62649
     - key: Lightbulb
       value: 62679
     - key: Link
       value: 62693
+    - key: Icon 102
+      value: 62700
     - key: Location On
       value: 62713
     - key: Mail
@@ -132,8 +228,24 @@ MonoBehaviour:
       value: 62807
     - key: Movie
       value: 62810
+    - key: My Location
+      value: 62815
     - key: Menu
       value: 62817
+    - key: Newspaper
+      value: 62822
+    - key: Sticky Note
+      value: 62828
+    - key: Add Note
+      value: 62831
+    - key: Settings Sliders
+      value: 62856
+    - key: Hierarchy
+      value: 62858
+    - key: Group
+      value: 62889
+    - key: Add Group
+      value: 62893
     - key: Person
       value: 62910
     - key: Phone
@@ -184,120 +296,8 @@ MonoBehaviour:
       value: 63594
     - key: Undo
       value: 63703
-    - key: Grid View
-      value: 59407
-    - key: Show Chart
-      value: 59416
-    - key: Cached
-      value: 59440
-    - key: Add Location
-      value: 59521
-    - key: Remove Location
-      value: 59522
-    - key: Add Circle
-      value: 61709
-    - key: Headphones
-      value: 62578
-    - key: Heart Outline
-      value: 62586
-    - key: Exclamation Point
-      value: 62624
-    - key: Flag Outline
-      value: 62476
-    - key: Globe
-      value: 62427
-    - key: Language
-      value: 62555
-    - key: Sticky Note
-      value: 62828
     - key: Book
       value: 63742
-    - key: Add Group
-      value: 62893
-    - key: Hierarchy
-      value: 62858
-    - key: Settings Sliders
-      value: 62856
-    - key: Add Note
-      value: 62831
-    - key: Pen Tip
-      value: 62632
-    - key: Pan
-      value: 59518
-    - key: Hand Left
-      value: 59519
-    - key: Write Mail
-      value: 59526
-    - key: Music
-      value: 59531
-    - key: Music Mute
-      value: 59532
-    - key: Circle
-      value: 59846
-    - key: Sound
-      value: 60227
-    - key: Add Tab
-      value: 60390
-    - key: Uniform Grid
-      value: 61731
-    - key: Mobile
-      value: 61733
-    - key: Reset
-      value: 61760
-    - key: Move
-      value: 61801
-    - key: Swap Vert
-      value: 61835
-    - key: Tab
-      value: 61877
-    - key: Layout Grid
-      value: 61923
-    - key: Vertical List
-      value: 61967
-    - key: Horizontal List
-      value: 61972
-    - key: Shopping Cart
-      value: 62059
-    - key: Messenger
-      value: 62087
-    - key: Time
-      value: 62174
-    - key: Alarm
-      value: 62178
-    - key: Open In New
-      value: 62194
-    - key: Color Palette
-      value: 62198
-    - key: Message
-      value: 62208
-    - key: Draft
-      value: 62229
-    - key: Exit
-      value: 62233
-    - key: User
-      value: 62240
-    - key: Line Chart
-      value: 62269
-    - key: Bar Chart
-      value: 62274
-    - key: Pie Chart
-      value: 62277
-    - key: Zoom
-      value: 62181
-    - key: Layout 2
-      value: 62326
-    - key: Doc
-      value: 62329
-    - key: Edit Doc
-      value: 62343
-    - key: Smiley
-      value: 62433
-    - key: My Location
-      value: 62815
-    - key: Newspaper
-      value: 62822
-    - key: Group
-      value: 62889
   iconFontAsset: {fileID: 11400000, guid: 9b0d0ee11ff70b04d901a29b519cbaa0, type: 2}
   optionalEditorMaterial: {fileID: 0}
   fontIconSetDefinition: {fileID: 11400000, guid: e63daff880b56ed439a2e852b6e6993a, type: 2}

--- a/org.mixedrealitytoolkit.standardassets/Icons/MRTK_FluentIconSet.asset
+++ b/org.mixedrealitytoolkit.standardassets/Icons/MRTK_FluentIconSet.asset
@@ -14,84 +14,10 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   glyphIconsByName:
     entries:
-    - key: Icon 110
-      value: 62822
-    - key: Icon 108
-      value: 62815
     - key: Icon 102
       value: 62700
-    - key: Icon 86
-      value: 62433
-    - key: Icon 83
-      value: 62343
-    - key: Icon 82
-      value: 62329
-    - key: Icon 81
-      value: 62326
     - key: Icon 77
       value: 62298
-    - key: Icon 75
-      value: 62277
-    - key: Icon 74
-      value: 62274
-    - key: Icon 73
-      value: 62269
-    - key: Icon 71
-      value: 62240
-    - key: Icon 70
-      value: 62233
-    - key: Icon 69
-      value: 62229
-    - key: Icon 68
-      value: 62208
-    - key: Icon 67
-      value: 62198
-    - key: Icon 66
-      value: 62194
-    - key: Icon 65
-      value: 62181
-    - key: Icon 64
-      value: 62178
-    - key: Icon 63
-      value: 62174
-    - key: Icon 56
-      value: 62087
-    - key: Icon 54
-      value: 62059
-    - key: Icon 51
-      value: 61972
-    - key: Icon 50
-      value: 61967
-    - key: Icon 48
-      value: 61923
-    - key: Icon 46
-      value: 61877
-    - key: Icon 43
-      value: 61835
-    - key: Icon 40
-      value: 61801
-    - key: Icon 37
-      value: 61760
-    - key: Icon 34
-      value: 61733
-    - key: Icon 33
-      value: 61731
-    - key: Icon 28
-      value: 60390
-    - key: Icon 26
-      value: 60227
-    - key: Icon 24
-      value: 59846
-    - key: Icon 23
-      value: 59532
-    - key: Icon 22
-      value: 59531
-    - key: Icon 19
-      value: 59526
-    - key: Icon 13
-      value: 59519
-    - key: Icon 12
-      value: 59518
     - key: Brightness
       value: 59456
     - key: Calendar
@@ -208,8 +134,6 @@ MonoBehaviour:
       value: 62810
     - key: Menu
       value: 62817
-    - key: People
-      value: 62889
     - key: Person
       value: 62910
     - key: Phone
@@ -298,6 +222,82 @@ MonoBehaviour:
       value: 62831
     - key: Pen Tip
       value: 62632
+    - key: Pan
+      value: 59518
+    - key: Hand Left
+      value: 59519
+    - key: Write Mail
+      value: 59526
+    - key: Music
+      value: 59531
+    - key: Music Mute
+      value: 59532
+    - key: Circle
+      value: 59846
+    - key: Sound
+      value: 60227
+    - key: Add Tab
+      value: 60390
+    - key: Uniform Grid
+      value: 61731
+    - key: Mobile
+      value: 61733
+    - key: Reset
+      value: 61760
+    - key: Move
+      value: 61801
+    - key: Swap Vert
+      value: 61835
+    - key: Tab
+      value: 61877
+    - key: Layout Grid
+      value: 61923
+    - key: Vertical List
+      value: 61967
+    - key: Horizontal List
+      value: 61972
+    - key: Shopping Cart
+      value: 62059
+    - key: Messenger
+      value: 62087
+    - key: Time
+      value: 62174
+    - key: Alarm
+      value: 62178
+    - key: Open In New
+      value: 62194
+    - key: Color Palette
+      value: 62198
+    - key: Message
+      value: 62208
+    - key: Draft
+      value: 62229
+    - key: Exit
+      value: 62233
+    - key: User
+      value: 62240
+    - key: Line Chart
+      value: 62269
+    - key: Bar Chart
+      value: 62274
+    - key: Pie Chart
+      value: 62277
+    - key: Zoom
+      value: 62181
+    - key: Layout 2
+      value: 62326
+    - key: Doc
+      value: 62329
+    - key: Edit Doc
+      value: 62343
+    - key: Smiley
+      value: 62433
+    - key: My Location
+      value: 62815
+    - key: Newspaper
+      value: 62822
+    - key: Group
+      value: 62889
   iconFontAsset: {fileID: 11400000, guid: 9b0d0ee11ff70b04d901a29b519cbaa0, type: 2}
   optionalEditorMaterial: {fileID: 0}
   fontIconSetDefinition: {fileID: 11400000, guid: e63daff880b56ed439a2e852b6e6993a, type: 2}

--- a/org.mixedrealitytoolkit.standardassets/package.json
+++ b/org.mixedrealitytoolkit.standardassets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "org.mixedrealitytoolkit.standardassets",
-  "version": "3.2.1-development",
+  "version": "3.3.0-development",
   "description": "Common assets used by the MRTK packages, including common fonts, materials, and models. Relies on the Graphics Tools collection of shaders.",
   "displayName": "MRTK Standard Assets",
   "msftFeatureCategory": "MRTK3",

--- a/org.mixedrealitytoolkit.uxcomponents/Button/Prefabs/Action Button.prefab
+++ b/org.mixedrealitytoolkit.uxcomponents/Button/Prefabs/Action Button.prefab
@@ -151,9 +151,9 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   fontIcons: {fileID: 11400000, guid: 98fec9bd136c93c44ba1f6f1bd5f38b5, type: 2}
-  currentIconName: Icon 117
+  currentIconName: Person
   textMeshProComponent: {fileID: 5095746839500215027}
-  iconFontAsset: {fileID: 0}
+  migratedSuccessfully: 1
 --- !u!1 &410843422125320171
 GameObject:
   m_ObjectHideFlags: 0

--- a/org.mixedrealitytoolkit.uxcomponents/CHANGELOG.md
+++ b/org.mixedrealitytoolkit.uxcomponents/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 * Updated the minimum editor version to 6000.0.66f2 [PR #1112](https://github.com/MixedRealityToolkit/MixedRealityToolkit-Unity/pull/1112)
 * Reserialized prefabs and animations to remove stale serialized fields. [PR #1115](https://github.com/MixedRealityToolkit/MixedRealityToolkit-Unity/pull/1115)
+* Updated the Action Button prefab to have a more descriptive icon name. [PR #1117](https://github.com/MixedRealityToolkit/MixedRealityToolkit-Unity/pull/1117)
 
 ## [4.0.0-pre.2] - 2025-12-05
 

--- a/org.mixedrealitytoolkit.uxcore/CHANGELOG.md
+++ b/org.mixedrealitytoolkit.uxcore/CHANGELOG.md
@@ -4,6 +4,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## Unreleased
 
+### Added
+
+* Added the ability to map different icon sets together to have matching names (prerequisite for theming work). [PR #1077](https://github.com/MixedRealityToolkit/MixedRealityToolkit-Unity/pull/1077)
+
 ### Changed
 
 * Updated the minimum editor version to 6000.0.66f2 [PR #1112](https://github.com/MixedRealityToolkit/MixedRealityToolkit-Unity/pull/1112)

--- a/org.mixedrealitytoolkit.uxcore/Editor/Inspectors/FontIconSet/FontIconSelectorInspector.cs
+++ b/org.mixedrealitytoolkit.uxcore/Editor/Inspectors/FontIconSet/FontIconSelectorInspector.cs
@@ -1,4 +1,3 @@
-
 // Copyright (c) Mixed Reality Toolkit Contributors
 // Licensed under the BSD 3-Clause
 
@@ -13,12 +12,6 @@ namespace MixedReality.Toolkit.Editor
     [CanEditMultipleObjects]
     class FontIconSelectorInspector : UnityEditor.Editor
     {
-
-        private const string defaultShaderName = "TextMeshPro/Distance Field SSD";
-        private float fontTileSize = 32;
-
-        private static Material fontRenderMaterial;
-
         private const string noFontIconsMessage = "No IconFontSet profile selected. No icons available.";
         private const string emptyFontIconSetMessage = "The selected IconFontSet profile has no icons defined. Please edit the IconFontSet.";
 
@@ -29,6 +22,7 @@ namespace MixedReality.Toolkit.Editor
         private GUIStyle currentButtonStyle;
 
         private bool initializedStyle = false;
+        private float fontTileSize = 32;
 
         /// <summary>
         /// A Unity event function that is called when the script component has been enabled.
@@ -38,7 +32,6 @@ namespace MixedReality.Toolkit.Editor
             fontIconsProp = serializedObject.FindProperty("fontIcons");
             currentIconNameProp = serializedObject.FindProperty("currentIconName");
             tmProProp = serializedObject.FindProperty("textMeshProComponent");
-            
         }
 
         /// <summary>
@@ -90,7 +83,6 @@ namespace MixedReality.Toolkit.Editor
         }
 
         private int numColumns = 4;
-
         private Vector2 scrollAmount;
 
         public void DrawIconGrid(FontIconSelector fontIconSelector, float tileSize)
@@ -101,45 +93,42 @@ namespace MixedReality.Toolkit.Editor
 
             scrollAmount = EditorGUILayout.BeginScrollView(scrollAmount, GUILayout.MaxHeight(128), GUILayout.MinHeight(64));
             EditorGUILayout.BeginHorizontal();
-            
+
             foreach (string iconName in fontIconSet.GlyphIconsByName.Keys)
             {
                 uint unicodeValue = fontIconSet.GlyphIconsByName[iconName];
-                bool selected = (iconName == fontIconSelector.CurrentIconName);
+
                 if (column >= numColumns)
                 {
                     column = 0;
                     EditorGUILayout.EndHorizontal();
                     EditorGUILayout.BeginHorizontal();
                 }
+
                 if (GUILayout.Button(" ",
-                    GUILayout.MinHeight(tileSize),
-                    GUILayout.MaxHeight(tileSize),
-                    GUILayout.MinWidth(tileSize),
-                    GUILayout.MaxWidth(tileSize)))
+                    GUILayout.Height(tileSize),
+                    GUILayout.Width(tileSize)))
                 {
-                    Undo.RecordObjects(new UnityEngine.Object[]{fontIconSelector, fontIconSelector.TextMeshProComponent}, "Changed icon");
+                    Undo.RecordObjects(new Object[] { fontIconSelector, fontIconSelector.TextMeshProComponent }, "Changed icon");
                     fontIconSelector.CurrentIconName = iconName;
                     PrefabUtility.RecordPrefabInstancePropertyModifications(fontIconSelector);
                     PrefabUtility.RecordPrefabInstancePropertyModifications(fontIconSelector.TextMeshProComponent);
                 }
+
                 Rect textureRect = GUILayoutUtility.GetLastRect();
                 if (textureRect.yMin + 8 < scrollAmount.y || textureRect.yMax - 8 > scrollAmount.y + 128)
                 {
                     unicodeValue = 0;
                 }
-
                 textureRect.width = tileSize;
                 textureRect.height = tileSize;
-                FontIconSetInspector.EditorDrawTMPGlyph(textureRect, unicodeValue, fontAsset, selected);
+                FontIconSetInspector.EditorDrawTMPGlyph(textureRect, unicodeValue, fontAsset, iconName == fontIconSelector.CurrentIconName);
+
                 column++;
             }
 
-            if (column > 0)
-            {
-                EditorGUILayout.EndHorizontal();
-            }
-            
+            EditorGUILayout.EndHorizontal();
+
             if (Event.current.type == EventType.Repaint)
             {
                 float editorWindowWidth = GUILayoutUtility.GetLastRect().width;

--- a/org.mixedrealitytoolkit.uxcore/Editor/Inspectors/FontIconSet/FontIconSelectorInspector.cs
+++ b/org.mixedrealitytoolkit.uxcore/Editor/Inspectors/FontIconSet/FontIconSelectorInspector.cs
@@ -12,16 +12,15 @@ namespace MixedReality.Toolkit.Editor
     [CanEditMultipleObjects]
     class FontIconSelectorInspector : UnityEditor.Editor
     {
-        private const string noFontIconsMessage = "No FontIconSet profile selected. No icons available.";
-        private const string emptyFontIconSetMessage = "The selected FontIconSet profile has no icons defined. Please edit the FontIconSet.";
+        private const string NoFontIconsMessage = "No FontIconSet profile selected. No icons available.";
+        private const string EmptyFontIconSetMessage = "The selected FontIconSet profile has no icons defined. Please edit the FontIconSet.";
 
         private SerializedProperty fontIconsProp = null;
         private SerializedProperty currentIconNameProp = null;
         private SerializedProperty tmProProp = null;
 
-        private GUIStyle currentButtonStyle;
+        private GUIStyle currentButtonStyle = null;
 
-        private bool initializedStyle = false;
         private float fontTileSize = 32;
 
         /// <summary>
@@ -66,11 +65,7 @@ namespace MixedReality.Toolkit.Editor
         {
             serializedObject.Update();
 
-            if (!initializedStyle)
-            {
-                currentButtonStyle = new GUIStyle(GUI.skin.button);
-                initializedStyle = true;
-            }
+            currentButtonStyle ??= new GUIStyle(GUI.skin.button);
 
             FontIconSelector fontIconSelector = (FontIconSelector)target;
             FontIconSet fontIconSet = fontIconSelector.FontIcons;
@@ -86,11 +81,11 @@ namespace MixedReality.Toolkit.Editor
 
             if (fontIconsProp.objectReferenceValue == null)
             {
-                EditorGUILayout.HelpBox(noFontIconsMessage, MessageType.Warning);
+                EditorGUILayout.HelpBox(NoFontIconsMessage, MessageType.Warning);
             }
             else if (!fontIconSet || fontIconSet.GlyphIconsByName.Count == 0)
             {
-                EditorGUILayout.HelpBox(emptyFontIconSetMessage, MessageType.Warning);
+                EditorGUILayout.HelpBox(EmptyFontIconSetMessage, MessageType.Warning);
             }
             else
             {

--- a/org.mixedrealitytoolkit.uxcore/Editor/Inspectors/FontIconSet/FontIconSelectorInspector.cs
+++ b/org.mixedrealitytoolkit.uxcore/Editor/Inspectors/FontIconSet/FontIconSelectorInspector.cs
@@ -12,8 +12,8 @@ namespace MixedReality.Toolkit.Editor
     [CanEditMultipleObjects]
     class FontIconSelectorInspector : UnityEditor.Editor
     {
-        private const string noFontIconsMessage = "No IconFontSet profile selected. No icons available.";
-        private const string emptyFontIconSetMessage = "The selected IconFontSet profile has no icons defined. Please edit the IconFontSet.";
+        private const string noFontIconsMessage = "No FontIconSet profile selected. No icons available.";
+        private const string emptyFontIconSetMessage = "The selected FontIconSet profile has no icons defined. Please edit the FontIconSet.";
 
         private SerializedProperty fontIconsProp = null;
         private SerializedProperty currentIconNameProp = null;
@@ -39,6 +39,8 @@ namespace MixedReality.Toolkit.Editor
         /// </summary>
         public override void OnInspectorGUI()
         {
+            serializedObject.Update();
+
             if (!initializedStyle)
             {
                 currentButtonStyle = new GUIStyle(GUI.skin.button);

--- a/org.mixedrealitytoolkit.uxcore/Editor/Inspectors/FontIconSet/FontIconSelectorInspector.cs
+++ b/org.mixedrealitytoolkit.uxcore/Editor/Inspectors/FontIconSet/FontIconSelectorInspector.cs
@@ -136,10 +136,22 @@ namespace MixedReality.Toolkit.Editor
                     GUILayout.Height(tileSize),
                     GUILayout.Width(tileSize)))
                 {
-                    Undo.RecordObjects(new Object[] { fontIconSelector, fontIconSelector.TextMeshProComponent }, "Changed icon");
+                    if (fontIconSelector.TextMeshProComponent != null)
+                    {
+                        Undo.RecordObjects(new Object[] { fontIconSelector, fontIconSelector.TextMeshProComponent }, "Changed icon");
+                    }
+                    else
+                    {
+                        Undo.RecordObject(fontIconSelector, "Changed icon");
+                    }
+
                     fontIconSelector.CurrentIconName = iconName;
+
                     PrefabUtility.RecordPrefabInstancePropertyModifications(fontIconSelector);
-                    PrefabUtility.RecordPrefabInstancePropertyModifications(fontIconSelector.TextMeshProComponent);
+                    if (fontIconSelector.TextMeshProComponent != null)
+                    {
+                        PrefabUtility.RecordPrefabInstancePropertyModifications(fontIconSelector.TextMeshProComponent);
+                    }
                 }
 
                 Rect textureRect = GUILayoutUtility.GetLastRect();

--- a/org.mixedrealitytoolkit.uxcore/Editor/Inspectors/FontIconSet/FontIconSelectorInspector.cs
+++ b/org.mixedrealitytoolkit.uxcore/Editor/Inspectors/FontIconSet/FontIconSelectorInspector.cs
@@ -32,6 +32,31 @@ namespace MixedReality.Toolkit.Editor
             fontIconsProp = serializedObject.FindProperty("fontIcons");
             currentIconNameProp = serializedObject.FindProperty("currentIconName");
             tmProProp = serializedObject.FindProperty("textMeshProComponent");
+
+            bool migratedAny = false;
+            foreach (Object targetObject in targets)
+            {
+                FontIconSelector selector = targetObject as FontIconSelector;
+                if (selector != null)
+                {
+                    Undo.RecordObject(selector, "Migrate Font Icon Selector");
+
+                    if (selector.TryMigrate())
+                    {
+                        EditorUtility.SetDirty(selector);
+                        if (PrefabUtility.IsPartOfPrefabInstance(selector))
+                        {
+                            PrefabUtility.RecordPrefabInstancePropertyModifications(selector);
+                        }
+                        migratedAny = true;
+                    }
+                }
+            }
+
+            if (migratedAny)
+            {
+                serializedObject.Update();
+            }
         }
 
         /// <summary>

--- a/org.mixedrealitytoolkit.uxcore/Editor/Inspectors/FontIconSet/FontIconSetInspector.cs
+++ b/org.mixedrealitytoolkit.uxcore/Editor/Inspectors/FontIconSet/FontIconSetInspector.cs
@@ -75,7 +75,7 @@ namespace MixedReality.Toolkit.Editor
 
             serializedObject.Update();
 
-            showGlyphIconFoldout = EditorGUILayout.Foldout(showGlyphIconFoldout, "Font Icons");
+            showGlyphIconFoldout = EditorGUILayout.Foldout(showGlyphIconFoldout, "Font Icons", true);
             if (showGlyphIconFoldout)
             {
                 EditorGUILayout.PropertyField(iconFontAssetProp);
@@ -98,7 +98,7 @@ namespace MixedReality.Toolkit.Editor
                     FontIconSet fontIconSet = (FontIconSet)target;
                     TMP_FontAsset fontAsset = (TMP_FontAsset)iconFontAssetProp.objectReferenceValue;
 
-                    showAvailableIcons = EditorGUILayout.Foldout(showAvailableIcons, "Available Icons");
+                    showAvailableIcons = EditorGUILayout.Foldout(showAvailableIcons, "Available Icons", true);
                     if (showAvailableIcons)
                     {
                         if (fontAsset.characterTable.Count == 0)
@@ -123,7 +123,7 @@ namespace MixedReality.Toolkit.Editor
                         EditorGUILayout.Space();
                     }
 
-                    showSelectedIcons = EditorGUILayout.Foldout(showSelectedIcons, "Selected Icons");
+                    showSelectedIcons = EditorGUILayout.Foldout(showSelectedIcons, "Selected Icons", true);
                     if (showSelectedIcons)
                     {
                         if (fontIconSet.GlyphIconsByName.Count > 0)

--- a/org.mixedrealitytoolkit.uxcore/Editor/Inspectors/FontIconSet/FontIconSetInspector.cs
+++ b/org.mixedrealitytoolkit.uxcore/Editor/Inspectors/FontIconSet/FontIconSetInspector.cs
@@ -73,8 +73,6 @@ namespace MixedReality.Toolkit.Editor
         /// </summary>
         public override void OnInspectorGUI()
         {
-            FontIconSet fontIconSet = (FontIconSet)target;
-
             bool showGlyphIconFoldout = SessionState.GetBool(ShowGlyphIconsFoldoutKey, false);
             bool showAvailableIcons = SessionState.GetBool(AvailableIconsFoldoutKey, true);
             bool showSelectedIcons = SessionState.GetBool(SelectedIconsFoldoutKey, true);
@@ -103,6 +101,7 @@ namespace MixedReality.Toolkit.Editor
                 }
                 else
                 {
+                    FontIconSet fontIconSet = (FontIconSet)target;
                     TMP_FontAsset fontAsset = (TMP_FontAsset)iconFontAssetProp.objectReferenceValue;
 
                     showAvailableIcons = EditorGUILayout.BeginFoldoutHeaderGroup(showAvailableIcons, "Available Icons");
@@ -113,7 +112,7 @@ namespace MixedReality.Toolkit.Editor
                             EditorGUILayout.HelpBox("No icons are available in this font. The font may be configured incorrectly.", MessageType.Warning);
                             if (GUILayout.Button("Open Font Editor"))
                             {
-                                Selection.activeObject = fontIconSet.IconFontAsset;
+                                Selection.activeObject = fontAsset;
                             }
                         }
                         else
@@ -121,16 +120,16 @@ namespace MixedReality.Toolkit.Editor
                             EditorGUILayout.HelpBox("Click an icon to add it to your selected icons.", MessageType.Info);
                             if (GUILayout.Button("Open Font Editor"))
                             {
-                                Selection.activeObject = fontIconSet.IconFontAsset;
+                                Selection.activeObject = fontAsset;
                             }
 
-                            DrawFontGlyphsGrid(fontIconSet, maxButtonsPerColumn);
+                            DrawFontGlyphsGrid(fontAsset, fontIconSet, maxButtonsPerColumn);
                         }
 
                         EditorGUILayout.Space();
                     }
-
                     EditorGUILayout.EndFoldoutHeaderGroup();
+
                     showSelectedIcons = EditorGUILayout.BeginFoldoutHeaderGroup(showSelectedIcons, "Selected Icons");
                     if (showSelectedIcons)
                     {
@@ -177,7 +176,6 @@ namespace MixedReality.Toolkit.Editor
                             EditorGUILayout.HelpBox("No icons added yet. Click available icons to add.", MessageType.Info);
                         }
                     }
-
                     EditorGUILayout.EndFoldoutHeaderGroup();
                 }
             }
@@ -194,9 +192,21 @@ namespace MixedReality.Toolkit.Editor
         /// </summary>
         /// <param name="fontIconSet">The set of font glyphs to draw.</param>
         /// <param name="maxButtonsPerColumn">The number of buttons per column.</param>
+        [Obsolete("This method has been removed.")]
         public void DrawFontGlyphsGrid(FontIconSet fontIconSet, int maxButtonsPerColumn)
         {
             TMP_FontAsset fontAsset = fontIconSet.IconFontAsset;
+            DrawFontGlyphsGrid(fontAsset, fontIconSet, maxButtonsPerColumn);
+        }
+
+        /// <summary>
+        /// Draw a grid of buttons than can be clicked to select a glyph from a set up glyphs.
+        /// </summary>
+        /// <param name="fontAsset"></param>
+        /// <param name="fontIconSet">The set of font glyphs to draw.</param>
+        /// <param name="maxButtonsPerColumn">The number of buttons per column.</param>
+        private void DrawFontGlyphsGrid(TMP_FontAsset fontAsset, FontIconSet fontIconSet, int maxButtonsPerColumn)
+        {
             int column = 0;
             EditorGUILayout.BeginHorizontal();
             for (int i = 0; i < fontAsset.characterTable.Count; i++)

--- a/org.mixedrealitytoolkit.uxcore/Editor/Inspectors/FontIconSet/FontIconSetInspector.cs
+++ b/org.mixedrealitytoolkit.uxcore/Editor/Inspectors/FontIconSet/FontIconSetInspector.cs
@@ -213,18 +213,21 @@ namespace MixedReality.Toolkit.Editor
                     EditorGUILayout.BeginHorizontal();
                 }
 
-                if (GUILayout.Button(" ",
-                    GUILayout.Height(ButtonDimension),
-                    GUILayout.MaxWidth(ButtonDimension)))
+                using (new EditorGUI.DisabledGroupScope(fontIconSet.GlyphIconsByName.ContainsValue(fontAsset.characterTable[i].unicode)))
                 {
-                    AddIcon(fontIconSet, fontAsset.characterTable[i].unicode);
-                    EditorUtility.SetDirty(target);
-                }
+                    if (GUILayout.Button(" ",
+                        GUILayout.Height(ButtonDimension),
+                        GUILayout.MaxWidth(ButtonDimension)))
+                    {
+                        AddIcon(fontIconSet, fontAsset.characterTable[i].unicode);
+                        EditorUtility.SetDirty(target);
+                    }
 
-                Rect textureRect = GUILayoutUtility.GetLastRect();
-                textureRect.width = GlyphDrawSize;
-                textureRect.height = GlyphDrawSize;
-                EditorDrawTMPGlyph(textureRect, fontAsset, fontAsset.characterTable[i]);
+                    Rect textureRect = GUILayoutUtility.GetLastRect();
+                    textureRect.width = GlyphDrawSize;
+                    textureRect.height = GlyphDrawSize;
+                    EditorDrawTMPGlyph(textureRect, fontAsset, fontAsset.characterTable[i]);
+                }
 
                 column++;
             }

--- a/org.mixedrealitytoolkit.uxcore/Editor/Inspectors/FontIconSet/FontIconSetInspector.cs
+++ b/org.mixedrealitytoolkit.uxcore/Editor/Inspectors/FontIconSet/FontIconSetInspector.cs
@@ -34,6 +34,7 @@ namespace MixedReality.Toolkit.Editor
         private const string TextMeshProMenuItem = "Window/TextMeshPro/Font Asset Creator";
 
         private SerializedProperty iconFontAssetProp = null;
+        private SerializedProperty fontIconSetDefinition = null;
 
         private class IconEntry
         {
@@ -56,6 +57,7 @@ namespace MixedReality.Toolkit.Editor
         {
             FontIconSet fontIconSet = (FontIconSet)target;
             iconFontAssetProp = serializedObject.FindProperty("iconFontAsset");
+            fontIconSetDefinition = serializedObject.FindProperty("fontIconSetDefinition");
 
             // Make a list out of dictionary to avoid changing order while editing names
             foreach (KeyValuePair<string, uint> kv in fontIconSet.GlyphIconsByName)
@@ -79,6 +81,7 @@ namespace MixedReality.Toolkit.Editor
             if (showGlyphIconFoldout)
             {
                 EditorGUILayout.PropertyField(iconFontAssetProp);
+                EditorGUILayout.PropertyField(fontIconSetDefinition);
 
                 if (iconFontAssetProp.objectReferenceValue == null)
                 {
@@ -129,6 +132,11 @@ namespace MixedReality.Toolkit.Editor
                         if (fontIconSet.GlyphIconsByName.Count > 0)
                         {
                             EditorGUILayout.HelpBox("These icons will appear in the button config helper inspector. Click an icon to remove it from this list.", MessageType.Info);
+
+                            if (fontIconSetDefinition.objectReferenceValue == null)
+                            {
+                                EditorGUILayout.HelpBox("It's recommended to use a Font Icon Set Definition to ensure consistent icon names across icon sets.", MessageType.Warning);
+                            }
 
                             int column = 0;
                             string iconToRemove = null;

--- a/org.mixedrealitytoolkit.uxcore/Editor/Inspectors/FontIconSet/FontIconSetInspector.cs
+++ b/org.mixedrealitytoolkit.uxcore/Editor/Inspectors/FontIconSet/FontIconSetInspector.cs
@@ -75,9 +75,7 @@ namespace MixedReality.Toolkit.Editor
 
             serializedObject.Update();
 
-            showGlyphIconFoldout = EditorGUILayout.BeginFoldoutHeaderGroup(showGlyphIconFoldout, "Font Icons");
-            EditorGUILayout.EndFoldoutHeaderGroup();
-
+            showGlyphIconFoldout = EditorGUILayout.Foldout(showGlyphIconFoldout, "Font Icons");
             if (showGlyphIconFoldout)
             {
                 EditorGUILayout.PropertyField(iconFontAssetProp);
@@ -100,7 +98,7 @@ namespace MixedReality.Toolkit.Editor
                     FontIconSet fontIconSet = (FontIconSet)target;
                     TMP_FontAsset fontAsset = (TMP_FontAsset)iconFontAssetProp.objectReferenceValue;
 
-                    showAvailableIcons = EditorGUILayout.BeginFoldoutHeaderGroup(showAvailableIcons, "Available Icons");
+                    showAvailableIcons = EditorGUILayout.Foldout(showAvailableIcons, "Available Icons");
                     if (showAvailableIcons)
                     {
                         if (fontAsset.characterTable.Count == 0)
@@ -124,9 +122,8 @@ namespace MixedReality.Toolkit.Editor
 
                         EditorGUILayout.Space();
                     }
-                    EditorGUILayout.EndFoldoutHeaderGroup();
 
-                    showSelectedIcons = EditorGUILayout.BeginFoldoutHeaderGroup(showSelectedIcons, "Selected Icons");
+                    showSelectedIcons = EditorGUILayout.Foldout(showSelectedIcons, "Selected Icons");
                     if (showSelectedIcons)
                     {
                         if (fontIconSet.GlyphIconsByName.Count > 0)
@@ -172,7 +169,6 @@ namespace MixedReality.Toolkit.Editor
                             EditorGUILayout.HelpBox("No icons added yet. Click available icons to add.", MessageType.Info);
                         }
                     }
-                    EditorGUILayout.EndFoldoutHeaderGroup();
                 }
             }
 
@@ -247,12 +243,9 @@ namespace MixedReality.Toolkit.Editor
         private bool RemoveIcon(FontIconSet fontIconSet, string iconName)
         {
             bool removed = fontIconSet.RemoveIcon(iconName);
-            if (removed)
+            if (removed && FindIconIndexByName(iconName, out int index))
             {
-                if (FindIconIndexByName(iconName, out int index))
-                {
-                    iconEntries.RemoveAt(index);
-                }
+                iconEntries.RemoveAt(index);
             }
             return removed;
         }
@@ -272,12 +265,9 @@ namespace MixedReality.Toolkit.Editor
 
         private void UpdateIconName(FontIconSet fontIconSet, string oldName, string newName)
         {
-            if (fontIconSet.UpdateIconName(oldName, newName))
+            if (fontIconSet.UpdateIconName(oldName, newName) && FindIconIndexByName(oldName, out int index))
             {
-                if (FindIconIndexByName(oldName, out int index))
-                {
-                    iconEntries[index].Name = newName;
-                }
+                iconEntries[index].Name = newName;
             }
         }
 

--- a/org.mixedrealitytoolkit.uxcore/Editor/Inspectors/FontIconSet/FontIconSetInspector.cs
+++ b/org.mixedrealitytoolkit.uxcore/Editor/Inspectors/FontIconSet/FontIconSetInspector.cs
@@ -130,38 +130,46 @@ namespace MixedReality.Toolkit.Editor
                         {
                             EditorGUILayout.HelpBox("These icons will appear in the button config helper inspector. Click an icon to remove it from this list.", MessageType.Info);
 
-                            using (new EditorGUILayout.VerticalScope())
+                            int column = 0;
+                            string iconToRemove = null;
+                            EditorGUILayout.BeginHorizontal();
+                            foreach (IconEntry iconEntry in iconEntries)
                             {
-                                string iconToRemove = null;
-                                foreach (IconEntry iconEntry in iconEntries)
+                                if (column >= MaxButtonsPerColumn)
                                 {
-                                    using (new EditorGUILayout.HorizontalScope())
-                                    {
-                                        if (GUILayout.Button(" ", GUILayout.Height(ButtonDimension), GUILayout.MaxWidth(ButtonDimension)))
-                                        {
-                                            iconToRemove = iconEntry.Name;
-                                        }
-                                        Rect textureRect = GUILayoutUtility.GetLastRect();
-                                        textureRect.width = GlyphDrawSize;
-                                        textureRect.height = GlyphDrawSize;
-                                        EditorDrawTMPGlyph(textureRect, iconEntry.UnicodeValue, fontAsset);
-
-                                        string currentName = iconEntry.Name;
-                                        currentName = EditorGUILayout.TextField(currentName);
-                                        if (currentName != iconEntry.Name)
-                                        {
-                                            UpdateIconName(fontIconSet, iconEntry.Name, currentName);
-                                        }
-                                        EditorGUILayout.Space();
-                                    }
-
-                                    EditorGUILayout.Space();
+                                    column = 0;
+                                    EditorGUILayout.EndHorizontal();
+                                    EditorGUILayout.BeginHorizontal();
                                 }
 
-                                if (iconToRemove != null)
+                                EditorGUILayout.BeginVertical(GUILayout.Width(ButtonDimension));
+
+                                if (GUILayout.Button(" ",
+                                    GUILayout.Height(ButtonDimension),
+                                    GUILayout.MaxWidth(ButtonDimension)))
                                 {
-                                    RemoveIcon(fontIconSet, iconToRemove);
+                                    iconToRemove = iconEntry.Name;
                                 }
+
+                                Rect textureRect = GUILayoutUtility.GetLastRect();
+                                textureRect.width = GlyphDrawSize;
+                                textureRect.height = GlyphDrawSize;
+                                EditorDrawTMPGlyph(textureRect, iconEntry.UnicodeValue, fontAsset);
+
+                                string currentName = EditorGUILayout.TextField(iconEntry.Name);
+                                if (currentName != iconEntry.Name)
+                                {
+                                    UpdateIconName(fontIconSet, iconEntry.Name, currentName);
+                                }
+                                EditorGUILayout.EndVertical();
+
+                                column++;
+                            }
+                            EditorGUILayout.EndHorizontal();
+
+                            if (iconToRemove != null)
+                            {
+                                RemoveIcon(fontIconSet, iconToRemove);
                             }
                         }
                         else

--- a/org.mixedrealitytoolkit.uxcore/Editor/Inspectors/FontIconSet/FontIconSetInspector.cs
+++ b/org.mixedrealitytoolkit.uxcore/Editor/Inspectors/FontIconSet/FontIconSetInspector.cs
@@ -34,7 +34,7 @@ namespace MixedReality.Toolkit.Editor
         private const string TextMeshProMenuItem = "Window/TextMeshPro/Font Asset Creator";
 
         private SerializedProperty iconFontAssetProp = null;
-        private SerializedProperty fontIconSetDefinition = null;
+        private SerializedProperty fontIconSetDefinitionProp = null;
 
         private class IconEntry
         {
@@ -57,7 +57,7 @@ namespace MixedReality.Toolkit.Editor
         {
             FontIconSet fontIconSet = (FontIconSet)target;
             iconFontAssetProp = serializedObject.FindProperty("iconFontAsset");
-            fontIconSetDefinition = serializedObject.FindProperty("fontIconSetDefinition");
+            fontIconSetDefinitionProp = serializedObject.FindProperty("fontIconSetDefinition");
 
             // Make a list out of dictionary to avoid changing order while editing names
             foreach (KeyValuePair<string, uint> kv in fontIconSet.GlyphIconsByName)
@@ -81,7 +81,7 @@ namespace MixedReality.Toolkit.Editor
             if (showGlyphIconFoldout)
             {
                 EditorGUILayout.PropertyField(iconFontAssetProp);
-                EditorGUILayout.PropertyField(fontIconSetDefinition);
+                EditorGUILayout.PropertyField(fontIconSetDefinitionProp);
 
                 if (iconFontAssetProp.objectReferenceValue == null)
                 {
@@ -133,7 +133,7 @@ namespace MixedReality.Toolkit.Editor
                         {
                             EditorGUILayout.HelpBox("These icons will appear in the button config helper inspector. Click an icon to remove it from this list.", MessageType.Info);
 
-                            if (fontIconSetDefinition.objectReferenceValue == null)
+                            if (fontIconSetDefinitionProp.objectReferenceValue == null)
                             {
                                 EditorGUILayout.HelpBox("It's recommended to use a Font Icon Set Definition to ensure consistent icon names across icon sets.", MessageType.Warning);
                             }
@@ -252,6 +252,7 @@ namespace MixedReality.Toolkit.Editor
             if (fontIconSet.AddIcon(name, unicodeValue))
             {
                 iconEntries.Add(new IconEntry(name, unicodeValue));
+                EditorUtility.SetDirty(fontIconSet);
             }
             return true;
         }
@@ -262,6 +263,7 @@ namespace MixedReality.Toolkit.Editor
             if (removed && FindIconIndexByName(iconName, out int index))
             {
                 iconEntries.RemoveAt(index);
+                EditorUtility.SetDirty(fontIconSet);
             }
             return removed;
         }
@@ -284,6 +286,7 @@ namespace MixedReality.Toolkit.Editor
             if (fontIconSet.UpdateIconName(oldName, newName) && FindIconIndexByName(oldName, out int index))
             {
                 iconEntries[index].Name = newName;
+                EditorUtility.SetDirty(fontIconSet);
             }
         }
 

--- a/org.mixedrealitytoolkit.uxcore/Editor/Inspectors/FontIconSet/FontIconSetInspector.cs
+++ b/org.mixedrealitytoolkit.uxcore/Editor/Inspectors/FontIconSet/FontIconSetInspector.cs
@@ -333,7 +333,7 @@ namespace MixedReality.Toolkit.Editor
 
                             Material glyphMaterial = fontRenderMaterial;
                             glyphMaterial.mainTexture = atlasTexture;
-                            glyphMaterial.SetColor("_Color", selected ? Color.green : Color.white);
+                            glyphMaterial.SetColor("_FaceColor", selected ? Color.green : Color.white);
 
                             int glyphOriginX = glyph.glyphRect.x;
                             int glyphOriginY = glyph.glyphRect.y;

--- a/org.mixedrealitytoolkit.uxcore/Editor/Inspectors/FontIconSet/FontIconSetInspector.cs
+++ b/org.mixedrealitytoolkit.uxcore/Editor/Inspectors/FontIconSet/FontIconSetInspector.cs
@@ -1,4 +1,3 @@
-
 // Copyright (c) Mixed Reality Toolkit Contributors
 // Licensed under the BSD 3-Clause
 
@@ -23,19 +22,16 @@ namespace MixedReality.Toolkit.Editor
         private const string AvailableIconsFoldoutKey = "MixedRealityToolkit.FontIconSet.ShowAvailableIcons";
         private const string SelectedIconsFoldoutKey = "MixedRealityToolkit.FontIconSet.ShowSelectedIcons";
 
-        private const string defaultShaderName = "TextMeshPro/Distance Field SSD"; // Only used for presentation in inspector, not at runtime.
-        private const int glyphDrawSize = 75;
-        private const int buttonWidth = 75;
-        private const int buttonHeight = 90;
-        private const int maxButtonsPerColumn = 6;
+        private const string DefaultShaderName = "TextMeshPro/Distance Field SSD"; // Only used for presentation in inspector, not at runtime.
+        private const int GlyphDrawSize = 75;
+        private const int ButtonDimension = 75;
+        private const int MaxButtonsPerColumn = 6;
 
-        private static Material fontRenderMaterial;
-
-        private const string noIconFontMessage = "No icon font asset selected. Icon fonts will be unavailable.";
-        private const string downloadIconFontMessage = "For instructions on how to install the HoloLens icon font asset, click the button below.";
-        private const string hololensIconFontUrl = "https://docs.microsoft.com/windows/mixed-reality/mrtk-unity/features/ux-building-blocks/button";
-        private const string mdl2IconFontName = "holomdl2";
-        private const string textMeshProMenuItem = "Window/TextMeshPro/Font Asset Creator";
+        private const string NoIconFontMessage = "No icon font asset selected. Icon fonts will be unavailable.";
+        private const string DownloadIconFontMessage = "For instructions on how to install the HoloLens icon font asset, click the button below.";
+        private const string HoloLensIconFontUrl = "https://docs.microsoft.com/windows/mixed-reality/mrtk-unity/features/ux-building-blocks/button";
+        private const string MDL2IconFontName = "holomdl2";
+        private const string TextMeshProMenuItem = "Window/TextMeshPro/Font Asset Creator";
 
         private SerializedProperty iconFontAssetProp = null;
 
@@ -88,14 +84,14 @@ namespace MixedReality.Toolkit.Editor
 
                 if (iconFontAssetProp.objectReferenceValue == null)
                 {
-                    EditorGUILayout.HelpBox(noIconFontMessage, MessageType.Warning);
-                    if (!CheckIfHololensIconFontExists())
+                    EditorGUILayout.HelpBox(NoIconFontMessage, MessageType.Warning);
+                    if (!CheckIfHoloLensIconFontExists())
                     {
-                        EditorGUILayout.HelpBox(downloadIconFontMessage, MessageType.Info);
+                        EditorGUILayout.HelpBox(DownloadIconFontMessage, MessageType.Info);
                         if (GUILayout.Button("View Font Asset Icons Documentation"))
                         {
-                            EditorApplication.ExecuteMenuItem(textMeshProMenuItem);
-                            Application.OpenURL(hololensIconFontUrl);
+                            EditorApplication.ExecuteMenuItem(TextMeshProMenuItem);
+                            Application.OpenURL(HoloLensIconFontUrl);
                         }
                     }
                 }
@@ -123,7 +119,7 @@ namespace MixedReality.Toolkit.Editor
                                 Selection.activeObject = fontAsset;
                             }
 
-                            DrawFontGlyphsGrid(fontAsset, fontIconSet, maxButtonsPerColumn);
+                            DrawFontGlyphsGrid(fontAsset, fontIconSet, MaxButtonsPerColumn);
                         }
 
                         EditorGUILayout.Space();
@@ -144,13 +140,13 @@ namespace MixedReality.Toolkit.Editor
                                 {
                                     using (new EditorGUILayout.HorizontalScope())
                                     {
-                                        if (GUILayout.Button(" ", GUILayout.MinHeight(buttonHeight), GUILayout.MaxHeight(buttonHeight), GUILayout.MaxWidth(buttonWidth)))
+                                        if (GUILayout.Button(" ", GUILayout.Height(ButtonDimension), GUILayout.MaxWidth(ButtonDimension)))
                                         {
                                             iconToRemove = iconEntry.Name;
                                         }
                                         Rect textureRect = GUILayoutUtility.GetLastRect();
-                                        textureRect.width = glyphDrawSize;
-                                        textureRect.height = glyphDrawSize;
+                                        textureRect.width = GlyphDrawSize;
+                                        textureRect.height = GlyphDrawSize;
                                         EditorDrawTMPGlyph(textureRect, iconEntry.UnicodeValue, fontAsset);
 
                                         string currentName = iconEntry.Name;
@@ -195,14 +191,13 @@ namespace MixedReality.Toolkit.Editor
         [Obsolete("This method has been removed.")]
         public void DrawFontGlyphsGrid(FontIconSet fontIconSet, int maxButtonsPerColumn)
         {
-            TMP_FontAsset fontAsset = fontIconSet.IconFontAsset;
-            DrawFontGlyphsGrid(fontAsset, fontIconSet, maxButtonsPerColumn);
+            DrawFontGlyphsGrid(fontIconSet.IconFontAsset, fontIconSet, maxButtonsPerColumn);
         }
 
         /// <summary>
         /// Draw a grid of buttons than can be clicked to select a glyph from a set up glyphs.
         /// </summary>
-        /// <param name="fontAsset"></param>
+        /// <param name="fontAsset">The font asset containing the glyphs.</param>
         /// <param name="fontIconSet">The set of font glyphs to draw.</param>
         /// <param name="maxButtonsPerColumn">The number of buttons per column.</param>
         private void DrawFontGlyphsGrid(TMP_FontAsset fontAsset, FontIconSet fontIconSet, int maxButtonsPerColumn)
@@ -217,25 +212,23 @@ namespace MixedReality.Toolkit.Editor
                     EditorGUILayout.EndHorizontal();
                     EditorGUILayout.BeginHorizontal();
                 }
+
                 if (GUILayout.Button(" ",
-                    GUILayout.MinHeight(buttonHeight),
-                    GUILayout.MaxHeight(buttonHeight),
-                    GUILayout.MaxWidth(buttonWidth)))
+                    GUILayout.Height(ButtonDimension),
+                    GUILayout.MaxWidth(ButtonDimension)))
                 {
                     AddIcon(fontIconSet, fontAsset.characterTable[i].unicode);
                     EditorUtility.SetDirty(target);
                 }
+
                 Rect textureRect = GUILayoutUtility.GetLastRect();
-                textureRect.width = glyphDrawSize;
-                textureRect.height = glyphDrawSize;
+                textureRect.width = GlyphDrawSize;
+                textureRect.height = GlyphDrawSize;
                 EditorDrawTMPGlyph(textureRect, fontAsset, fontAsset.characterTable[i]);
+
                 column++;
             }
-
-            if (column > 0)
-            {
-                EditorGUILayout.EndHorizontal();
-            }
+            EditorGUILayout.EndHorizontal();
         }
 
         private bool AddIcon(FontIconSet fontIconSet, uint unicodeValue)
@@ -285,11 +278,11 @@ namespace MixedReality.Toolkit.Editor
             }
         }
 
-        private bool CheckIfHololensIconFontExists()
+        private bool CheckIfHoloLensIconFontExists()
         {
             foreach (string guid in AssetDatabase.FindAssets($"t:{typeof(UnityEngine.Font).Name}"))
             {
-                if (AssetDatabase.GUIDToAssetPath(guid).Contains(mdl2IconFontName))
+                if (AssetDatabase.GUIDToAssetPath(guid).Contains(MDL2IconFontName))
                 {
                     return true;
                 }
@@ -317,7 +310,7 @@ namespace MixedReality.Toolkit.Editor
             {
                 try
                 {
-                    float iconSizeMultiplier = 0.625f;
+                    const float IconSizeMultiplier = 0.625f;
 
                     // Get a reference to the Glyph Table
                     int glyphIndex = (int)character.glyphIndex;
@@ -335,20 +328,12 @@ namespace MixedReality.Toolkit.Editor
                         {
                             if (fontRenderMaterial == null)
                             {
-                                fontRenderMaterial = new Material(Shader.Find(defaultShaderName));
+                                fontRenderMaterial = new Material(Shader.Find(DefaultShaderName));
                             }
 
                             Material glyphMaterial = fontRenderMaterial;
                             glyphMaterial.mainTexture = atlasTexture;
-
-                            if (selected)
-                            {
-                                glyphMaterial.SetColor("_Color", Color.green);
-                            }
-                            else
-                            {
-                                glyphMaterial.SetColor("_Color", Color.white);
-                            }
+                            glyphMaterial.SetColor("_Color", selected ? Color.green : Color.white);
 
                             int glyphOriginX = glyph.glyphRect.x;
                             int glyphOriginY = glyph.glyphRect.y;
@@ -356,13 +341,13 @@ namespace MixedReality.Toolkit.Editor
                             int glyphHeight = glyph.glyphRect.height;
 
                             float normalizedHeight = fontAsset.faceInfo.ascentLine - fontAsset.faceInfo.descentLine;
-                            float scale = Mathf.Min(glyphRect.width, glyphRect.height) / normalizedHeight * iconSizeMultiplier;
+                            float scale = Mathf.Min(glyphRect.width, glyphRect.height) / normalizedHeight * IconSizeMultiplier;
 
                             // Compute the normalized texture coordinates
                             Rect texCoords = new Rect((float)glyphOriginX / atlasTexture.width, (float)glyphOriginY / atlasTexture.height, (float)glyphWidth / atlasTexture.width, (float)glyphHeight / atlasTexture.height);
 
-                            glyphWidth = (int)Mathf.Min(glyphDrawSize, glyphWidth * scale);
-                            glyphHeight = (int)Mathf.Min(glyphDrawSize, glyphHeight * scale);
+                            glyphWidth = (int)Mathf.Min(GlyphDrawSize, glyphWidth * scale);
+                            glyphHeight = (int)Mathf.Min(GlyphDrawSize, glyphHeight * scale);
 
                             glyphRect.x += (glyphRect.width - glyphWidth) / 2;
                             glyphRect.y += (glyphRect.height - glyphHeight) / 2;

--- a/org.mixedrealitytoolkit.uxcore/Editor/Inspectors/FontIconSet/FontIconSetInspector.cs
+++ b/org.mixedrealitytoolkit.uxcore/Editor/Inspectors/FontIconSet/FontIconSetInspector.cs
@@ -37,7 +37,7 @@ namespace MixedReality.Toolkit.Editor
         private SerializedProperty fontIconSetDefinitionProp = null;
         private bool anyInvalidName = false;
 
-        private SortedList<uint, string> iconEntries = new SortedList<uint, string>();
+        private List<KeyValuePair<uint, string>> iconEntries = new List<KeyValuePair<uint, string>>();
         private List<string> validNames = new List<string>();
         private List<string> availableNames = new List<string>();
         private string[] availableNamesArray = Array.Empty<string>();
@@ -51,11 +51,56 @@ namespace MixedReality.Toolkit.Editor
             iconFontAssetProp = serializedObject.FindProperty("iconFontAsset");
             fontIconSetDefinitionProp = serializedObject.FindProperty("fontIconSetDefinition");
 
-            // Make a list out of dictionary to avoid changing order while editing names
+            // Listen for undo/redo events to ensure our local iconEntries cache stays in sync
+            Undo.undoRedoPerformed += UpdateIconEntries;
+            UpdateIconEntries();
+        }
+
+        private void OnDisable()
+        {
+            Undo.undoRedoPerformed -= UpdateIconEntries;
+        }
+
+        private void UpdateIconEntries()
+        {
+            FontIconSet fontIconSet = target as FontIconSet;
+            if (fontIconSet == null) { return; }
+
+            iconEntries.Clear();
+
+            if (iconEntries.Capacity < fontIconSet.GlyphIconsByName.Count)
+            {
+                iconEntries.Capacity = fontIconSet.GlyphIconsByName.Count;
+            }
+
             foreach (KeyValuePair<string, uint> kv in fontIconSet.GlyphIconsByName)
             {
-                iconEntries.Add(kv.Value, kv.Key);
+                iconEntries.Add(new KeyValuePair<uint, string>(kv.Value, kv.Key));
             }
+            iconEntries.Sort((a, b) => a.Key.CompareTo(b.Key));
+
+            validNames.Clear();
+            availableNames.Clear();
+            availableNames.Add(string.Empty);
+
+            if (fontIconSetDefinitionProp != null)
+            {
+                FontIconSetDefinition setDefinition = fontIconSetDefinitionProp.objectReferenceValue as FontIconSetDefinition;
+                if (setDefinition != null && setDefinition.IconNames != null)
+                {
+                    foreach (string name in setDefinition.IconNames)
+                    {
+                        validNames.Add(name);
+                        if (!fontIconSet.GlyphIconsByName.ContainsKey(name))
+                        {
+                            availableNames.Add(name);
+                        }
+                    }
+                }
+            }
+            availableNamesArray = availableNames.ToArray();
+
+            Repaint();
         }
 
         /// <summary>
@@ -73,7 +118,13 @@ namespace MixedReality.Toolkit.Editor
             if (showGlyphIconFoldout)
             {
                 EditorGUILayout.PropertyField(iconFontAssetProp);
+                EditorGUI.BeginChangeCheck();
                 EditorGUILayout.PropertyField(fontIconSetDefinitionProp);
+                if (EditorGUI.EndChangeCheck())
+                {
+                    serializedObject.ApplyModifiedProperties();
+                    UpdateIconEntries();
+                }
 
                 if (iconFontAssetProp.objectReferenceValue == null)
                 {
@@ -138,20 +189,11 @@ namespace MixedReality.Toolkit.Editor
                                     anyInvalidName = false;
                                 }
 
-                                validNames.Clear();
-                                availableNames.Clear();
-                                // Reserve space for the current icon's name
-                                availableNames.Add(string.Empty);
-                                foreach (string name in setDefinition.IconNames)
+                                // Catch edge cases where the external asset size changes while this inspector is still focused
+                                if (setDefinition.IconNames != null && validNames.Count != setDefinition.IconNames.Count)
                                 {
-                                    validNames.Add(name);
-                                    if (!iconEntries.ContainsValue(name))
-                                    {
-                                        availableNames.Add(name);
-                                    }
+                                    UpdateIconEntries();
                                 }
-
-                                availableNamesArray = availableNames.ToArray();
                             }
 
                             int column = 0;
@@ -297,9 +339,11 @@ namespace MixedReality.Toolkit.Editor
         private bool AddIcon(FontIconSet fontIconSet, uint unicodeValue)
         {
             string name = $"Icon {unicodeValue}";
+
+            Undo.RecordObject(fontIconSet, "Add Icon");
             if (fontIconSet.AddIcon(name, unicodeValue))
             {
-                iconEntries.Add(unicodeValue, name);
+                UpdateIconEntries();
                 EditorUtility.SetDirty(fontIconSet);
                 return true;
             }
@@ -308,20 +352,25 @@ namespace MixedReality.Toolkit.Editor
 
         private bool RemoveIcon(FontIconSet fontIconSet, string iconName)
         {
-            if (fontIconSet.TryGetGlyphIcon(iconName, out uint unicodeValue) && fontIconSet.RemoveIcon(iconName))
+            if (fontIconSet.TryGetGlyphIcon(iconName, out uint unicodeValue))
             {
-                iconEntries.Remove(unicodeValue);
-                EditorUtility.SetDirty(fontIconSet);
-                return true;
+                Undo.RecordObject(fontIconSet, "Remove Icon");
+                if (fontIconSet.RemoveIcon(iconName))
+                {
+                    UpdateIconEntries();
+                    EditorUtility.SetDirty(fontIconSet);
+                    return true;
+                }
             }
             return false;
         }
 
         private void UpdateIconName(FontIconSet fontIconSet, string oldName, string newName)
         {
-            if (fontIconSet.UpdateIconName(oldName, newName) && fontIconSet.TryGetGlyphIcon(newName, out uint unicodeValue))
+            Undo.RecordObject(fontIconSet, "Rename Icon");
+            if (fontIconSet.UpdateIconName(oldName, newName))
             {
-                iconEntries[unicodeValue] = newName;
+                UpdateIconEntries();
                 EditorUtility.SetDirty(fontIconSet);
             }
         }

--- a/org.mixedrealitytoolkit.uxcore/Editor/Inspectors/FontIconSet/FontIconSetInspector.cs
+++ b/org.mixedrealitytoolkit.uxcore/Editor/Inspectors/FontIconSet/FontIconSetInspector.cs
@@ -48,9 +48,17 @@ namespace MixedReality.Toolkit.Editor
         /// </summary>
         private void OnEnable()
         {
-            FontIconSet fontIconSet = (FontIconSet)target;
             iconFontAssetProp = serializedObject.FindProperty("iconFontAsset");
             fontIconSetDefinitionProp = serializedObject.FindProperty("fontIconSetDefinition");
+
+            foreach (UnityEngine.Object targetObject in targets)
+            {
+                FontIconSet fontIconSet = targetObject as FontIconSet;
+                if (fontIconSet != null && fontIconSet.SortIcons())
+                {
+                    EditorUtility.SetDirty(fontIconSet);
+                }
+            }
 
             // Listen for undo/redo events to ensure our local iconEntries cache stays in sync
             Undo.undoRedoPerformed += UpdateIconEntries;
@@ -129,6 +137,7 @@ namespace MixedReality.Toolkit.Editor
                 {
                     serializedObject.ApplyModifiedProperties();
                     UpdateIconEntries();
+                    GUIUtility.ExitGUI();
                 }
 
                 if (iconFontAssetProp.objectReferenceValue == null)
@@ -198,6 +207,7 @@ namespace MixedReality.Toolkit.Editor
                                 if (setDefinition.IconNames != null && validNames.Count != setDefinition.IconNames.Count)
                                 {
                                     UpdateIconEntries();
+                                    GUIUtility.ExitGUI();
                                 }
                             }
 
@@ -269,10 +279,12 @@ namespace MixedReality.Toolkit.Editor
                             if (iconToRename != null)
                             {
                                 UpdateIconName(fontIconSet, iconToRemove, iconToRename);
+                                GUIUtility.ExitGUI();
                             }
                             else if (iconToRemove != null)
                             {
                                 RemoveIcon(fontIconSet, iconToRemove);
+                                GUIUtility.ExitGUI();
                             }
                         }
                         else
@@ -310,6 +322,7 @@ namespace MixedReality.Toolkit.Editor
         private void DrawFontGlyphsGrid(TMP_FontAsset fontAsset, FontIconSet fontIconSet, int maxButtonsPerColumn)
         {
             int column = 0;
+            bool iconAdded = false;
             EditorGUILayout.BeginHorizontal();
             for (int i = 0; i < fontAsset.characterTable.Count; i++)
             {
@@ -327,7 +340,7 @@ namespace MixedReality.Toolkit.Editor
                         GUILayout.MaxWidth(ButtonDimension)))
                     {
                         AddIcon(fontIconSet, fontAsset.characterTable[i].unicode);
-                        EditorUtility.SetDirty(target);
+                        iconAdded = true;
                     }
 
                     Rect textureRect = GUILayoutUtility.GetLastRect();
@@ -336,9 +349,19 @@ namespace MixedReality.Toolkit.Editor
                     EditorDrawTMPGlyph(textureRect, fontAsset, fontAsset.characterTable[i]);
                 }
 
+                if (iconAdded)
+                {
+                    break;
+                }
+
                 column++;
             }
             EditorGUILayout.EndHorizontal();
+
+            if (iconAdded)
+            {
+                GUIUtility.ExitGUI();
+            }
         }
 
         private bool AddIcon(FontIconSet fontIconSet, uint unicodeValue)

--- a/org.mixedrealitytoolkit.uxcore/Editor/Inspectors/FontIconSet/FontIconSetInspector.cs
+++ b/org.mixedrealitytoolkit.uxcore/Editor/Inspectors/FontIconSet/FontIconSetInspector.cs
@@ -40,6 +40,7 @@ namespace MixedReality.Toolkit.Editor
         private List<KeyValuePair<uint, string>> iconEntries = new List<KeyValuePair<uint, string>>();
         private List<string> validNames = new List<string>();
         private List<string> availableNames = new List<string>();
+        private HashSet<uint> selectedUnicodeValues = new HashSet<uint>();
         private string[] availableNamesArray = Array.Empty<string>();
 
         /// <summary>
@@ -73,9 +74,12 @@ namespace MixedReality.Toolkit.Editor
                 iconEntries.Capacity = fontIconSet.GlyphIconsByName.Count;
             }
 
+            selectedUnicodeValues.Clear();
+
             foreach (KeyValuePair<string, uint> kv in fontIconSet.GlyphIconsByName)
             {
                 iconEntries.Add(new KeyValuePair<uint, string>(kv.Value, kv.Key));
+                selectedUnicodeValues.Add(kv.Value);
             }
             iconEntries.Sort((a, b) => a.Key.CompareTo(b.Key));
 
@@ -315,7 +319,7 @@ namespace MixedReality.Toolkit.Editor
                     EditorGUILayout.BeginHorizontal();
                 }
 
-                using (new EditorGUI.DisabledGroupScope(fontIconSet.GlyphIconsByName.ContainsValue(fontAsset.characterTable[i].unicode)))
+                using (new EditorGUI.DisabledGroupScope(selectedUnicodeValues.Contains(fontAsset.characterTable[i].unicode)))
                 {
                     if (GUILayout.Button(" ",
                         GUILayout.Height(ButtonDimension),

--- a/org.mixedrealitytoolkit.uxcore/Editor/Inspectors/FontIconSet/FontIconSetInspector.cs
+++ b/org.mixedrealitytoolkit.uxcore/Editor/Inspectors/FontIconSet/FontIconSetInspector.cs
@@ -43,6 +43,12 @@ namespace MixedReality.Toolkit.Editor
         private string[] availableNamesArray = Array.Empty<string>();
         private bool requiresUpdate = false;
 
+        // Deferred State Variables
+        private uint? pendingIconToAdd = null;
+        private string pendingIconToRemove = null;
+        private string pendingIconToRenameOld = null;
+        private string pendingIconToRenameNew = null;
+
         /// <summary>
         /// A Unity event function that is called when the script component has been enabled.
         /// </summary>
@@ -127,10 +133,30 @@ namespace MixedReality.Toolkit.Editor
         /// </summary>
         public override void OnInspectorGUI()
         {
-            if (requiresUpdate && Event.current.type == EventType.Layout)
+            if (Event.current.type == EventType.Layout)
             {
-                UpdateIconEntries();
-                requiresUpdate = false;
+                if (pendingIconToAdd.HasValue)
+                {
+                    AddIcon((FontIconSet)target, pendingIconToAdd.Value);
+                    pendingIconToAdd = null;
+                }
+                if (pendingIconToRemove != null)
+                {
+                    RemoveIcon((FontIconSet)target, pendingIconToRemove);
+                    pendingIconToRemove = null;
+                }
+                if (pendingIconToRenameOld != null && pendingIconToRenameNew != null)
+                {
+                    UpdateIconName((FontIconSet)target, pendingIconToRenameOld, pendingIconToRenameNew);
+                    pendingIconToRenameOld = null;
+                    pendingIconToRenameNew = null;
+                }
+
+                if (requiresUpdate)
+                {
+                    UpdateIconEntries();
+                    requiresUpdate = false;
+                }
             }
 
             bool showGlyphIconFoldout = SessionState.GetBool(ShowGlyphIconsFoldoutKey, false);
@@ -148,8 +174,7 @@ namespace MixedReality.Toolkit.Editor
                 if (EditorGUI.EndChangeCheck())
                 {
                     serializedObject.ApplyModifiedProperties();
-                    UpdateIconEntries();
-                    GUIUtility.ExitGUI();
+                    requiresUpdate = true;
                 }
 
                 if (iconFontAssetProp.objectReferenceValue == null)
@@ -190,7 +215,7 @@ namespace MixedReality.Toolkit.Editor
                                 Selection.activeObject = fontAsset;
                             }
 
-                            DrawFontGlyphsGrid(fontAsset, fontIconSet, MaxButtonsPerColumn);
+                            DrawFontGlyphsGrid(fontAsset, MaxButtonsPerColumn);
                         }
 
                         EditorGUILayout.Space();
@@ -227,14 +252,11 @@ namespace MixedReality.Toolkit.Editor
                                 // Catch edge cases where the external asset size changes while this inspector is still focused
                                 if (setDefinition.IconNames != null && validNames.Count != setDefinition.IconNames.Count)
                                 {
-                                    UpdateIconEntries();
-                                    GUIUtility.ExitGUI();
+                                    requiresUpdate = true;
                                 }
                             }
 
                             int column = 0;
-                            string iconToRemove = null;
-                            string iconToRename = null;
                             EditorGUILayout.BeginHorizontal();
                             foreach (KeyValuePair<uint, string> iconEntry in iconEntries)
                             {
@@ -251,7 +273,7 @@ namespace MixedReality.Toolkit.Editor
                                     GUILayout.Height(ButtonDimension),
                                     GUILayout.MaxWidth(ButtonDimension)))
                                 {
-                                    iconToRemove = iconEntry.Value;
+                                    pendingIconToRemove = iconEntry.Value;
                                 }
 
                                 Rect textureRect = GUILayoutUtility.GetLastRect();
@@ -275,8 +297,8 @@ namespace MixedReality.Toolkit.Editor
                                         int selected = EditorGUILayout.Popup(string.Empty, 0, availableNamesArray, GUILayout.MaxWidth(ButtonDimension));
                                         if (check.changed)
                                         {
-                                            iconToRename = availableNamesArray[selected];
-                                            iconToRemove = iconEntry.Value;
+                                            pendingIconToRenameNew = availableNamesArray[selected];
+                                            pendingIconToRenameOld = iconEntry.Value;
                                         }
                                         GUI.backgroundColor = oldColor;
                                     }
@@ -286,8 +308,8 @@ namespace MixedReality.Toolkit.Editor
                                     string currentName = EditorGUILayout.TextField(iconEntry.Value);
                                     if (currentName != iconEntry.Value)
                                     {
-                                        iconToRename = currentName;
-                                        iconToRemove = iconEntry.Value;
+                                        pendingIconToRenameNew = currentName;
+                                        pendingIconToRenameOld = iconEntry.Value;
                                     }
                                 }
                                 EditorGUILayout.EndVertical();
@@ -295,17 +317,6 @@ namespace MixedReality.Toolkit.Editor
                                 column++;
                             }
                             EditorGUILayout.EndHorizontal();
-
-                            if (iconToRename != null)
-                            {
-                                UpdateIconName(fontIconSet, iconToRemove, iconToRename);
-                                GUIUtility.ExitGUI();
-                            }
-                            else if (iconToRemove != null)
-                            {
-                                RemoveIcon(fontIconSet, iconToRemove);
-                                GUIUtility.ExitGUI();
-                            }
                         }
                         else
                         {
@@ -330,7 +341,7 @@ namespace MixedReality.Toolkit.Editor
         [Obsolete("This method has been deprecated in version 4.0 and will be removed in a future version.")]
         public void DrawFontGlyphsGrid(FontIconSet fontIconSet, int maxButtonsPerColumn)
         {
-            DrawFontGlyphsGrid(fontIconSet.IconFontAsset, fontIconSet, maxButtonsPerColumn);
+            DrawFontGlyphsGrid(fontIconSet.IconFontAsset, maxButtonsPerColumn);
         }
 
         /// <summary>
@@ -339,10 +350,9 @@ namespace MixedReality.Toolkit.Editor
         /// <param name="fontAsset">The font asset containing the glyphs.</param>
         /// <param name="fontIconSet">The set of font glyphs to draw.</param>
         /// <param name="maxButtonsPerColumn">The number of buttons per column.</param>
-        private void DrawFontGlyphsGrid(TMP_FontAsset fontAsset, FontIconSet fontIconSet, int maxButtonsPerColumn)
+        private void DrawFontGlyphsGrid(TMP_FontAsset fontAsset, int maxButtonsPerColumn)
         {
             int column = 0;
-            bool iconAdded = false;
             EditorGUILayout.BeginHorizontal();
             for (int i = 0; i < fontAsset.characterTable.Count; i++)
             {
@@ -359,8 +369,7 @@ namespace MixedReality.Toolkit.Editor
                         GUILayout.Height(ButtonDimension),
                         GUILayout.MaxWidth(ButtonDimension)))
                     {
-                        AddIcon(fontIconSet, fontAsset.characterTable[i].unicode);
-                        iconAdded = true;
+                        pendingIconToAdd = fontAsset.characterTable[i].unicode;
                     }
 
                     Rect textureRect = GUILayoutUtility.GetLastRect();
@@ -369,19 +378,9 @@ namespace MixedReality.Toolkit.Editor
                     EditorDrawTMPGlyph(textureRect, fontAsset, fontAsset.characterTable[i]);
                 }
 
-                if (iconAdded)
-                {
-                    break;
-                }
-
                 column++;
             }
             EditorGUILayout.EndHorizontal();
-
-            if (iconAdded)
-            {
-                GUIUtility.ExitGUI();
-            }
         }
 
         private bool AddIcon(FontIconSet fontIconSet, uint unicodeValue)

--- a/org.mixedrealitytoolkit.uxcore/Editor/Inspectors/FontIconSet/FontIconSetInspector.cs
+++ b/org.mixedrealitytoolkit.uxcore/Editor/Inspectors/FontIconSet/FontIconSetInspector.cs
@@ -35,13 +35,13 @@ namespace MixedReality.Toolkit.Editor
 
         private SerializedProperty iconFontAssetProp = null;
         private SerializedProperty fontIconSetDefinitionProp = null;
-        private bool anyInvalidName = false;
 
         private List<KeyValuePair<uint, string>> iconEntries = new List<KeyValuePair<uint, string>>();
         private List<string> validNames = new List<string>();
         private List<string> availableNames = new List<string>();
         private HashSet<uint> selectedUnicodeValues = new HashSet<uint>();
         private string[] availableNamesArray = Array.Empty<string>();
+        private bool requiresUpdate = false;
 
         /// <summary>
         /// A Unity event function that is called when the script component has been enabled.
@@ -61,13 +61,19 @@ namespace MixedReality.Toolkit.Editor
             }
 
             // Listen for undo/redo events to ensure our local iconEntries cache stays in sync
-            Undo.undoRedoPerformed += UpdateIconEntries;
+            Undo.undoRedoPerformed += OnUndoRedo;
             UpdateIconEntries();
         }
 
         private void OnDisable()
         {
-            Undo.undoRedoPerformed -= UpdateIconEntries;
+            Undo.undoRedoPerformed -= OnUndoRedo;
+        }
+
+        private void OnUndoRedo()
+        {
+            requiresUpdate = true;
+            Repaint();
         }
 
         private void UpdateIconEntries()
@@ -93,7 +99,6 @@ namespace MixedReality.Toolkit.Editor
 
             validNames.Clear();
             availableNames.Clear();
-            availableNames.Add(string.Empty);
 
             if (fontIconSetDefinitionProp != null)
             {
@@ -111,6 +116,7 @@ namespace MixedReality.Toolkit.Editor
                 }
             }
             availableNames.Sort();
+            availableNames.Insert(0, string.Empty);
             availableNamesArray = availableNames.ToArray();
 
             Repaint();
@@ -121,6 +127,12 @@ namespace MixedReality.Toolkit.Editor
         /// </summary>
         public override void OnInspectorGUI()
         {
+            if (requiresUpdate && Event.current.type == EventType.Layout)
+            {
+                UpdateIconEntries();
+                requiresUpdate = false;
+            }
+
             bool showGlyphIconFoldout = SessionState.GetBool(ShowGlyphIconsFoldoutKey, false);
             bool showAvailableIcons = SessionState.GetBool(AvailableIconsFoldoutKey, true);
             bool showSelectedIcons = SessionState.GetBool(SelectedIconsFoldoutKey, true);
@@ -187,7 +199,7 @@ namespace MixedReality.Toolkit.Editor
                     showSelectedIcons = EditorGUILayout.Foldout(showSelectedIcons, "Selected Icons", true);
                     if (showSelectedIcons)
                     {
-                        if (fontIconSet.GlyphIconsByName.Count > 0)
+                        if (iconEntries.Count > 0)
                         {
                             EditorGUILayout.HelpBox("These icons will appear in the button config helper inspector. Click an icon to remove it from this list.", MessageType.Info);
 
@@ -197,10 +209,19 @@ namespace MixedReality.Toolkit.Editor
                             }
                             else
                             {
-                                if (anyInvalidName)
+                                bool hasInvalidName = false;
+                                foreach (KeyValuePair<uint, string> entry in iconEntries)
+                                {
+                                    if (!validNames.Contains(entry.Value))
+                                    {
+                                        hasInvalidName = true;
+                                        break;
+                                    }
+                                }
+
+                                if (hasInvalidName)
                                 {
                                     EditorGUILayout.HelpBox("Icon names highlighted yellow are not present in the selected Font Icon Set Definition and should be updated.", MessageType.Warning);
-                                    anyInvalidName = false;
                                 }
 
                                 // Catch edge cases where the external asset size changes while this inspector is still focused
@@ -250,7 +271,6 @@ namespace MixedReality.Toolkit.Editor
                                         if (!validNames.Contains(iconEntry.Value))
                                         {
                                             GUI.backgroundColor = Color.yellow;
-                                            anyInvalidName = true;
                                         }
                                         int selected = EditorGUILayout.Popup(string.Empty, 0, availableNamesArray, GUILayout.MaxWidth(ButtonDimension));
                                         if (check.changed)

--- a/org.mixedrealitytoolkit.uxcore/Editor/Inspectors/FontIconSet/FontIconSetInspector.cs
+++ b/org.mixedrealitytoolkit.uxcore/Editor/Inspectors/FontIconSet/FontIconSetInspector.cs
@@ -327,7 +327,7 @@ namespace MixedReality.Toolkit.Editor
         /// </summary>
         /// <param name="fontIconSet">The set of font glyphs to draw.</param>
         /// <param name="maxButtonsPerColumn">The number of buttons per column.</param>
-        [Obsolete("This method has been removed.")]
+        [Obsolete("This method has been deprecated in version 4.0 and will be removed in a future version.")]
         public void DrawFontGlyphsGrid(FontIconSet fontIconSet, int maxButtonsPerColumn)
         {
             DrawFontGlyphsGrid(fontIconSet.IconFontAsset, fontIconSet, maxButtonsPerColumn);

--- a/org.mixedrealitytoolkit.uxcore/Editor/Inspectors/FontIconSet/FontIconSetInspector.cs
+++ b/org.mixedrealitytoolkit.uxcore/Editor/Inspectors/FontIconSet/FontIconSetInspector.cs
@@ -102,6 +102,7 @@ namespace MixedReality.Toolkit.Editor
                     }
                 }
             }
+            availableNames.Sort();
             availableNamesArray = availableNames.ToArray();
 
             Repaint();

--- a/org.mixedrealitytoolkit.uxcore/FontIcons/FontIconSelector.cs
+++ b/org.mixedrealitytoolkit.uxcore/FontIcons/FontIconSelector.cs
@@ -107,7 +107,7 @@ namespace MixedReality.Toolkit.UX
         /// <returns><see langword="true"/> if a migration was successfully performed or an empty icon state was resolved, otherwise <see langword="false"/>.</returns>
         public bool TryMigrate()
         {
-            if (migratedSuccessfully || fontIcons == null || fontIcons.FontIconSetDefinition == null)
+            if (fontIcons == null || fontIcons.FontIconSetDefinition == null)
             {
                 return false;
             }
@@ -123,6 +123,20 @@ namespace MixedReality.Toolkit.UX
             {
                 // If there's no icon text assigned, there's nothing to migrate.
                 if (textMeshProComponent != null)
+                {
+                    if (!migratedSuccessfully)
+                    {
+                        migratedSuccessfully = true;
+                        return true;
+                    }
+                }
+                return false;
+            }
+
+            // Check if the current icon name is already in sync with the text component's unicode value.
+            if (fontIcons.TryGetGlyphIcon(currentIconName, out uint expectedUnicode) && expectedUnicode == unicodeValue)
+            {
+                if (!migratedSuccessfully)
                 {
                     migratedSuccessfully = true;
                     return true;

--- a/org.mixedrealitytoolkit.uxcore/FontIcons/FontIconSelector.cs
+++ b/org.mixedrealitytoolkit.uxcore/FontIcons/FontIconSelector.cs
@@ -85,7 +85,6 @@ namespace MixedReality.Toolkit.UX
         /// </summary>
         private void OnValidate()
         {
-            TryMigrate();
             SetIcon(currentIconName);
         }
 

--- a/org.mixedrealitytoolkit.uxcore/FontIcons/FontIconSelector.cs
+++ b/org.mixedrealitytoolkit.uxcore/FontIcons/FontIconSelector.cs
@@ -25,7 +25,7 @@ namespace MixedReality.Toolkit.UX
 
         [Tooltip("The currently selected icon's name, as defined by the FontIconSet.")]
         [SerializeField]
-        private string currentIconName;
+        private string currentIconName = string.Empty;
 
         /// <summary>
         /// The currently selected icon's name, as defined by the <see cref="FontIcons"/>.

--- a/org.mixedrealitytoolkit.uxcore/FontIcons/FontIconSelector.cs
+++ b/org.mixedrealitytoolkit.uxcore/FontIcons/FontIconSelector.cs
@@ -11,7 +11,7 @@ namespace MixedReality.Toolkit.UX
     /// Allows the user to select a specific icon for display via a Unity text component.
     /// </summary>
     [AddComponentMenu("MRTK/UX/Font Icon Selector")]
-    public class FontIconSelector : MonoBehaviour, ISerializationCallbackReceiver
+    public class FontIconSelector : MonoBehaviour
     {
         [Tooltip("The FontIconSet that contains the icons available for use.")]
         [SerializeField]
@@ -52,10 +52,20 @@ namespace MixedReality.Toolkit.UX
         /// </summary>
         public TMP_Text TextMeshProComponent => textMeshProComponent;
 
-        // A temporary variable used to migrate instances of FontIconSelector to use new FontIconSetDefinition names.
-        // TODO: Remove this after some time to ensure users have successfully migrated.
+        /// <summary>
+        /// A temporary variable used to migrate instances of FontIconSelector to use new FontIconSetDefinition names.
+        /// </summary>
+        /// <remarks>TODO: Remove this after some time to ensure users have successfully migrated.</remarks>
         [SerializeField, HideInInspector]
         private bool migratedSuccessfully = false;
+
+        /// <summary>
+        /// A Unity event function that is called when the script component is added to a GameObject.
+        /// </summary>
+        private void Reset()
+        {
+            textMeshProComponent = GetComponent<TMP_Text>();
+        }
 
         /// <summary>
         /// A Unity event function that is called when an enabled script instance is being loaded.
@@ -66,6 +76,7 @@ namespace MixedReality.Toolkit.UX
             {
                 textMeshProComponent = GetComponent<TMP_Text>();
             }
+            TryMigrate();
             SetIcon(currentIconName);
         }
 
@@ -74,18 +85,14 @@ namespace MixedReality.Toolkit.UX
         /// </summary>
         private void OnValidate()
         {
+            TryMigrate();
             SetIcon(currentIconName);
         }
 
-        [Tooltip("Any TextMeshPro Font Asset that contains the desired icons as glyphs that map to Unicode character values.")]
-        [SerializeField]
-        private TMP_FontAsset iconFontAsset = null;
-
         /// <summary>
-        /// A TextMeshPro Font Asset that contains the desired icons as glyphs that map to Unicode character values.
+        /// Looks up the Unicode value for the specified icon name and applies it to the text component.
         /// </summary>
-        public TMP_FontAsset IconFontAsset => iconFontAsset;
-
+        /// <param name="newIconName">The descriptive name of the icon to set.</param>
         private void SetIcon(string newIconName)
         {
             if (fontIcons != null && textMeshProComponent != null && fontIcons.TryGetGlyphIcon(newIconName, out uint unicodeValue))
@@ -95,27 +102,61 @@ namespace MixedReality.Toolkit.UX
             }
         }
 
-        void ISerializationCallbackReceiver.OnBeforeSerialize() { }
-
-        void ISerializationCallbackReceiver.OnAfterDeserialize()
+        /// <summary>
+        /// Attempts to migrate the icon selector to use descriptive names.
+        /// </summary>
+        /// <returns><see langword="true"/> if a migration was successfully performed or an empty icon state was resolved, otherwise <see langword="false"/>.</returns>
+        public bool TryMigrate()
         {
-            if (!migratedSuccessfully && fontIcons != null && fontIcons.FontIconSetDefinition != null && textMeshProComponent != null)
+            if (migratedSuccessfully || fontIcons == null || fontIcons.FontIconSetDefinition == null)
             {
-                uint unicodeValue = FontIconSet.ConvertHexStringToUnicode(textMeshProComponent.text);
-                foreach (KeyValuePair<string, uint> kv in fontIcons.GlyphIconsByName)
+                return false;
+            }
+
+            uint unicodeValue = 0;
+
+            if (textMeshProComponent != null && !string.IsNullOrEmpty(textMeshProComponent.text))
+            {
+                unicodeValue = FontIconSet.ConvertHexStringToUnicode(textMeshProComponent.text);
+            }
+
+            if (unicodeValue == 0)
+            {
+                // If there's no icon text assigned, there's nothing to migrate.
+                if (textMeshProComponent != null)
                 {
-                    if (kv.Value == unicodeValue)
+                    migratedSuccessfully = true;
+                    return true;
+                }
+                return false;
+            }
+
+            bool foundMatch = false;
+
+            foreach (KeyValuePair<string, uint> kv in fontIcons.GlyphIconsByName)
+            {
+                if (kv.Value == unicodeValue)
+                {
+                    if (currentIconName != kv.Key)
                     {
-                        if (currentIconName != kv.Key)
-                        {
-                            Debug.Log($"[{nameof(FontIconSelector)}] Successfully migrated icon: \"{currentIconName}\" to \"{kv.Key}\"", this);
-                            currentIconName = kv.Key;
-                            migratedSuccessfully = true;
-                        }
-                        break;
+                        Debug.Log($"[{nameof(FontIconSelector)}] Successfully migrated icon: \"{currentIconName}\" to \"{kv.Key}\"", this);
+
+                        // Update the backing field directly to avoid calling the property setter during initialization.
+                        currentIconName = kv.Key;
                     }
+
+                    migratedSuccessfully = true;
+                    foundMatch = true;
+                    break;
                 }
             }
+
+            if (!foundMatch)
+            {
+                Debug.LogWarning($"[{nameof(FontIconSelector)}] Failed to migrate icon. Unicode value '{unicodeValue}' was not found in FontIconSet '{fontIcons.name}'.", this);
+            }
+
+            return foundMatch;
         }
     }
 }

--- a/org.mixedrealitytoolkit.uxcore/FontIcons/FontIconSelectorMigrationUtility.cs
+++ b/org.mixedrealitytoolkit.uxcore/FontIcons/FontIconSelectorMigrationUtility.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Mixed Reality Toolkit Contributors
 // Licensed under the BSD 3-Clause
 
-using MixedReality.Toolkit.Input;
 using MixedReality.Toolkit.UX;
 using UnityEditor;
 using UnityEditor.SceneManagement;
@@ -50,6 +49,8 @@ namespace MixedReality.Toolkit.Editor
 
             foreach (EditorBuildSettingsScene buildScene in EditorBuildSettings.scenes)
             {
+                if (!buildScene.enabled || string.IsNullOrEmpty(buildScene.path)) { continue; }
+
                 Scene scene = EditorSceneManager.OpenScene(buildScene.path, OpenSceneMode.Single);
                 bool sceneModified = false;
 

--- a/org.mixedrealitytoolkit.uxcore/FontIcons/FontIconSelectorMigrationUtility.cs
+++ b/org.mixedrealitytoolkit.uxcore/FontIcons/FontIconSelectorMigrationUtility.cs
@@ -1,0 +1,116 @@
+// Copyright (c) Mixed Reality Toolkit Contributors
+// Licensed under the BSD 3-Clause
+
+using MixedReality.Toolkit.Input;
+using MixedReality.Toolkit.UX;
+using UnityEditor;
+using UnityEditor.SceneManagement;
+using UnityEngine;
+using UnityEngine.SceneManagement;
+
+namespace MixedReality.Toolkit.Editor
+{
+    /// <summary>
+    /// Utility to bulk-migrate <see cref="FontIconSelector"/> components to the new descriptive naming format.
+    /// </summary>
+    public static class FontIconSelectorMigrationUtility
+    {
+        [MenuItem("Mixed Reality/MRTK3/Utilities/Migrate Font Icon Selectors", false, 100)]
+        public static void MigrateProject()
+        {
+            // Prompt the user to save any unsaved work before we start swapping scenes
+            if (!EditorSceneManager.SaveCurrentModifiedScenesIfUserWantsTo())
+            {
+                return;
+            }
+
+            int migratedCount = 0;
+
+            // 1. Migrate all prefabs in the project
+            string[] prefabGuids = AssetDatabase.FindAssets("t:Prefab");
+            foreach (string guid in prefabGuids)
+            {
+                string path = AssetDatabase.GUIDToAssetPath(guid);
+                GameObject prefab = AssetDatabase.LoadAssetAtPath<GameObject>(path);
+
+                if (prefab == null) { continue; }
+
+                FontIconSelector[] selectors = prefab.GetComponentsInChildren<FontIconSelector>(true);
+                foreach (FontIconSelector selector in selectors)
+                {
+                    if (ProcessSelector(selector))
+                    {
+                        migratedCount++;
+                    }
+                }
+            }
+
+            // 2. Migrate all scenes in Build Settings
+            SceneSetup[] setup = EditorSceneManager.GetSceneManagerSetup();
+
+            foreach (EditorBuildSettingsScene buildScene in EditorBuildSettings.scenes)
+            {
+                Scene scene = EditorSceneManager.OpenScene(buildScene.path, OpenSceneMode.Single);
+                bool sceneModified = false;
+
+                FontIconSelector[] sceneSelectors = Object.FindObjectsByType<FontIconSelector>(FindObjectsInactive.Include, FindObjectsSortMode.None);
+                foreach (FontIconSelector selector in sceneSelectors)
+                {
+                    // Skip prefabs that might accidentally be caught in FindObjectsOfType
+                    if (PrefabUtility.IsPartOfPrefabAsset(selector)) { continue; }
+
+                    if (ProcessSelector(selector))
+                    {
+                        sceneModified = true;
+                        migratedCount++;
+                    }
+                }
+
+                if (sceneModified)
+                {
+                    EditorSceneManager.MarkSceneDirty(scene);
+                    EditorSceneManager.SaveScene(scene);
+                }
+            }
+
+            // Restore the user's initially opened scenes
+            if (setup != null && setup.Length > 0)
+            {
+                EditorSceneManager.RestoreSceneManagerSetup(setup);
+            }
+
+            // Save all the SetDirty changes we applied to the prefabs
+            AssetDatabase.SaveAssets();
+
+            Debug.Log($"[{nameof(FontIconSelectorMigrationUtility)}] Migration complete! Processed and upgraded {migratedCount} FontIconSelectors.");
+        }
+
+        /// <summary>
+        /// Checks a selector's serialization state, runs migration, and dirty flags it if changes occurred.
+        /// </summary>
+        private static bool ProcessSelector(FontIconSelector selector)
+        {
+            SerializedObject so = new SerializedObject(selector);
+            SerializedProperty migratedProp = so.FindProperty("migratedSuccessfully");
+
+            if (migratedProp != null && !migratedProp.boolValue)
+            {
+                Undo.RecordObject(selector, "Migrate Font Icon Selector");
+
+                if (selector.TryMigrate())
+                {
+                    // Ensure that changes to prefab instances in scenes are explicitly recorded as overrides.
+                    if (PrefabUtility.IsPartOfPrefabInstance(selector))
+                    {
+                        PrefabUtility.RecordPrefabInstancePropertyModifications(selector);
+                    }
+
+                    EditorUtility.SetDirty(selector);
+                    return true;
+                }
+            }
+
+            return false;
+        }
+    }
+}

--- a/org.mixedrealitytoolkit.uxcore/FontIcons/FontIconSelectorMigrationUtility.cs
+++ b/org.mixedrealitytoolkit.uxcore/FontIcons/FontIconSelectorMigrationUtility.cs
@@ -91,24 +91,18 @@ namespace MixedReality.Toolkit.Editor
         /// </summary>
         private static bool ProcessSelector(FontIconSelector selector)
         {
-            SerializedObject so = new SerializedObject(selector);
-            SerializedProperty migratedProp = so.FindProperty("migratedSuccessfully");
+            Undo.RecordObject(selector, "Migrate Font Icon Selector");
 
-            if (migratedProp != null && !migratedProp.boolValue)
+            if (selector.TryMigrate())
             {
-                Undo.RecordObject(selector, "Migrate Font Icon Selector");
-
-                if (selector.TryMigrate())
+                // Ensure that changes to prefab instances in scenes are explicitly recorded as overrides.
+                if (PrefabUtility.IsPartOfPrefabInstance(selector))
                 {
-                    // Ensure that changes to prefab instances in scenes are explicitly recorded as overrides.
-                    if (PrefabUtility.IsPartOfPrefabInstance(selector))
-                    {
-                        PrefabUtility.RecordPrefabInstancePropertyModifications(selector);
-                    }
-
-                    EditorUtility.SetDirty(selector);
-                    return true;
+                    PrefabUtility.RecordPrefabInstancePropertyModifications(selector);
                 }
+
+                EditorUtility.SetDirty(selector);
+                return true;
             }
 
             return false;

--- a/org.mixedrealitytoolkit.uxcore/FontIcons/FontIconSelectorMigrationUtility.cs.meta
+++ b/org.mixedrealitytoolkit.uxcore/FontIcons/FontIconSelectorMigrationUtility.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 2ad50c43ce4334344b21243c33f0279c

--- a/org.mixedrealitytoolkit.uxcore/FontIcons/FontIconSet.cs
+++ b/org.mixedrealitytoolkit.uxcore/FontIcons/FontIconSet.cs
@@ -65,7 +65,6 @@ namespace MixedReality.Toolkit.UX
         /// <returns><see langword="true"/> if icon name found, otherwise <see langword="false"/>.</returns>
         public bool TryGetGlyphIcon(string iconName, out uint unicodeValue)
         {
-            unicodeValue = 0;
             return glyphIconsByName.TryGetValue(iconName, out unicodeValue);
         }
 
@@ -77,15 +76,7 @@ namespace MixedReality.Toolkit.UX
         /// <returns>Whether it was able to add this icon.</returns>
         public bool AddIcon(string name, uint unicodeValue)
         {
-            if (glyphIconsByName.ContainsValue(unicodeValue))
-            {
-                return false;
-            }
-            else
-            {
-                glyphIconsByName[name] = unicodeValue;
-                return true;
-            }
+            return !glyphIconsByName.ContainsValue(unicodeValue) && glyphIconsByName.TryAdd(name, unicodeValue);
         }
 
         /// <summary>
@@ -95,15 +86,7 @@ namespace MixedReality.Toolkit.UX
         /// <returns>Whether it was able to find the name and remove it.</returns>
         public bool RemoveIcon(string iconName)
         {
-            if (glyphIconsByName.ContainsKey(iconName))
-            {
-                glyphIconsByName.Remove(iconName);
-                return true;
-            }
-            else
-            {
-                return false;
-            }
+            return glyphIconsByName.Remove(iconName);
         }
 
         /// <summary>
@@ -118,16 +101,7 @@ namespace MixedReality.Toolkit.UX
         /// <returns><see langword="true"/> if it was able to find and update the name.</returns>
         public bool UpdateIconName(string oldName, string newName)
         {
-            if (glyphIconsByName.ContainsKey(oldName) && !glyphIconsByName.ContainsKey(newName))
-            {
-                glyphIconsByName[newName] = glyphIconsByName[oldName];
-                glyphIconsByName.Remove(oldName);
-                return true;
-            }
-            else
-            {
-                return false;
-            }
+            return glyphIconsByName.TryGetValue(oldName, out uint unicodeValue) && glyphIconsByName.TryAdd(newName, unicodeValue) && glyphIconsByName.Remove(oldName);
         }
 
         /// <summary>

--- a/org.mixedrealitytoolkit.uxcore/FontIcons/FontIconSet.cs
+++ b/org.mixedrealitytoolkit.uxcore/FontIcons/FontIconSet.cs
@@ -30,8 +30,8 @@ namespace MixedReality.Toolkit.UX
         /// </summary>
         public SerializableDictionary<string, uint> GlyphIconsByName => glyphIconsByName;
 
-        [Tooltip("Any TextMeshPro Font Asset that contains the desired icons as glyphs that map to Unicode character values.")]
         [SerializeField]
+        [Tooltip("Any TextMeshPro Font Asset that contains the desired icons as glyphs that map to Unicode character values.")]
         private TMP_FontAsset iconFontAsset = null;
 
         /// <summary>
@@ -39,14 +39,23 @@ namespace MixedReality.Toolkit.UX
         /// </summary>
         public TMP_FontAsset IconFontAsset => iconFontAsset;
 
-        [Tooltip("Optional material to use for rendering glyphs in editor.")]
         [SerializeField]
+        [Tooltip("Optional material to use for rendering glyphs in editor.")]
         private Material optionalEditorMaterial;
 
         /// <summary>
         /// Optional material to use for rendering glyphs in editor.
         /// </summary>
         public Material OptionalEditorMaterial => optionalEditorMaterial;
+
+        [SerializeField]
+        [Tooltip("Optional definition to provide consistent icon names.")]
+        private FontIconSetDefinition fontIconSetDefinition;
+
+        /// <summary>
+        /// Optional definition to provide consistent icon names.
+        /// </summary>
+        public FontIconSetDefinition FontIconSetDefinition => fontIconSetDefinition;
 
         /// <summary>
         /// Try to get a glyph icon's unicode value by name.

--- a/org.mixedrealitytoolkit.uxcore/FontIcons/FontIconSet.cs
+++ b/org.mixedrealitytoolkit.uxcore/FontIcons/FontIconSet.cs
@@ -76,7 +76,19 @@ namespace MixedReality.Toolkit.UX
         /// <returns>Whether it was able to add this icon.</returns>
         public bool AddIcon(string name, uint unicodeValue)
         {
-            return !glyphIconsByName.ContainsValue(unicodeValue) && glyphIconsByName.TryAdd(name, unicodeValue);
+            if (glyphIconsByName.ContainsValue(unicodeValue))
+            {
+                Debug.LogWarning($"[{nameof(FontIconSet)}] Failed to add icon '{name}'. An icon with the unicode value '{unicodeValue}' already exists in '{this.name}'.", this);
+                return false;
+            }
+
+            if (!glyphIconsByName.TryAdd(name, unicodeValue))
+            {
+                Debug.LogWarning($"[{nameof(FontIconSet)}] Failed to add icon '{name}'. An icon with that name already exists in '{this.name}'.", this);
+                return false;
+            }
+
+            return true;
         }
 
         /// <summary>
@@ -111,22 +123,12 @@ namespace MixedReality.Toolkit.UX
         /// <returns>The binary unicode value.</returns>
         public static uint ConvertHexStringToUnicode(string charString)
         {
-            uint unicode = 0;
-
             if (string.IsNullOrEmpty(charString))
                 return 0;
 
-            for (int i = 0; i < charString.Length; i++)
-            {
-                unicode = charString[i];
-                // Handle surrogate pairs
-                if (i < charString.Length - 1 && char.IsHighSurrogate((char)unicode) && char.IsLowSurrogate(charString[i + 1]))
-                {
-                    unicode = (uint)char.ConvertToUtf32(charString[i], charString[i + 1]);
-                    i += 1;
-                }
-            }
-            return unicode;
+            // Retrieve the 32-bit unicode codepoint for the first character in the string,
+            // automatically handling surrogate pairs if the character is outside the BMP.
+            return (uint)char.ConvertToUtf32(charString, 0);
         }
 
         /// <summary>
@@ -139,8 +141,7 @@ namespace MixedReality.Toolkit.UX
         /// <returns>The string version of the unicode value in the form of '\uFFFF', where FFFF is replaced with the associated hexadecimal value.</returns>
         public static string ConvertUnicodeToHexString(uint unicode)
         {
-            byte[] bytes = System.BitConverter.GetBytes(unicode);
-            return Encoding.Unicode.GetString(bytes);
+            return char.ConvertFromUtf32((int)unicode);
         }
     }
 }

--- a/org.mixedrealitytoolkit.uxcore/FontIcons/FontIconSet.cs
+++ b/org.mixedrealitytoolkit.uxcore/FontIcons/FontIconSet.cs
@@ -196,7 +196,7 @@ namespace MixedReality.Toolkit.UX
         /// Converts a unicode value to a string.
         /// </summary>
         /// <remarks>
-        /// This is used to convert unicode values into a strings that can be applied to text fields.
+        /// This is used to convert unicode values into strings that can be applied to text fields.
         /// </remarks>
         /// <param name="unicode">Unicode value to be converted to a hexadecimal string representation.</param>
         /// <returns>The string version of the unicode value in the form of '\uFFFF', where FFFF is replaced with the associated hexadecimal value.</returns>

--- a/org.mixedrealitytoolkit.uxcore/FontIcons/FontIconSet.cs
+++ b/org.mixedrealitytoolkit.uxcore/FontIcons/FontIconSet.cs
@@ -65,6 +65,11 @@ namespace MixedReality.Toolkit.UX
         /// <returns><see langword="true"/> if icon name found, otherwise <see langword="false"/>.</returns>
         public bool TryGetGlyphIcon(string iconName, out uint unicodeValue)
         {
+            if (string.IsNullOrEmpty(iconName))
+            {
+                unicodeValue = 0;
+                return false;
+            }
             return glyphIconsByName.TryGetValue(iconName, out unicodeValue);
         }
 
@@ -110,6 +115,10 @@ namespace MixedReality.Toolkit.UX
         /// <returns>Whether it was able to find the name and remove it.</returns>
         public bool RemoveIcon(string iconName)
         {
+            if (string.IsNullOrEmpty(iconName))
+            {
+                return false;
+            }
             return glyphIconsByName.Remove(iconName);
         }
 
@@ -125,6 +134,11 @@ namespace MixedReality.Toolkit.UX
         /// <returns><see langword="true"/> if it was able to find and update the name.</returns>
         public bool UpdateIconName(string oldName, string newName)
         {
+            if (string.IsNullOrEmpty(oldName) || string.IsNullOrEmpty(newName))
+            {
+                return false;
+            }
+
             if (glyphIconsByName.TryGetValue(oldName, out uint unicodeValue) && glyphIconsByName.TryAdd(newName, unicodeValue) && glyphIconsByName.Remove(oldName))
             {
                 SortIcons();

--- a/org.mixedrealitytoolkit.uxcore/FontIcons/FontIconSet.cs
+++ b/org.mixedrealitytoolkit.uxcore/FontIcons/FontIconSet.cs
@@ -2,7 +2,6 @@
 // Licensed under the BSD 3-Clause
 
 using System.Collections.Generic;
-using System.Text;
 using TMPro;
 using UnityEngine;
 
@@ -99,6 +98,8 @@ namespace MixedReality.Toolkit.UX
                 return false;
             }
 
+            SortIcons();
+
             return true;
         }
 
@@ -124,9 +125,58 @@ namespace MixedReality.Toolkit.UX
         /// <returns><see langword="true"/> if it was able to find and update the name.</returns>
         public bool UpdateIconName(string oldName, string newName)
         {
-            return glyphIconsByName.TryGetValue(oldName, out uint unicodeValue) && glyphIconsByName.TryAdd(newName, unicodeValue) && glyphIconsByName.Remove(oldName);
+            if (glyphIconsByName.TryGetValue(oldName, out uint unicodeValue) && glyphIconsByName.TryAdd(newName, unicodeValue) && glyphIconsByName.Remove(oldName))
+            {
+                SortIcons();
+                return true;
+            }
+
+            if (!glyphIconsByName.ContainsKey(oldName))
+            {
+                Debug.LogWarning($"[{nameof(FontIconSet)}] Failed to rename icon '{oldName}'. The icon could not be found in '{this.name}'.", this);
+            }
+            else if (glyphIconsByName.ContainsKey(newName))
+            {
+                Debug.LogWarning($"[{nameof(FontIconSet)}] Failed to rename icon '{oldName}' to '{newName}'. An icon with the name '{newName}' already exists in '{this.name}'.", this);
+            }
+
+            return false;
         }
 
+        /// <summary>
+        /// Sorts the icons by their unicode value to ensure deterministic serialization.
+        /// </summary>
+        /// <returns><see langword="true"/> if the dictionary was modified, otherwise <see langword="false"/>.</returns>
+        public bool SortIcons()
+        {
+            bool isSorted = true;
+            uint previousValue = 0;
+            foreach (uint value in glyphIconsByName.Values)
+            {
+                if (value < previousValue)
+                {
+                    isSorted = false;
+                    break;
+                }
+                previousValue = value;
+            }
+
+            if (isSorted)
+            {
+                return false;
+            }
+
+            var sortedEntries = new List<KeyValuePair<string, uint>>(glyphIconsByName);
+            sortedEntries.Sort((a, b) => a.Value.CompareTo(b.Value));
+
+            glyphIconsByName.Clear();
+            foreach (KeyValuePair<string, uint> kv in sortedEntries)
+            {
+                glyphIconsByName.TryAdd(kv.Key, kv.Value);
+            }
+
+            return true;
+        }
         /// <summary>
         /// Converts a unicode string to a uint code (for use with TextMeshPro).
         /// </summary>

--- a/org.mixedrealitytoolkit.uxcore/FontIcons/FontIconSet.cs
+++ b/org.mixedrealitytoolkit.uxcore/FontIcons/FontIconSet.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Mixed Reality Toolkit Contributors
 // Licensed under the BSD 3-Clause
 
+using System.Collections.Generic;
 using System.Text;
 using TMPro;
 using UnityEngine;
@@ -28,7 +29,7 @@ namespace MixedReality.Toolkit.UX
         /// <summary>
         /// A mapping between icon names and the unicode value of the glyph it describes.
         /// </summary>
-        public SerializableDictionary<string, uint> GlyphIconsByName => glyphIconsByName;
+        public IReadOnlyDictionary<string, uint> GlyphIconsByName => glyphIconsByName;
 
         [SerializeField]
         [Tooltip("Any TextMeshPro Font Asset that contains the desired icons as glyphs that map to Unicode character values.")]
@@ -66,6 +67,16 @@ namespace MixedReality.Toolkit.UX
         public bool TryGetGlyphIcon(string iconName, out uint unicodeValue)
         {
             return glyphIconsByName.TryGetValue(iconName, out unicodeValue);
+        }
+
+        /// <summary>
+        /// Checks if an icon with the specified unicode value exists in the set.
+        /// </summary>
+        /// <param name="unicodeValue">The unicode value to check.</param>
+        /// <returns><see langword="true"/> if the unicode value exists, otherwise <see langword="false"/>.</returns>
+        public bool ContainsIcon(uint unicodeValue)
+        {
+            return glyphIconsByName.ContainsValue(unicodeValue);
         }
 
         /// <summary>

--- a/org.mixedrealitytoolkit.uxcore/FontIcons/FontIconSetDefinition.cs
+++ b/org.mixedrealitytoolkit.uxcore/FontIcons/FontIconSetDefinition.cs
@@ -12,6 +12,9 @@ namespace MixedReality.Toolkit.UX
         [SerializeField]
         private string[] iconNames;
 
-        public string[] IconNames => iconNames;
+        /// <summary>
+        /// The list of icon names defined by this asset.
+        /// </summary>
+        public IReadOnlyList<string> IconNames => iconNames;
     }
 }

--- a/org.mixedrealitytoolkit.uxcore/FontIcons/FontIconSetDefinition.cs
+++ b/org.mixedrealitytoolkit.uxcore/FontIcons/FontIconSetDefinition.cs
@@ -1,0 +1,17 @@
+// Copyright (c) Mixed Reality Toolkit Contributors
+// Licensed under the BSD 3-Clause
+
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace MixedReality.Toolkit.UX
+{
+    [CreateAssetMenu(fileName = "FontIconSetDefinition", menuName = "MRTK/UX/Font Icon Set Definition")]
+    public class FontIconSetDefinition : ScriptableObject
+    {
+        [SerializeField]
+        private string[] iconNames;
+
+        public string[] IconNames => iconNames;
+    }
+}

--- a/org.mixedrealitytoolkit.uxcore/FontIcons/FontIconSetDefinition.cs.meta
+++ b/org.mixedrealitytoolkit.uxcore/FontIcons/FontIconSetDefinition.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 073dfa6d3114b214d8a2d2954d572301
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/org.mixedrealitytoolkit.uxcore/FontIcons/MRTKFontIconSetDefinition.asset
+++ b/org.mixedrealitytoolkit.uxcore/FontIcons/MRTKFontIconSetDefinition.asset
@@ -1,0 +1,96 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 073dfa6d3114b214d8a2d2954d572301, type: 3}
+  m_Name: MRTKFontIconSetDefinition
+  m_EditorClassIdentifier: 
+  iconNames:
+  - Wifi
+  - Bluetooth
+  - Brightness
+  - Airplane
+  - Settings
+  - People
+  - Pin
+  - Bookmark
+  - Stop Circle
+  - Add Favorite
+  - Favorite
+  - Send
+  - Search
+  - Save
+  - Record Circle
+  - Question Mark
+  - Block
+  - Print
+  - Power Button
+  - Play Circle
+  - Play
+  - Unpin
+  - Devices
+  - Phone
+  - Person
+  - Home
+  - Zoom
+  - Calendar
+  - Camera
+  - Paste
+  - Phone
+  - Add
+  - Mail
+  - Mute
+  - Mic Off
+  - Copy
+  - Visibility On
+  - Visibility Off
+  - Link
+  - Attach
+  - Lightbulb
+  - Movie
+  - Thumb Up
+  - Thumb Down
+  - Thumb Down
+  - Videocam
+  - Location On
+  - Location Off
+  - Mic
+  - Undo
+  - Apps
+  - Tag
+  - Arrow Left
+  - Arrow Right
+  - Arrow Up
+  - Arrow Down
+  - Refresh
+  - Menu
+  - More Vertical
+  - More Horizontal
+  - Delete
+  - Chevron Left
+  - Chevron Right
+  - Chevron Up
+  - Chevron Down
+  - Lock
+  - Unlock
+  - Repeat
+  - Cast
+  - Clipboard
+  - Erase
+  - History
+  - Notifications
+  - Notifications Off
+  - List
+  - Call
+  - Call End
+  - Check
+  - Edit
+  - Folder
+  - Alarm Off

--- a/org.mixedrealitytoolkit.uxcore/FontIcons/MRTKFontIconSetDefinition.asset
+++ b/org.mixedrealitytoolkit.uxcore/FontIcons/MRTKFontIconSetDefinition.asset
@@ -94,3 +94,13 @@ MonoBehaviour:
   - Edit
   - Folder
   - Alarm Off
+  - Warning
+  - Info
+  - Error
+  - Keyboard
+  - Cancel
+  - Dialpad
+  - Photo
+  - Save As
+  - Close
+  - Cut

--- a/org.mixedrealitytoolkit.uxcore/FontIcons/MRTKFontIconSetDefinition.asset
+++ b/org.mixedrealitytoolkit.uxcore/FontIcons/MRTKFontIconSetDefinition.asset
@@ -104,3 +104,26 @@ MonoBehaviour:
   - Save As
   - Close
   - Cut
+  - Move
+  - Sticky Note
+  - Add Note
+  - Pan
+  - Add Group
+  - Book
+  - Settings Sliders
+  - Hierarchy
+  - Add Location
+  - Grid View
+  - Show Chart
+  - Cached
+  - Add Circle
+  - Music Info
+  - Remove Location
+  - Language
+  - Globe
+  - Headphones
+  - Heart Outline
+  - Exclamation Point
+  - Pushpin
+  - Pen Tip
+  - Flag Outline

--- a/org.mixedrealitytoolkit.uxcore/FontIcons/MRTKFontIconSetDefinition.asset
+++ b/org.mixedrealitytoolkit.uxcore/FontIcons/MRTKFontIconSetDefinition.asset
@@ -18,7 +18,7 @@ MonoBehaviour:
   - Brightness
   - Airplane
   - Settings
-  - People
+  - Group
   - Pin
   - Bookmark
   - Stop Circle
@@ -127,3 +127,49 @@ MonoBehaviour:
   - Pushpin
   - Pen Tip
   - Flag Outline
+  - Keep
+  - Remove
+  - Sunny
+  - Report
+  - Graph 1
+  - Tune
+  - Mobile
+  - Newspaper
+  - No Sound
+  - Label
+  - Open In New
+  - Account Tree
+  - Doc
+  - My Location
+  - Write Mail
+  - Hand Left
+  - Hand Right
+  - Add Tab
+  - Sound
+  - Circle
+  - Tab
+  - Reset
+  - Music
+  - Music Mute
+  - Edit Doc
+  - Swap Vert
+  - Horizontal List
+  - Vertical List
+  - Layout Grid
+  - Uniform Grid
+  - Shopping Cart
+  - Messenger
+  - Message
+  - Alarm
+  - Color Palette
+  - Edit
+  - Draft
+  - User
+  - Bar Chart
+  - Pie Chart
+  - Line Chart
+  - Smiley
+  - Display
+  - Layout 2
+  - Time
+  - Exit

--- a/org.mixedrealitytoolkit.uxcore/FontIcons/MRTKFontIconSetDefinition.asset.meta
+++ b/org.mixedrealitytoolkit.uxcore/FontIcons/MRTKFontIconSetDefinition.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: e63daff880b56ed439a2e852b6e6993a
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/org.mixedrealitytoolkit.uxcore/Tests/Runtime/FontIconSelectorTests.cs
+++ b/org.mixedrealitytoolkit.uxcore/Tests/Runtime/FontIconSelectorTests.cs
@@ -1,0 +1,65 @@
+// Copyright (c) Mixed Reality Toolkit Contributors
+// Licensed under the BSD 3-Clause
+
+using MixedReality.Toolkit.UX;
+using NUnit.Framework;
+using System.Collections;
+using System.Reflection;
+using TMPro;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+namespace MixedReality.Toolkit.UX.Runtime.Tests
+{
+    /// <summary>
+    /// Tests for the <see cref="FontIconSelector"/> component.
+    /// </summary>
+    public class FontIconSelectorTests
+    {
+        [UnityTest]
+        public IEnumerator TestMigrationToDescriptiveNames()
+        {
+            // 1. Create a mock FontIconSetDefinition
+            FontIconSetDefinition iconSetDef = ScriptableObject.CreateInstance<FontIconSetDefinition>();
+
+            // 2. Create a mock FontIconSet and assign the definition to it via Reflection
+            FontIconSet iconSet = ScriptableObject.CreateInstance<FontIconSet>();
+            typeof(FontIconSet).GetField("fontIconSetDefinition", BindingFlags.NonPublic | BindingFlags.Instance)
+                ?.SetValue(iconSet, iconSetDef);
+
+            // 3. Add an icon with a descriptive name and a specific unicode value
+            uint checkmarkUnicode = 0xE10B;
+            iconSet.AddIcon("Checkmark", checkmarkUnicode);
+
+            // 4. Create a GameObject with a text component and a FontIconSelector
+            GameObject go = new GameObject("IconSelectorTest");
+            TMP_Text textComponent = go.AddComponent<TextMeshPro>();
+
+            // Set the text component to the old un-migrated unicode character
+            textComponent.text = FontIconSet.ConvertUnicodeToHexString(checkmarkUnicode);
+
+            FontIconSelector selector = go.AddComponent<FontIconSelector>();
+
+            // Assign our mock FontIconSet
+            typeof(FontIconSelector).GetField("fontIcons", BindingFlags.NonPublic | BindingFlags.Instance)
+                ?.SetValue(selector, iconSet);
+
+            // At this point, the selector doesn't know its descriptive name
+            Assert.AreNotEqual("Checkmark", selector.CurrentIconName);
+
+            // 5. Trigger migration
+            bool migrationSucceeded = selector.TryMigrate();
+
+            // 6. Verify the migration accurately found and assigned the descriptive name
+            Assert.IsTrue(migrationSucceeded, "TryMigrate should have returned true.");
+            Assert.AreEqual("Checkmark", selector.CurrentIconName, "FontIconSelector did not migrate to the descriptive icon name.");
+
+            // Cleanup
+            Object.Destroy(go);
+            Object.Destroy(iconSet);
+            Object.Destroy(iconSetDef);
+
+            yield return null;
+        }
+    }
+}

--- a/org.mixedrealitytoolkit.uxcore/Tests/Runtime/FontIconSelectorTests.cs.meta
+++ b/org.mixedrealitytoolkit.uxcore/Tests/Runtime/FontIconSelectorTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: f1a3703ea830e754cae0879bfd198ff4


### PR DESCRIPTION
* Creates a new Font Icon Set Definition asset that contains all valid icon names for a set
* This new asset can be assigned to a Font Icon Set, allowing for a dropdown of names when assigning names to icons
* Updated the flow and arrangement of the icons while setting their names, to allow more to be visible at once and reduce scrolling
* Also fixes some bugs:
    * Selected glyph highlighting wasn't setting a valid color entry, so it wasn't working (`_Color` to `_FaceColor`)
    * Fixed a race condition where `DrawFontGlyphsGrid` was trying to read an entry from the deserialized Font Icon Set when the entry had only just been written to the serialized representation and wasn't yet updated
    * Fixed the Font Icon Set asset not being marked dirty when icon names were updated

Provides a migration path from the current "Icon #" names

From this:
<img width="597" height="821" alt="{F80EAE1E-7476-4526-A9A8-2ECB9121148B}" src="https://github.com/user-attachments/assets/9e79fc2e-7d17-4ef7-81f4-81982d8958c1" />

to this:
<img width="597" height="480" alt="{DB5A99C9-C92C-4409-8E9D-4DBA47DFDD56}" src="https://github.com/user-attachments/assets/6917898b-10d1-45b3-9a41-82e1aef33339" />
