### PR TITLE
Deprecate HasUIHover and HasUISelection and query the underlying TrackedDeviceModel directly instead

### DIFF
--- a/org.mixedrealitytoolkit.input/CHANGELOG.md
+++ b/org.mixedrealitytoolkit.input/CHANGELOG.md
@@ -14,6 +14,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 * Added input action focus handling to disable controller/hand tracked state when the XrSession goes out of focus. [PR #1057](https://github.com/MixedRealityToolkit/MixedRealityToolkit-Unity/pull/1057)
 * Added support for XR_MSFT_hand_tracking_mesh and XR_ANDROID_hand_mesh on compatible runtimes. [PR #993](https://github.com/MixedRealityToolkit/MixedRealityToolkit-Unity/pull/993)
 
+### Changed
+
+* Updated `InteractionDetector` to work across all `XRRayInteractor` and `NearFarInteractor` implementations, instead of just MRTK-specific `MRTKRayInteractor` implementations. [PR #1090](https://github.com/MixedRealityToolkit/MixedRealityToolkit-Unity/pull/1090)
+
+### Deprecated
+
+* Deprecated `HasUIHover` and `HasUISelection` from `MRTKRayInteractor` in favor of querying the underlying `TrackedDeviceModel` directly instead. [PR #1090](https://github.com/MixedRealityToolkit/MixedRealityToolkit-Unity/pull/1090)
+
 ## [4.0.0-pre.2] - 2025-12-05
 
 ### Changed

--- a/org.mixedrealitytoolkit.input/InteractionModes/InteractionDetector.cs
+++ b/org.mixedrealitytoolkit.input/InteractionModes/InteractionDetector.cs
@@ -108,11 +108,11 @@ namespace MixedReality.Toolkit.Input
 
             if (interactor is XRRayInteractor rayInteractor)
             {
-                isDetected |= rayInteractor.TryGetUIModel(out TrackedDeviceModel model) && ((model.currentRaycast.isValid && detectHover) || (model.select && detectSelect));
+                isDetected |= rayInteractor.TryGetUIModel(out TrackedDeviceModel model) && model.currentRaycast.isValid && (detectHover || (model.select && detectSelect));
             }
             else if (interactor is NearFarInteractor nearFarInteractor)
             {
-                isDetected |= nearFarInteractor.TryGetUIModel(out TrackedDeviceModel model) && ((model.currentRaycast.isValid && detectHover) || (model.select && detectSelect));
+                isDetected |= nearFarInteractor.TryGetUIModel(out TrackedDeviceModel model) && model.currentRaycast.isValid && (detectHover || (model.select && detectSelect));
             }
 
             return isDetected;

--- a/org.mixedrealitytoolkit.input/Interactors/Ray/MRTKRayInteractor.cs
+++ b/org.mixedrealitytoolkit.input/Interactors/Ray/MRTKRayInteractor.cs
@@ -63,33 +63,14 @@ namespace MixedReality.Toolkit.Input
         /// <summary>
         /// Is this ray currently hovering a UnityUI/Canvas element?
         /// </summary>
+        [Obsolete("This property has been deprecated in version 4.0.0. Call " + nameof(TryGetUIModel) + " and use " + nameof(TrackedDeviceModel.currentRaycast.isValid) + " instead.")]
         public bool HasUIHover => TryGetUIModel(out TrackedDeviceModel model) && model.currentRaycast.isValid;
 
         /// <summary>
         /// Is this ray currently selecting a UnityUI/Canvas element?
         /// </summary>
-        public bool HasUISelection
-        {
-            get
-            {
-                bool hasUISelection = HasUIHover;
-#pragma warning disable CS0618 // isUISelectActive is obsolete
-                if (forceDeprecatedInput)
-                {
-                    hasUISelection &= isUISelectActive;
-                }
-#pragma warning restore CS0618 // isUISelectActiver is obsolete
-                else if (uiPressInput != null)
-                {
-                    hasUISelection &= uiPressInput.ReadIsPerformed();
-                }
-                else
-                {
-                    hasUISelection = false;
-                }
-                return hasUISelection;
-            }
-        }
+        [Obsolete("This property has been deprecated in version 4.0.0. Call " + nameof(TryGetUIModel) + " and use " + nameof(TrackedDeviceModel.select) + " instead.")]
+        public bool HasUISelection => TryGetUIModel(out TrackedDeviceModel model) && model.select;
 
         /// <summary>
         /// Used to check if the parent controller is tracked or not

--- a/org.mixedrealitytoolkit.input/Tests/Runtime/InteractionModeManagerTests.cs
+++ b/org.mixedrealitytoolkit.input/Tests/Runtime/InteractionModeManagerTests.cs
@@ -10,7 +10,6 @@ using NUnit.Framework;
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Linq;
 using UnityEngine;
 using UnityEngine.TestTools;
 using UnityEngine.XR.Interaction.Toolkit;
@@ -206,7 +205,11 @@ namespace MixedReality.Toolkit.Input.Tests
         {
             // We construct the list of managed interactor types manually because we don't want to expose the internal controller mapping implementation to even internal use, since
             // we don't want any other class to be able to modify those collections without going through the Mode Manager or its in-editor inspector.
-            HashSet<Type> managedInteractorTypes = new HashSet<System.Type>(InteractionModeManager.Instance.PrioritizedInteractionModes.SelectMany(x => x.AssociatedTypes));
+            HashSet<Type> managedInteractorTypes = new HashSet<Type>();
+            foreach (InteractionModeDefinition interactionMode in InteractionModeManager.Instance.PrioritizedInteractionModes)
+            {
+                managedInteractorTypes.UnionWith(interactionMode.AssociatedTypes);
+            }
             HashSet<Type> activeInteractorTypes = InteractionModeManager.Instance.PrioritizedInteractionModes.Find(x => x.ModeName == currentMode.Name).AssociatedTypes;
 
             // Ensure the prox detector has actually had the desired effect of enabling/disabling interactors.

--- a/org.mixedrealitytoolkit.input/Tests/Runtime/InteractionModeManagerTests.cs
+++ b/org.mixedrealitytoolkit.input/Tests/Runtime/InteractionModeManagerTests.cs
@@ -88,7 +88,10 @@ namespace MixedReality.Toolkit.Input.Tests
             yield return rightHand.AimAt(cube.transform.position);
             yield return RuntimeTestUtilities.WaitForUpdates();
 
-            InteractionDetector interactionDetector = rightHandController.GetComponentInChildren<MRTKRayInteractor>().GetComponent<InteractionDetector>();
+            if (!rightHandController.GetComponentInChildren<MRTKRayInteractor>().TryGetComponent(out InteractionDetector interactionDetector))
+            {
+                Assert.Fail("No interaction detector found on right hand ray interactor. Is the component missing?");
+            }
 
             InteractionMode expectedMode = interactionDetector.ModeOnHover;
             Assert.AreEqual(expectedMode, interactionDetector.ModeOnDetection);
@@ -147,7 +150,10 @@ namespace MixedReality.Toolkit.Input.Tests
             InputTestUtilities.SetHandAnchorPoint(Handedness.Right, ControllerAnchorPoint.Grab);
             yield return RuntimeTestUtilities.WaitForUpdates();
 
-            InteractionDetector rayInteractionDetector = rightHandController.GetComponentInChildren<MRTKRayInteractor>().GetComponent<InteractionDetector>();
+            if (!rightHandController.GetComponentInChildren<MRTKRayInteractor>().TryGetComponent(out InteractionDetector rayInteractionDetector))
+            {
+                Assert.Fail("No interaction detector found on right hand ray interactor. Is the component missing?");
+            }
 
             // Moving the hand to a position where its far ray is hovering over the cube
             yield return rightHand.AimAt(cube.transform.position);
@@ -172,7 +178,10 @@ namespace MixedReality.Toolkit.Input.Tests
             yield return rightHand.SetHandshape(HandshapeTypes.HandshapeId.Grab);
             yield return RuntimeTestUtilities.WaitForUpdates();
 
-            InteractionDetector grabInteractionDetector = rightHandController.GetComponentInChildren<GrabInteractor>().GetComponent<InteractionDetector>();
+            if (!rightHandController.GetComponentInChildren<GrabInteractor>().TryGetComponent(out InteractionDetector grabInteractionDetector))
+            {
+                Assert.Fail("No interaction detector found on right hand grab interactor. Is the component missing?");
+            }
 
             InteractionMode grabMode = grabInteractionDetector.ModeOnSelect;
             Assert.AreEqual(grabMode, grabInteractionDetector.ModeOnDetection);

--- a/org.mixedrealitytoolkit.input/Tests/Runtime/InteractionModeManagerTestsForControllerlessRig.cs
+++ b/org.mixedrealitytoolkit.input/Tests/Runtime/InteractionModeManagerTestsForControllerlessRig.cs
@@ -91,30 +91,42 @@ namespace MixedReality.Toolkit.Input.Tests
             yield return RuntimeTestUtilities.WaitForUpdates();
 
             TrackedPoseDriver rightHandTrackedPoseDriver = CachedTrackedPoseDriverLookup.RightHandTrackedPoseDriver;
-            InteractionDetector rightHandInteractionDetector = rightHandTrackedPoseDriver.transform.parent.GetComponentInChildren<MRTKRayInteractor>().GetComponent<InteractionDetector>();
+            Assert.IsTrue(rightHandTrackedPoseDriver != null, "No tracked pose driver found for right hand.");
 
             // Moving the hand to a position where it's far ray is hovering over the cube
             yield return rightHand.AimAt(cube.transform.position);
             yield return RuntimeTestUtilities.WaitForUpdates();
 
-            InteractionMode currentMode = rightHandInteractionDetector.ModeOnHover;
-            Assert.AreEqual(currentMode, rightHandInteractionDetector.ModeOnDetection);
-            ValidateInteractionModeActive(rightHandTrackedPoseDriver, currentMode);
+            InteractionDetector interactionDetector = rightHandTrackedPoseDriver.transform.parent.GetComponentInChildren<MRTKRayInteractor>().GetComponent<InteractionDetector>();
 
+            InteractionMode expectedMode = interactionDetector.ModeOnHover;
+            Assert.AreEqual(expectedMode, interactionDetector.ModeOnDetection);
+            ValidateInteractionModeActive(rightHandTrackedPoseDriver, expectedMode);
+
+            // Select the cube and check that we're in the correct mode
             yield return rightHand.SetHandshape(HandshapeTypes.HandshapeId.Grab);
             yield return RuntimeTestUtilities.WaitForUpdates();
-            currentMode = rightHandInteractionDetector.ModeOnSelect;
-            Assert.AreEqual(currentMode, rightHandInteractionDetector.ModeOnDetection);
-            ValidateInteractionModeActive(rightHandTrackedPoseDriver, currentMode);
+            expectedMode = interactionDetector.ModeOnSelect;
+            Assert.AreEqual(expectedMode, interactionDetector.ModeOnDetection);
+            ValidateInteractionModeActive(rightHandTrackedPoseDriver, expectedMode);
 
-            // move the hand far away and validate that we are in the default mode
+            // Release the selection and move the hand far away and validate that we are in the default mode
             yield return rightHand.SetHandshape(HandshapeTypes.HandshapeId.Open);
             yield return RuntimeTestUtilities.WaitForUpdates();
-            yield return rightHand.MoveTo(cube.transform.position + new Vector3(3.0f,0,0));
+            yield return rightHand.MoveTo(cube.transform.position + new Vector3(3.0f, 0, 0));
             yield return RuntimeTestUtilities.WaitForUpdates();
+            expectedMode = InteractionModeManager.Instance.DefaultMode;
+            ValidateInteractionModeActive(rightHandTrackedPoseDriver, expectedMode);
 
-            currentMode = InteractionModeManager.Instance.DefaultMode;
-            ValidateInteractionModeActive(rightHandTrackedPoseDriver, currentMode);
+            // Put the hand into a grab state and validate that we are in the default mode, since we're not selecting an object
+            yield return rightHand.SetHandshape(HandshapeTypes.HandshapeId.Grab);
+            yield return RuntimeTestUtilities.WaitForUpdates();
+            ValidateInteractionModeActive(rightHandTrackedPoseDriver, expectedMode);
+
+            // Release the grab state and validate that we are in the default mode
+            yield return rightHand.SetHandshape(HandshapeTypes.HandshapeId.Open);
+            yield return RuntimeTestUtilities.WaitForUpdates();
+            ValidateInteractionModeActive(rightHandTrackedPoseDriver, expectedMode);
         }
 
         /// <summary>


### PR DESCRIPTION
This allows more types of interactors to work here, not _just_ MRTK-defined interactors.

All tests pass 
<img width="140" height="48" alt="{776D266C-67CB-403E-B79F-FB79A9C208AE}" src="https://github.com/user-attachments/assets/90e0307f-75a0-42bc-9143-56fa405a81fe" />
