### PR TITLE
chore: Upgrade GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/pr_labeler.yaml
+++ b/.github/workflows/pr_labeler.yaml
@@ -11,7 +11,7 @@ jobs:
   label-pr:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/github-script@v6
+      - uses: actions/github-script@v8
         with:
           script: |
             if (context.payload.pull_request.base.ref == 'feature/XRI3')

--- a/.github/workflows/validation_mrtk3.yaml
+++ b/.github/workflows/validation_mrtk3.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v6
 
     - name: Get Pull Request changes
       if: github.event_name == 'pull_request'


### PR DESCRIPTION
## Summary

This PR upgrades all GitHub Actions in the repository to their latest versions to benefit from the newest features, security patches, and Node.js runtime improvements.

## Changes

| Workflow | Action | Previous | Updated |
|----------|--------|----------|---------|
| `pr_labeler.yaml` | `actions/github-script` | v6 | **v8** |
| `validation_mrtk3.yaml` | `actions/checkout` | v3 | **v6** |

## Details

### actions/github-script v6 → v8
- Updated to Node.js 24 runtime
- Improved performance and security updates
- [Release notes](https://github.com/actions/github-script/releases)

### actions/checkout v3 → v6
- Updated to Node.js 24 runtime
- Credentials now stored under `$RUNNER_TEMP` for improved security
- Better worktree support
- [Release notes](https://github.com/actions/checkout/releases)

## Notes
- Both actions require a minimum runner version of **v2.327.1** (GitHub-hosted runners are already compatible)