### PR TITLE
Deprecate AdjustTrackingOrigin

### DIFF
--- a/org.mixedrealitytoolkit.core/CHANGELOG.md
+++ b/org.mixedrealitytoolkit.core/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 * Fixed "The type MixedReality.Toolkit.Core MixedReality.Toolkit.Experimental.BubbleChildHoverEvents/TrickleChildHoverEvents/BubbleChildSelectEvents/TrickleChildSelectEvents is being serialized by [SerializeReference], but is missing the [Serializable] attribute." on Unity 6.3. [PR #1107](https://github.com/MixedRealityToolkit/MixedRealityToolkit-Unity/pull/1107)
 
+## Deprecated
+
+* Deprecated `AdjustTrackingOrigin` on `CameraSettings`. This functionality has been deprecated by the XR Origin component. This property has never had an effect in MRTK3 and will be removed in a future release. [PR #1110](https://github.com/MixedRealityToolkit/MixedRealityToolkit-Unity/pull/1110)
+
 ## [3.3.0] - 2025-11-12
 
 ### Changed
@@ -44,7 +48,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 * StabilizedRay constructor with explicit position and direction half life values. [PR #625](https://github.com/MixedRealityToolkit/MixedRealityToolkit-Unity/pull/625)
 * Added IsProximityHovered property of type TimedFlag to detect when a button starts being hovered or on interactor proximity and when it stops being hovered or on proximity of any interactor. [PR #611](https://github.com/MixedRealityToolkit/MixedRealityToolkit-Unity/pull/611)
 * Adding ProximityHover events (Entered & Exited) to PressableButton class. [PR #611](https://github.com/MixedRealityToolkit/MixedRealityToolkit-Unity/pull/611)
-
 
 ### Fixed
 

--- a/org.mixedrealitytoolkit.core/Camera/CameraSettings.cs
+++ b/org.mixedrealitytoolkit.core/Camera/CameraSettings.cs
@@ -76,7 +76,7 @@ namespace MixedReality.Toolkit
         /// The default <see cref="Color"/> to apply to <see cref="ClearColor"/> if on an opaque XR headset.
         /// </summary>
         public static readonly Color DefaultClearColorOpaque = Color.black;
-        
+
         /// <summary>
         /// The default <see cref="Color"/> to apply to <see cref="ClearColor"/> if on a transparent XR headset.
         /// </summary>
@@ -122,7 +122,7 @@ namespace MixedReality.Toolkit
         /// The default value to apply to <see cref="FarPlaneDistance"/> if on an opaque XR headset.
         /// </summary>
         public static readonly float DefaultFarPlaneDistanceOpaque = 1000f;
-        
+
         /// <summary>
         /// The default value to apply to <see cref="FarPlaneDistance"/> if on a transparent XR headset.
         /// </summary>
@@ -141,18 +141,11 @@ namespace MixedReality.Toolkit
             set => farPlaneDistance = value;
         }
 
-        [SerializeField]
-        [Tooltip("Should the tracking origin be adjusted base on camera type?")]
-        private bool adjustTrackingOrigin = true;
-
         /// <summary>
         /// Should the tracking origin be adjusted based on camera type?
         /// </summary>
-        public bool AdjustTrackingOrigin
-        {
-            get => adjustTrackingOrigin;
-            set => adjustTrackingOrigin = value;
-        }
+        [Obsolete("This functionality has been deprecated by the XR Origin component. This property has never had an effect in MRTK3 and will be removed in a future release.")]
+        public bool AdjustTrackingOrigin { get; set; }
 
         [SerializeField]
         [Tooltip("Should the quality level be adjusted based on camera type?")]
@@ -174,7 +167,7 @@ namespace MixedReality.Toolkit
 
         /// <summary>
         /// The default value to apply to <see cref="QualityLevel"/> if on a transparent XR headset.
-        /// </summary>        
+        /// </summary>
         public static readonly int DefaultQualityLevelTransparent = 0;  // Very Low
 
         [SerializeField]

--- a/org.mixedrealitytoolkit.input/Assets/Prefabs/MRTK XR Rig.prefab
+++ b/org.mixedrealitytoolkit.input/Assets/Prefabs/MRTK XR Rig.prefab
@@ -220,7 +220,6 @@ MonoBehaviour:
       m_Action: Main Camera - TPD - Rotation
       m_Flags: 0
     m_Flags: 0
-  m_HasMigratedActions: 1
 --- !u!114 &404949538145338360
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -238,7 +237,6 @@ MonoBehaviour:
     clearColor: {r: 0, g: 0, b: 0, a: 0}
     nearPlaneDistance: 0.1
     farPlaneDistance: 1000
-    adjustTrackingOrigin: 1
     adjustQualityLevel: 1
     qualityLevel: 5
   transparentDisplay:
@@ -246,7 +244,6 @@ MonoBehaviour:
     clearColor: {r: 0, g: 0, b: 0, a: 0}
     nearPlaneDistance: 0.1
     farPlaneDistance: 50
-    adjustTrackingOrigin: 1
     adjustQualityLevel: 1
     qualityLevel: 0
 --- !u!1 &2351505566903569413

--- a/org.mixedrealitytoolkit.input/CHANGELOG.md
+++ b/org.mixedrealitytoolkit.input/CHANGELOG.md
@@ -4,6 +4,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## Unreleased
 
+### Changed
+
+* Reserialized MRTK XR Rig prefab to remove stale serialized fields. [PR #1110](https://github.com/MixedRealityToolkit/MixedRealityToolkit-Unity/pull/1110)
+
 ### Fixed
 
 * Fixed `EyeCalibrationChecker` build issue on UWP when the Mixed Reality OpenXR Plugin wasn't installed. [PR #1106](https://github.com/MixedRealityToolkit/MixedRealityToolkit-Unity/pull/1106)


### PR DESCRIPTION
This functionality has been deprecated by the XR Origin component. This property has never had an effect in MRTK3 and will be removed in a future release.