### PR TITLE
Reserialize org.mixedrealitytoolkit.standardassets for Unity 6 (except materials and textures)

### DIFF
--- a/org.mixedrealitytoolkit.standardassets/Audio/HoloLens2/MRTK_ButtonPress.wav.meta
+++ b/org.mixedrealitytoolkit.standardassets/Audio/HoloLens2/MRTK_ButtonPress.wav.meta
@@ -2,18 +2,19 @@ fileFormatVersion: 2
 guid: 3e4887b6014c9e04290e816ac261a414
 AudioImporter:
   externalObjects: {}
-  serializedVersion: 6
+  serializedVersion: 8
   defaultSettings:
+    serializedVersion: 2
     loadType: 0
     sampleRateSetting: 0
     sampleRateOverride: 44100
     compressionFormat: 1
     quality: 1
     conversionMode: 0
+    preloadAudioData: 1
   platformSettingOverrides: {}
   forceToMono: 0
   normalize: 1
-  preloadAudioData: 1
   loadInBackground: 0
   ambisonic: 0
   3D: 1

--- a/org.mixedrealitytoolkit.standardassets/Audio/HoloLens2/MRTK_ButtonUnpress.wav.meta
+++ b/org.mixedrealitytoolkit.standardassets/Audio/HoloLens2/MRTK_ButtonUnpress.wav.meta
@@ -2,18 +2,19 @@ fileFormatVersion: 2
 guid: f2b39c1fa02395640bced3c8e5f9696e
 AudioImporter:
   externalObjects: {}
-  serializedVersion: 6
+  serializedVersion: 8
   defaultSettings:
+    serializedVersion: 2
     loadType: 0
     sampleRateSetting: 0
     sampleRateOverride: 44100
     compressionFormat: 1
     quality: 1
     conversionMode: 0
+    preloadAudioData: 1
   platformSettingOverrides: {}
   forceToMono: 0
   normalize: 1
-  preloadAudioData: 1
   loadInBackground: 0
   ambisonic: 0
   3D: 1

--- a/org.mixedrealitytoolkit.standardassets/Audio/HoloLens2/MRTK_Gem.wav.meta
+++ b/org.mixedrealitytoolkit.standardassets/Audio/HoloLens2/MRTK_Gem.wav.meta
@@ -2,18 +2,19 @@ fileFormatVersion: 2
 guid: c6586241cbe52ba44b40351d74c9dc39
 AudioImporter:
   externalObjects: {}
-  serializedVersion: 6
+  serializedVersion: 8
   defaultSettings:
+    serializedVersion: 2
     loadType: 0
     sampleRateSetting: 0
     sampleRateOverride: 44100
     compressionFormat: 1
     quality: 1
     conversionMode: 0
+    preloadAudioData: 1
   platformSettingOverrides: {}
   forceToMono: 0
   normalize: 1
-  preloadAudioData: 1
   loadInBackground: 0
   ambisonic: 0
   3D: 1

--- a/org.mixedrealitytoolkit.standardassets/Audio/HoloLens2/MRTK_Manipulation_End.wav.meta
+++ b/org.mixedrealitytoolkit.standardassets/Audio/HoloLens2/MRTK_Manipulation_End.wav.meta
@@ -2,18 +2,19 @@ fileFormatVersion: 2
 guid: 9f512430eba32d845aab8de9ba5e393c
 AudioImporter:
   externalObjects: {}
-  serializedVersion: 6
+  serializedVersion: 8
   defaultSettings:
+    serializedVersion: 2
     loadType: 0
     sampleRateSetting: 0
     sampleRateOverride: 44100
     compressionFormat: 1
     quality: 1
     conversionMode: 0
+    preloadAudioData: 1
   platformSettingOverrides: {}
   forceToMono: 0
   normalize: 1
-  preloadAudioData: 1
   loadInBackground: 0
   ambisonic: 0
   3D: 1

--- a/org.mixedrealitytoolkit.standardassets/Audio/HoloLens2/MRTK_Manipulation_Start.wav.meta
+++ b/org.mixedrealitytoolkit.standardassets/Audio/HoloLens2/MRTK_Manipulation_Start.wav.meta
@@ -2,18 +2,19 @@ fileFormatVersion: 2
 guid: 29437a55b95f2eb489a5ec8574f185e9
 AudioImporter:
   externalObjects: {}
-  serializedVersion: 6
+  serializedVersion: 8
   defaultSettings:
+    serializedVersion: 2
     loadType: 0
     sampleRateSetting: 0
     sampleRateOverride: 44100
     compressionFormat: 1
     quality: 1
     conversionMode: 0
+    preloadAudioData: 1
   platformSettingOverrides: {}
   forceToMono: 0
   normalize: 1
-  preloadAudioData: 1
   loadInBackground: 0
   ambisonic: 0
   3D: 1

--- a/org.mixedrealitytoolkit.standardassets/Audio/HoloLens2/MRTK_Move_End.wav.meta
+++ b/org.mixedrealitytoolkit.standardassets/Audio/HoloLens2/MRTK_Move_End.wav.meta
@@ -2,18 +2,19 @@ fileFormatVersion: 2
 guid: 49bfc3418fff4924886a8b52a7569152
 AudioImporter:
   externalObjects: {}
-  serializedVersion: 6
+  serializedVersion: 8
   defaultSettings:
+    serializedVersion: 2
     loadType: 0
     sampleRateSetting: 0
     sampleRateOverride: 44100
     compressionFormat: 1
     quality: 1
     conversionMode: 0
+    preloadAudioData: 1
   platformSettingOverrides: {}
   forceToMono: 0
   normalize: 1
-  preloadAudioData: 1
   loadInBackground: 0
   ambisonic: 0
   3D: 1

--- a/org.mixedrealitytoolkit.standardassets/Audio/HoloLens2/MRTK_Move_Start.wav.meta
+++ b/org.mixedrealitytoolkit.standardassets/Audio/HoloLens2/MRTK_Move_Start.wav.meta
@@ -2,18 +2,19 @@ fileFormatVersion: 2
 guid: 1cd58df2ed177f74cb6a1882c7e52079
 AudioImporter:
   externalObjects: {}
-  serializedVersion: 6
+  serializedVersion: 8
   defaultSettings:
+    serializedVersion: 2
     loadType: 0
     sampleRateSetting: 0
     sampleRateOverride: 44100
     compressionFormat: 1
     quality: 1
     conversionMode: 0
+    preloadAudioData: 1
   platformSettingOverrides: {}
   forceToMono: 0
   normalize: 1
-  preloadAudioData: 1
   loadInBackground: 0
   ambisonic: 0
   3D: 1

--- a/org.mixedrealitytoolkit.standardassets/Audio/HoloLens2/MRTK_Notification.wav.meta
+++ b/org.mixedrealitytoolkit.standardassets/Audio/HoloLens2/MRTK_Notification.wav.meta
@@ -2,18 +2,19 @@ fileFormatVersion: 2
 guid: 50b629cc6a6feb0458f4b22b5c96eb91
 AudioImporter:
   externalObjects: {}
-  serializedVersion: 6
+  serializedVersion: 8
   defaultSettings:
+    serializedVersion: 2
     loadType: 0
     sampleRateSetting: 0
     sampleRateOverride: 44100
     compressionFormat: 1
     quality: 1
     conversionMode: 0
+    preloadAudioData: 1
   platformSettingOverrides: {}
   forceToMono: 0
   normalize: 1
-  preloadAudioData: 1
   loadInBackground: 0
   ambisonic: 0
   3D: 1

--- a/org.mixedrealitytoolkit.standardassets/Audio/HoloLens2/MRTK_Rotate_Start.wav.meta
+++ b/org.mixedrealitytoolkit.standardassets/Audio/HoloLens2/MRTK_Rotate_Start.wav.meta
@@ -2,18 +2,19 @@ fileFormatVersion: 2
 guid: 8cf342cfdef942745bff6d0d7b750fb9
 AudioImporter:
   externalObjects: {}
-  serializedVersion: 6
+  serializedVersion: 8
   defaultSettings:
+    serializedVersion: 2
     loadType: 0
     sampleRateSetting: 0
     sampleRateOverride: 44100
     compressionFormat: 1
     quality: 1
     conversionMode: 0
+    preloadAudioData: 1
   platformSettingOverrides: {}
   forceToMono: 0
   normalize: 1
-  preloadAudioData: 1
   loadInBackground: 0
   ambisonic: 0
   3D: 1

--- a/org.mixedrealitytoolkit.standardassets/Audio/HoloLens2/MRTK_Rotate_Stop.wav.meta
+++ b/org.mixedrealitytoolkit.standardassets/Audio/HoloLens2/MRTK_Rotate_Stop.wav.meta
@@ -2,18 +2,19 @@ fileFormatVersion: 2
 guid: b59dfcadf9127b64aad15b10b470a7ff
 AudioImporter:
   externalObjects: {}
-  serializedVersion: 6
+  serializedVersion: 8
   defaultSettings:
+    serializedVersion: 2
     loadType: 0
     sampleRateSetting: 0
     sampleRateOverride: 44100
     compressionFormat: 1
     quality: 1
     conversionMode: 0
+    preloadAudioData: 1
   platformSettingOverrides: {}
   forceToMono: 0
   normalize: 1
-  preloadAudioData: 1
   loadInBackground: 0
   ambisonic: 0
   3D: 1

--- a/org.mixedrealitytoolkit.standardassets/Audio/HoloLens2/MRTK_Scale_Start.wav.meta
+++ b/org.mixedrealitytoolkit.standardassets/Audio/HoloLens2/MRTK_Scale_Start.wav.meta
@@ -2,18 +2,19 @@ fileFormatVersion: 2
 guid: 035f176b1bcdd7a4d904529a96346fd1
 AudioImporter:
   externalObjects: {}
-  serializedVersion: 6
+  serializedVersion: 8
   defaultSettings:
+    serializedVersion: 2
     loadType: 0
     sampleRateSetting: 0
     sampleRateOverride: 44100
     compressionFormat: 1
     quality: 1
     conversionMode: 0
+    preloadAudioData: 1
   platformSettingOverrides: {}
   forceToMono: 0
   normalize: 1
-  preloadAudioData: 1
   loadInBackground: 0
   ambisonic: 0
   3D: 1

--- a/org.mixedrealitytoolkit.standardassets/Audio/HoloLens2/MRTK_Scale_Stop.wav.meta
+++ b/org.mixedrealitytoolkit.standardassets/Audio/HoloLens2/MRTK_Scale_Stop.wav.meta
@@ -2,18 +2,19 @@ fileFormatVersion: 2
 guid: ca1d2149dae1f1c46bd86eda5ac11494
 AudioImporter:
   externalObjects: {}
-  serializedVersion: 6
+  serializedVersion: 8
   defaultSettings:
+    serializedVersion: 2
     loadType: 0
     sampleRateSetting: 0
     sampleRateOverride: 44100
     compressionFormat: 1
     quality: 1
     conversionMode: 0
+    preloadAudioData: 1
   platformSettingOverrides: {}
   forceToMono: 0
   normalize: 1
-  preloadAudioData: 1
   loadInBackground: 0
   ambisonic: 0
   3D: 1

--- a/org.mixedrealitytoolkit.standardassets/Audio/HoloLens2/MRTK_Select_Main.wav.meta
+++ b/org.mixedrealitytoolkit.standardassets/Audio/HoloLens2/MRTK_Select_Main.wav.meta
@@ -2,18 +2,19 @@ fileFormatVersion: 2
 guid: d6dc4c2cdecc0854c86657006920372f
 AudioImporter:
   externalObjects: {}
-  serializedVersion: 6
+  serializedVersion: 8
   defaultSettings:
+    serializedVersion: 2
     loadType: 0
     sampleRateSetting: 0
     sampleRateOverride: 44100
     compressionFormat: 1
     quality: 1
     conversionMode: 0
+    preloadAudioData: 1
   platformSettingOverrides: {}
   forceToMono: 0
   normalize: 1
-  preloadAudioData: 1
   loadInBackground: 0
   ambisonic: 0
   3D: 1

--- a/org.mixedrealitytoolkit.standardassets/Audio/HoloLens2/MRTK_Select_Secondary.wav.meta
+++ b/org.mixedrealitytoolkit.standardassets/Audio/HoloLens2/MRTK_Select_Secondary.wav.meta
@@ -2,18 +2,19 @@ fileFormatVersion: 2
 guid: 7bbab62483287dd47838e134a553fa1d
 AudioImporter:
   externalObjects: {}
-  serializedVersion: 6
+  serializedVersion: 8
   defaultSettings:
+    serializedVersion: 2
     loadType: 0
     sampleRateSetting: 0
     sampleRateOverride: 44100
     compressionFormat: 1
     quality: 1
     conversionMode: 0
+    preloadAudioData: 1
   platformSettingOverrides: {}
   forceToMono: 0
   normalize: 1
-  preloadAudioData: 1
   loadInBackground: 0
   ambisonic: 0
   3D: 1

--- a/org.mixedrealitytoolkit.standardassets/Audio/HoloLens2/MRTK_Shell_Click_In.wav.meta
+++ b/org.mixedrealitytoolkit.standardassets/Audio/HoloLens2/MRTK_Shell_Click_In.wav.meta
@@ -2,18 +2,19 @@ fileFormatVersion: 2
 guid: c786d2d6f58426f45a09f169fe5a1649
 AudioImporter:
   externalObjects: {}
-  serializedVersion: 6
+  serializedVersion: 8
   defaultSettings:
+    serializedVersion: 2
     loadType: 0
     sampleRateSetting: 0
     sampleRateOverride: 44100
     compressionFormat: 1
     quality: 1
     conversionMode: 0
+    preloadAudioData: 1
   platformSettingOverrides: {}
   forceToMono: 0
   normalize: 1
-  preloadAudioData: 1
   loadInBackground: 0
   ambisonic: 0
   3D: 1

--- a/org.mixedrealitytoolkit.standardassets/Audio/HoloLens2/MRTK_Shell_Click_Init.wav.meta
+++ b/org.mixedrealitytoolkit.standardassets/Audio/HoloLens2/MRTK_Shell_Click_Init.wav.meta
@@ -2,18 +2,19 @@ fileFormatVersion: 2
 guid: 1285b8566fdd22947a7e83ade04469c4
 AudioImporter:
   externalObjects: {}
-  serializedVersion: 6
+  serializedVersion: 8
   defaultSettings:
+    serializedVersion: 2
     loadType: 0
     sampleRateSetting: 0
     sampleRateOverride: 44100
     compressionFormat: 1
     quality: 1
     conversionMode: 0
+    preloadAudioData: 1
   platformSettingOverrides: {}
   forceToMono: 0
   normalize: 1
-  preloadAudioData: 1
   loadInBackground: 0
   ambisonic: 0
   3D: 1

--- a/org.mixedrealitytoolkit.standardassets/Audio/HoloLens2/MRTK_Shell_Click_Out.wav.meta
+++ b/org.mixedrealitytoolkit.standardassets/Audio/HoloLens2/MRTK_Shell_Click_Out.wav.meta
@@ -2,18 +2,19 @@ fileFormatVersion: 2
 guid: 56f0c69e11f787a4e85f235bbcd637a6
 AudioImporter:
   externalObjects: {}
-  serializedVersion: 6
+  serializedVersion: 8
   defaultSettings:
+    serializedVersion: 2
     loadType: 0
     sampleRateSetting: 0
     sampleRateOverride: 44100
     compressionFormat: 1
     quality: 1
     conversionMode: 0
+    preloadAudioData: 1
   platformSettingOverrides: {}
   forceToMono: 0
   normalize: 1
-  preloadAudioData: 1
   loadInBackground: 0
   ambisonic: 0
   3D: 1

--- a/org.mixedrealitytoolkit.standardassets/Audio/HoloLens2/MRTK_Slate_Release.wav.meta
+++ b/org.mixedrealitytoolkit.standardassets/Audio/HoloLens2/MRTK_Slate_Release.wav.meta
@@ -2,18 +2,19 @@ fileFormatVersion: 2
 guid: 310c809e9e1292846bb8d82d3c320767
 AudioImporter:
   externalObjects: {}
-  serializedVersion: 6
+  serializedVersion: 8
   defaultSettings:
+    serializedVersion: 2
     loadType: 0
     sampleRateSetting: 0
     sampleRateOverride: 44100
     compressionFormat: 1
     quality: 1
     conversionMode: 0
+    preloadAudioData: 1
   platformSettingOverrides: {}
   forceToMono: 0
   normalize: 1
-  preloadAudioData: 1
   loadInBackground: 0
   ambisonic: 0
   3D: 1

--- a/org.mixedrealitytoolkit.standardassets/Audio/HoloLens2/MRTK_Slate_Touch.wav.meta
+++ b/org.mixedrealitytoolkit.standardassets/Audio/HoloLens2/MRTK_Slate_Touch.wav.meta
@@ -2,18 +2,19 @@ fileFormatVersion: 2
 guid: e6aaa47d01f073c408f85bad24c97528
 AudioImporter:
   externalObjects: {}
-  serializedVersion: 6
+  serializedVersion: 8
   defaultSettings:
+    serializedVersion: 2
     loadType: 0
     sampleRateSetting: 0
     sampleRateOverride: 44100
     compressionFormat: 1
     quality: 1
     conversionMode: 0
+    preloadAudioData: 1
   platformSettingOverrides: {}
   forceToMono: 0
   normalize: 1
-  preloadAudioData: 1
   loadInBackground: 0
   ambisonic: 0
   3D: 1

--- a/org.mixedrealitytoolkit.standardassets/Audio/HoloLens2/MRTK_Slider_Grab.wav.meta
+++ b/org.mixedrealitytoolkit.standardassets/Audio/HoloLens2/MRTK_Slider_Grab.wav.meta
@@ -2,18 +2,19 @@ fileFormatVersion: 2
 guid: a6df42a6534a99b44bab6bf896cad6a4
 AudioImporter:
   externalObjects: {}
-  serializedVersion: 6
+  serializedVersion: 8
   defaultSettings:
+    serializedVersion: 2
     loadType: 0
     sampleRateSetting: 0
     sampleRateOverride: 44100
     compressionFormat: 1
     quality: 1
     conversionMode: 0
+    preloadAudioData: 1
   platformSettingOverrides: {}
   forceToMono: 0
   normalize: 1
-  preloadAudioData: 1
   loadInBackground: 0
   ambisonic: 0
   3D: 1

--- a/org.mixedrealitytoolkit.standardassets/Audio/HoloLens2/MRTK_Slider_Pass_Notch.wav.meta
+++ b/org.mixedrealitytoolkit.standardassets/Audio/HoloLens2/MRTK_Slider_Pass_Notch.wav.meta
@@ -2,18 +2,19 @@ fileFormatVersion: 2
 guid: bb2e061449451aa45960db70c734b513
 AudioImporter:
   externalObjects: {}
-  serializedVersion: 6
+  serializedVersion: 8
   defaultSettings:
+    serializedVersion: 2
     loadType: 0
     sampleRateSetting: 0
     sampleRateOverride: 44100
     compressionFormat: 1
     quality: 1
     conversionMode: 0
+    preloadAudioData: 1
   platformSettingOverrides: {}
   forceToMono: 0
   normalize: 1
-  preloadAudioData: 1
   loadInBackground: 0
   ambisonic: 0
   3D: 1

--- a/org.mixedrealitytoolkit.standardassets/Audio/HoloLens2/MRTK_Slider_Release.wav.meta
+++ b/org.mixedrealitytoolkit.standardassets/Audio/HoloLens2/MRTK_Slider_Release.wav.meta
@@ -2,18 +2,19 @@ fileFormatVersion: 2
 guid: 9bb44e4e04a41434082d97b1064421e1
 AudioImporter:
   externalObjects: {}
-  serializedVersion: 6
+  serializedVersion: 8
   defaultSettings:
+    serializedVersion: 2
     loadType: 0
     sampleRateSetting: 0
     sampleRateOverride: 44100
     compressionFormat: 1
     quality: 1
     conversionMode: 0
+    preloadAudioData: 1
   platformSettingOverrides: {}
   forceToMono: 0
   normalize: 1
-  preloadAudioData: 1
   loadInBackground: 0
   ambisonic: 0
   3D: 1

--- a/org.mixedrealitytoolkit.standardassets/Audio/HoloLens2/MRTK_Tap.wav.meta
+++ b/org.mixedrealitytoolkit.standardassets/Audio/HoloLens2/MRTK_Tap.wav.meta
@@ -2,18 +2,19 @@ fileFormatVersion: 2
 guid: 72e7ec6b3237f724aa37a13418cbf0ba
 AudioImporter:
   externalObjects: {}
-  serializedVersion: 6
+  serializedVersion: 8
   defaultSettings:
+    serializedVersion: 2
     loadType: 0
     sampleRateSetting: 0
     sampleRateOverride: 44100
     compressionFormat: 1
     quality: 1
     conversionMode: 0
+    preloadAudioData: 1
   platformSettingOverrides: {}
   forceToMono: 0
   normalize: 1
-  preloadAudioData: 1
   loadInBackground: 0
   ambisonic: 0
   3D: 1

--- a/org.mixedrealitytoolkit.standardassets/Audio/HoloLens2/MRTK_Voice_Confirmation.wav.meta
+++ b/org.mixedrealitytoolkit.standardassets/Audio/HoloLens2/MRTK_Voice_Confirmation.wav.meta
@@ -2,18 +2,19 @@ fileFormatVersion: 2
 guid: e71dd7a1eab98024a8c581ce99141e3b
 AudioImporter:
   externalObjects: {}
-  serializedVersion: 6
+  serializedVersion: 8
   defaultSettings:
+    serializedVersion: 2
     loadType: 0
     sampleRateSetting: 0
     sampleRateOverride: 44100
     compressionFormat: 1
     quality: 1
     conversionMode: 0
+    preloadAudioData: 1
   platformSettingOverrides: {}
   forceToMono: 0
   normalize: 1
-  preloadAudioData: 1
   loadInBackground: 0
   ambisonic: 0
   3D: 1

--- a/org.mixedrealitytoolkit.standardassets/Audio/MRDesignSystem/UI_AddSelected.wav.meta
+++ b/org.mixedrealitytoolkit.standardassets/Audio/MRDesignSystem/UI_AddSelected.wav.meta
@@ -2,18 +2,19 @@ fileFormatVersion: 2
 guid: 68338d2f57cc5cb47a63dee2d126d021
 AudioImporter:
   externalObjects: {}
-  serializedVersion: 6
+  serializedVersion: 8
   defaultSettings:
+    serializedVersion: 2
     loadType: 0
     sampleRateSetting: 0
     sampleRateOverride: 44100
     compressionFormat: 1
     quality: 1
     conversionMode: 0
+    preloadAudioData: 1
   platformSettingOverrides: {}
   forceToMono: 0
   normalize: 1
-  preloadAudioData: 1
   loadInBackground: 0
   ambisonic: 0
   3D: 1

--- a/org.mixedrealitytoolkit.standardassets/Audio/MRDesignSystem/UI_Cancel.wav.meta
+++ b/org.mixedrealitytoolkit.standardassets/Audio/MRDesignSystem/UI_Cancel.wav.meta
@@ -2,18 +2,19 @@ fileFormatVersion: 2
 guid: ee6faa794c675a040a3bc81fb540705e
 AudioImporter:
   externalObjects: {}
-  serializedVersion: 6
+  serializedVersion: 8
   defaultSettings:
+    serializedVersion: 2
     loadType: 0
     sampleRateSetting: 0
     sampleRateOverride: 44100
     compressionFormat: 1
     quality: 1
     conversionMode: 0
+    preloadAudioData: 1
   platformSettingOverrides: {}
   forceToMono: 0
   normalize: 1
-  preloadAudioData: 1
   loadInBackground: 0
   ambisonic: 0
   3D: 1

--- a/org.mixedrealitytoolkit.standardassets/Audio/MRDesignSystem/UI_Closed.wav.meta
+++ b/org.mixedrealitytoolkit.standardassets/Audio/MRDesignSystem/UI_Closed.wav.meta
@@ -2,18 +2,19 @@ fileFormatVersion: 2
 guid: 43ce90410fbfbd7419914ead766bcf71
 AudioImporter:
   externalObjects: {}
-  serializedVersion: 6
+  serializedVersion: 8
   defaultSettings:
+    serializedVersion: 2
     loadType: 0
     sampleRateSetting: 0
     sampleRateOverride: 44100
     compressionFormat: 1
     quality: 1
     conversionMode: 0
+    preloadAudioData: 1
   platformSettingOverrides: {}
   forceToMono: 0
   normalize: 1
-  preloadAudioData: 1
   loadInBackground: 0
   ambisonic: 0
   3D: 1

--- a/org.mixedrealitytoolkit.standardassets/Audio/MRDesignSystem/UI_Confirmed.wav.meta
+++ b/org.mixedrealitytoolkit.standardassets/Audio/MRDesignSystem/UI_Confirmed.wav.meta
@@ -2,18 +2,19 @@ fileFormatVersion: 2
 guid: 2089af8cd1fe912498a274f8065ed5fd
 AudioImporter:
   externalObjects: {}
-  serializedVersion: 6
+  serializedVersion: 8
   defaultSettings:
+    serializedVersion: 2
     loadType: 0
     sampleRateSetting: 0
     sampleRateOverride: 44100
     compressionFormat: 1
     quality: 1
     conversionMode: 0
+    preloadAudioData: 1
   platformSettingOverrides: {}
   forceToMono: 0
   normalize: 1
-  preloadAudioData: 1
   loadInBackground: 0
   ambisonic: 0
   3D: 1

--- a/org.mixedrealitytoolkit.standardassets/Audio/MRDesignSystem/UI_Grab.wav.meta
+++ b/org.mixedrealitytoolkit.standardassets/Audio/MRDesignSystem/UI_Grab.wav.meta
@@ -2,18 +2,19 @@ fileFormatVersion: 2
 guid: 8370bcd72a26cf5468e9373181299eca
 AudioImporter:
   externalObjects: {}
-  serializedVersion: 6
+  serializedVersion: 8
   defaultSettings:
+    serializedVersion: 2
     loadType: 0
     sampleRateSetting: 0
     sampleRateOverride: 44100
     compressionFormat: 1
     quality: 1
     conversionMode: 0
+    preloadAudioData: 1
   platformSettingOverrides: {}
   forceToMono: 0
   normalize: 1
-  preloadAudioData: 1
   loadInBackground: 0
   ambisonic: 0
   3D: 1

--- a/org.mixedrealitytoolkit.standardassets/Audio/MRDesignSystem/UI_Hydrate.wav.meta
+++ b/org.mixedrealitytoolkit.standardassets/Audio/MRDesignSystem/UI_Hydrate.wav.meta
@@ -2,18 +2,19 @@ fileFormatVersion: 2
 guid: 3cb12cc240db7b845b1269efafe7272c
 AudioImporter:
   externalObjects: {}
-  serializedVersion: 6
+  serializedVersion: 8
   defaultSettings:
+    serializedVersion: 2
     loadType: 0
     sampleRateSetting: 0
     sampleRateOverride: 44100
     compressionFormat: 1
     quality: 1
     conversionMode: 0
+    preloadAudioData: 1
   platformSettingOverrides: {}
   forceToMono: 0
   normalize: 1
-  preloadAudioData: 1
   loadInBackground: 0
   ambisonic: 0
   3D: 1

--- a/org.mixedrealitytoolkit.standardassets/Audio/MRDesignSystem/UI_Mute.wav.meta
+++ b/org.mixedrealitytoolkit.standardassets/Audio/MRDesignSystem/UI_Mute.wav.meta
@@ -2,18 +2,19 @@ fileFormatVersion: 2
 guid: 114f052040c1e0040bfca486d9983e4f
 AudioImporter:
   externalObjects: {}
-  serializedVersion: 6
+  serializedVersion: 8
   defaultSettings:
+    serializedVersion: 2
     loadType: 0
     sampleRateSetting: 0
     sampleRateOverride: 44100
     compressionFormat: 1
     quality: 1
     conversionMode: 0
+    preloadAudioData: 1
   platformSettingOverrides: {}
   forceToMono: 0
   normalize: 1
-  preloadAudioData: 1
   loadInBackground: 0
   ambisonic: 0
   3D: 1

--- a/org.mixedrealitytoolkit.standardassets/Audio/MRDesignSystem/UI_Pin.wav.meta
+++ b/org.mixedrealitytoolkit.standardassets/Audio/MRDesignSystem/UI_Pin.wav.meta
@@ -2,18 +2,19 @@ fileFormatVersion: 2
 guid: c53bc30dd1055eb4eb2a4007b82236d2
 AudioImporter:
   externalObjects: {}
-  serializedVersion: 6
+  serializedVersion: 8
   defaultSettings:
+    serializedVersion: 2
     loadType: 0
     sampleRateSetting: 0
     sampleRateOverride: 44100
     compressionFormat: 1
     quality: 1
     conversionMode: 0
+    preloadAudioData: 1
   platformSettingOverrides: {}
   forceToMono: 0
   normalize: 1
-  preloadAudioData: 1
   loadInBackground: 0
   ambisonic: 0
   3D: 1

--- a/org.mixedrealitytoolkit.standardassets/Audio/MRDesignSystem/UI_Press.wav.meta
+++ b/org.mixedrealitytoolkit.standardassets/Audio/MRDesignSystem/UI_Press.wav.meta
@@ -2,18 +2,19 @@ fileFormatVersion: 2
 guid: 51de19e15e660e845bdedcfbb9c6a0e8
 AudioImporter:
   externalObjects: {}
-  serializedVersion: 6
+  serializedVersion: 8
   defaultSettings:
+    serializedVersion: 2
     loadType: 0
     sampleRateSetting: 0
     sampleRateOverride: 44100
     compressionFormat: 1
     quality: 1
     conversionMode: 0
+    preloadAudioData: 1
   platformSettingOverrides: {}
   forceToMono: 0
   normalize: 1
-  preloadAudioData: 1
   loadInBackground: 0
   ambisonic: 0
   3D: 1

--- a/org.mixedrealitytoolkit.standardassets/Audio/MRDesignSystem/UI_Release.wav.meta
+++ b/org.mixedrealitytoolkit.standardassets/Audio/MRDesignSystem/UI_Release.wav.meta
@@ -2,18 +2,19 @@ fileFormatVersion: 2
 guid: 55c56ad83252ca647b56e238abee1047
 AudioImporter:
   externalObjects: {}
-  serializedVersion: 6
+  serializedVersion: 8
   defaultSettings:
+    serializedVersion: 2
     loadType: 0
     sampleRateSetting: 0
     sampleRateOverride: 44100
     compressionFormat: 1
     quality: 1
     conversionMode: 0
+    preloadAudioData: 1
   platformSettingOverrides: {}
   forceToMono: 0
   normalize: 1
-  preloadAudioData: 1
   loadInBackground: 0
   ambisonic: 0
   3D: 1

--- a/org.mixedrealitytoolkit.standardassets/Audio/MRDesignSystem/UI_RemoveSelected.wav.meta
+++ b/org.mixedrealitytoolkit.standardassets/Audio/MRDesignSystem/UI_RemoveSelected.wav.meta
@@ -2,18 +2,19 @@ fileFormatVersion: 2
 guid: 68b53e5ad1ebe6f4c81d0aa1601c1824
 AudioImporter:
   externalObjects: {}
-  serializedVersion: 6
+  serializedVersion: 8
   defaultSettings:
+    serializedVersion: 2
     loadType: 0
     sampleRateSetting: 0
     sampleRateOverride: 44100
     compressionFormat: 1
     quality: 1
     conversionMode: 0
+    preloadAudioData: 1
   platformSettingOverrides: {}
   forceToMono: 0
   normalize: 1
-  preloadAudioData: 1
   loadInBackground: 0
   ambisonic: 0
   3D: 1

--- a/org.mixedrealitytoolkit.standardassets/Audio/MRDesignSystem/UI_RemoveSelected_Confirmed.wav.meta
+++ b/org.mixedrealitytoolkit.standardassets/Audio/MRDesignSystem/UI_RemoveSelected_Confirmed.wav.meta
@@ -2,18 +2,19 @@ fileFormatVersion: 2
 guid: 4f6b28d86c90c7544a17a12f63c22f6e
 AudioImporter:
   externalObjects: {}
-  serializedVersion: 6
+  serializedVersion: 8
   defaultSettings:
+    serializedVersion: 2
     loadType: 0
     sampleRateSetting: 0
     sampleRateOverride: 44100
     compressionFormat: 1
     quality: 1
     conversionMode: 0
+    preloadAudioData: 1
   platformSettingOverrides: {}
   forceToMono: 0
   normalize: 1
-  preloadAudioData: 1
   loadInBackground: 0
   ambisonic: 0
   3D: 1

--- a/org.mixedrealitytoolkit.standardassets/Audio/MRDesignSystem/UI_Scroll_Down.wav.meta
+++ b/org.mixedrealitytoolkit.standardassets/Audio/MRDesignSystem/UI_Scroll_Down.wav.meta
@@ -2,18 +2,19 @@ fileFormatVersion: 2
 guid: ebcd8b3cb475fb8478bf3f7a10d75db7
 AudioImporter:
   externalObjects: {}
-  serializedVersion: 6
+  serializedVersion: 8
   defaultSettings:
+    serializedVersion: 2
     loadType: 0
     sampleRateSetting: 0
     sampleRateOverride: 44100
     compressionFormat: 1
     quality: 1
     conversionMode: 0
+    preloadAudioData: 1
   platformSettingOverrides: {}
   forceToMono: 0
   normalize: 1
-  preloadAudioData: 1
   loadInBackground: 0
   ambisonic: 0
   3D: 1

--- a/org.mixedrealitytoolkit.standardassets/Audio/MRDesignSystem/UI_Scroll_Up.wav.meta
+++ b/org.mixedrealitytoolkit.standardassets/Audio/MRDesignSystem/UI_Scroll_Up.wav.meta
@@ -2,18 +2,19 @@ fileFormatVersion: 2
 guid: fab35621148be91419487be779c1c29f
 AudioImporter:
   externalObjects: {}
-  serializedVersion: 6
+  serializedVersion: 8
   defaultSettings:
+    serializedVersion: 2
     loadType: 0
     sampleRateSetting: 0
     sampleRateOverride: 44100
     compressionFormat: 1
     quality: 1
     conversionMode: 0
+    preloadAudioData: 1
   platformSettingOverrides: {}
   forceToMono: 0
   normalize: 1
-  preloadAudioData: 1
   loadInBackground: 0
   ambisonic: 0
   3D: 1

--- a/org.mixedrealitytoolkit.standardassets/Audio/MRDesignSystem/UI_ToggleOff.wav.meta
+++ b/org.mixedrealitytoolkit.standardassets/Audio/MRDesignSystem/UI_ToggleOff.wav.meta
@@ -2,18 +2,19 @@ fileFormatVersion: 2
 guid: e32303defa786934dbca7f8a304f04c3
 AudioImporter:
   externalObjects: {}
-  serializedVersion: 6
+  serializedVersion: 8
   defaultSettings:
+    serializedVersion: 2
     loadType: 0
     sampleRateSetting: 0
     sampleRateOverride: 44100
     compressionFormat: 1
     quality: 1
     conversionMode: 0
+    preloadAudioData: 1
   platformSettingOverrides: {}
   forceToMono: 0
   normalize: 1
-  preloadAudioData: 1
   loadInBackground: 0
   ambisonic: 0
   3D: 1

--- a/org.mixedrealitytoolkit.standardassets/Audio/MRDesignSystem/UI_ToggleOn.wav.meta
+++ b/org.mixedrealitytoolkit.standardassets/Audio/MRDesignSystem/UI_ToggleOn.wav.meta
@@ -2,18 +2,19 @@ fileFormatVersion: 2
 guid: d7c0a9fca9557794dbe29b65909f7e3f
 AudioImporter:
   externalObjects: {}
-  serializedVersion: 6
+  serializedVersion: 8
   defaultSettings:
+    serializedVersion: 2
     loadType: 0
     sampleRateSetting: 0
     sampleRateOverride: 44100
     compressionFormat: 1
     quality: 1
     conversionMode: 0
+    preloadAudioData: 1
   platformSettingOverrides: {}
   forceToMono: 0
   normalize: 1
-  preloadAudioData: 1
   loadInBackground: 0
   ambisonic: 0
   3D: 1

--- a/org.mixedrealitytoolkit.standardassets/Audio/MRDesignSystem/UI_Unmute.wav.meta
+++ b/org.mixedrealitytoolkit.standardassets/Audio/MRDesignSystem/UI_Unmute.wav.meta
@@ -2,18 +2,19 @@ fileFormatVersion: 2
 guid: c05b53fa1de51a84396a499b237144a7
 AudioImporter:
   externalObjects: {}
-  serializedVersion: 6
+  serializedVersion: 8
   defaultSettings:
+    serializedVersion: 2
     loadType: 0
     sampleRateSetting: 0
     sampleRateOverride: 44100
     compressionFormat: 1
     quality: 1
     conversionMode: 0
+    preloadAudioData: 1
   platformSettingOverrides: {}
   forceToMono: 0
   normalize: 1
-  preloadAudioData: 1
   loadInBackground: 0
   ambisonic: 0
   3D: 1

--- a/org.mixedrealitytoolkit.standardassets/Audio/MRDesignSystem/UI_Unpin.wav.meta
+++ b/org.mixedrealitytoolkit.standardassets/Audio/MRDesignSystem/UI_Unpin.wav.meta
@@ -2,18 +2,19 @@ fileFormatVersion: 2
 guid: c48db6fa34b7da14a95f3e6866940d08
 AudioImporter:
   externalObjects: {}
-  serializedVersion: 6
+  serializedVersion: 8
   defaultSettings:
+    serializedVersion: 2
     loadType: 0
     sampleRateSetting: 0
     sampleRateOverride: 44100
     compressionFormat: 1
     quality: 1
     conversionMode: 0
+    preloadAudioData: 1
   platformSettingOverrides: {}
   forceToMono: 0
   normalize: 1
-  preloadAudioData: 1
   loadInBackground: 0
   ambisonic: 0
   3D: 1

--- a/org.mixedrealitytoolkit.standardassets/Audio/MRDesignSystem/UI_Unpress.wav.meta
+++ b/org.mixedrealitytoolkit.standardassets/Audio/MRDesignSystem/UI_Unpress.wav.meta
@@ -2,18 +2,19 @@ fileFormatVersion: 2
 guid: 31f34f35c8f745846b7d4237bdca909e
 AudioImporter:
   externalObjects: {}
-  serializedVersion: 6
+  serializedVersion: 8
   defaultSettings:
+    serializedVersion: 2
     loadType: 0
     sampleRateSetting: 0
     sampleRateOverride: 44100
     compressionFormat: 1
     quality: 1
     conversionMode: 0
+    preloadAudioData: 1
   platformSettingOverrides: {}
   forceToMono: 0
   normalize: 1
-  preloadAudioData: 1
   loadInBackground: 0
   ambisonic: 0
   3D: 1

--- a/org.mixedrealitytoolkit.standardassets/Fonts/Selawik-Bold-MRTKIcons SDF.asset
+++ b/org.mixedrealitytoolkit.standardassets/Fonts/Selawik-Bold-MRTKIcons SDF.asset
@@ -9,6 +9,8 @@ Material:
   m_PrefabAsset: {fileID: 0}
   m_Name: selawkb Atlas Material
   m_Shader: {fileID: 4800000, guid: c5f3f59b19556b3479f929a84f25f776, type: 3}
+  m_Parent: {fileID: 0}
+  m_ModifiedSerializedProperties: 0
   m_ValidKeywords: []
   m_InvalidKeywords: []
   m_LightmapFlags: 4
@@ -17,6 +19,7 @@ Material:
   m_CustomRenderQueue: -1
   stringTagMap: {}
   disabledShaderPasses: []
+  m_LockedProperties: 
   m_SavedProperties:
     serializedVersion: 3
     m_TexEnvs:
@@ -112,6 +115,7 @@ Material:
     - _SpecularColor: {r: 1, g: 1, b: 1, a: 1}
     - _UnderlayColor: {r: 0, g: 0, b: 0, a: 0.5}
   m_BuildTextureStacks: []
+  m_AllowLocking: 1
 --- !u!28 &-182009929712840728
 Texture2D:
   m_ObjectHideFlags: 0
@@ -122,10 +126,8 @@ Texture2D:
   m_ImageContentsHash:
     serializedVersion: 2
     Hash: 00000000000000000000000000000000
-  m_ForcedFallbackFormat: 4
-  m_DownscaleFallback: 0
   m_IsAlphaChannelOptional: 0
-  serializedVersion: 2
+  serializedVersion: 3
   m_Width: 1024
   m_Height: 1024
   m_CompleteImageSize: 1048576
@@ -134,7 +136,8 @@ Texture2D:
   m_MipCount: 1
   m_IsReadable: 1
   m_IsPreProcessed: 0
-  m_IgnoreMasterTextureLimit: 0
+  m_IgnoreMipmapLimit: 0
+  m_MipmapLimitGroupName: 
   m_StreamingMipmaps: 0
   m_StreamingMipmapsPriority: 0
   m_VTOnly: 0
@@ -171,14 +174,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71c1514a6bd24e1e882cebbe1904ce04, type: 3}
   m_Name: Selawik-Bold-MRTKIcons SDF
   m_EditorClassIdentifier: 
-  hashCode: 449731266
-  material: {fileID: -1440009900055822571}
-  materialHashCode: 1553978530
   m_Version: 1.1.0
-  m_SourceFontFileGUID: 3fa3a351e0ae62a44948b05c0e4beaea
-  m_SourceFontFile_EditorRef: {fileID: 12800000, guid: 3fa3a351e0ae62a44948b05c0e4beaea, type: 3}
-  m_SourceFontFile: {fileID: 12800000, guid: 3fa3a351e0ae62a44948b05c0e4beaea, type: 3}
-  m_AtlasPopulationMode: 1
   m_FaceInfo:
     m_FaceIndex: 0
     m_FamilyName: Selawik Bold MRTK Icons
@@ -201,6 +197,31 @@ MonoBehaviour:
     m_StrikethroughOffset: 13.2
     m_StrikethroughThickness: 1.6845703
     m_TabWidth: 19
+  m_Material: {fileID: -1440009900055822571}
+  m_SourceFontFileGUID: 3fa3a351e0ae62a44948b05c0e4beaea
+  m_CreationSettings:
+    sourceFontFileName: 
+    sourceFontFileGUID: 3fa3a351e0ae62a44948b05c0e4beaea
+    faceIndex: 0
+    pointSizeSamplingMode: 0
+    pointSize: 69
+    padding: 9
+    paddingMode: 0
+    packingMode: 0
+    atlasWidth: 1024
+    atlasHeight: 1024
+    characterSetSelectionMode: 6
+    characterSequence: 20-22,26-29,2C-37,3A-3B,3E,41-49,4B-50,52-59,5F,61-7A,2026,E80F,E818,E830,E840,E844-E845,E854,E874,E877-E878,E87D-E87F,E881-E885,E886-E887,E889,E88B-E88C,E9C6,EA49,EB43,EB4B,EBE6,F10A,F10D,F115,F119,F123,F125,F138,F13E,F140,F149,F15C,F169,F172,F182,F18B,F19C,F1AA,F1B5,F1DF,F1E3,F1F6,F20F,F214,F248,F255,F26B,F26D,F287,F295,F2A4,F2AB,F2B1,F2B7,F2D6,F2DE,F2E2,F2E5,F2F2,F2F6,F300,F315,F319,F320,F33B,F33D,F342,F345,F34D,F35A,F35F,F36A,F36E,F376,F379,F387,F3DB,F3DE,F3E1,F3F2,F40C,F419,F45B,F472,F47A,F47F,F481,F489,F4A0,F4A4,F4A8,F4B9,F4D7,F4E5,F4EC,F4F9,F507,F541,F557,F55A,F55F,F561,F566,F56C,F56F,F588,F58A,F5A9,F5AD,F5BE,F5E1,F5E6,F602,F604,F606,F608,F60F,F62B,F62E,F639,F662,F680,F690,F69A,F6AA,F710,F714,F75B,F77D,F81E,F820,F84D,F86A,F8D7,F8FE
+    referencedFontAssetGUID: d15b9765f7a456340a28cee00f9beeb2
+    referencedTextAssetGUID: 
+    fontStyle: 0
+    fontStyleModifier: 0
+    renderMode: 4165
+    includeFontFeatures: 0
+  m_SourceFontFile: {fileID: 12800000, guid: 3fa3a351e0ae62a44948b05c0e4beaea, type: 3}
+  m_SourceFontFilePath: 
+  m_AtlasPopulationMode: 1
+  InternalDynamicOS: 0
   m_GlyphTable:
   - m_Index: 3
     m_Metrics:
@@ -4292,7 +4313,12 @@ MonoBehaviour:
   - {fileID: -182009929712840728}
   m_AtlasTextureIndex: 0
   m_IsMultiAtlasTexturesEnabled: 0
+  m_GetFontFeatures: 1
   m_ClearDynamicDataOnBuild: 0
+  m_AtlasWidth: 1024
+  m_AtlasHeight: 1024
+  m_AtlasPadding: 9
+  m_AtlasRenderMode: 4165
   m_UsedGlyphRects:
   - m_X: 0
     m_Y: 0
@@ -5787,57 +5813,14 @@ MonoBehaviour:
     m_Y: 890
     m_Width: 160
     m_Height: 133
-  m_fontInfo:
-    Name: 
-    PointSize: 0
-    Scale: 0
-    CharacterCount: 0
-    LineHeight: 0
-    Baseline: 0
-    Ascender: 0
-    CapHeight: 0
-    Descender: 0
-    CenterLine: 0
-    SuperscriptOffset: 0
-    SubscriptOffset: 0
-    SubSize: 0
-    Underline: 0
-    UnderlineThickness: 0
-    strikethrough: 0
-    strikethroughThickness: 0
-    TabWidth: 0
-    Padding: 0
-    AtlasWidth: 0
-    AtlasHeight: 0
-  atlas: {fileID: 0}
-  m_AtlasWidth: 1024
-  m_AtlasHeight: 1024
-  m_AtlasPadding: 9
-  m_AtlasRenderMode: 4165
-  m_glyphInfoList: []
-  m_KerningTable:
-    kerningPairs: []
   m_FontFeatureTable:
+    m_MultipleSubstitutionRecords: []
+    m_LigatureSubstitutionRecords: []
     m_GlyphPairAdjustmentRecords: []
-  fallbackFontAssets: []
+    m_MarkToBaseAdjustmentRecords: []
+    m_MarkToMarkAdjustmentRecords: []
+  m_ShouldReimportFontFeatures: 0
   m_FallbackFontAssetTable: []
-  m_CreationSettings:
-    sourceFontFileName: 
-    sourceFontFileGUID: 3fa3a351e0ae62a44948b05c0e4beaea
-    pointSizeSamplingMode: 0
-    pointSize: 69
-    padding: 9
-    packingMode: 0
-    atlasWidth: 1024
-    atlasHeight: 1024
-    characterSetSelectionMode: 6
-    characterSequence: 20-22,26-29,2C-37,3A-3B,3E,41-49,4B-50,52-59,5F,61-7A,2026,E80F,E818,E830,E840,E844-E845,E854,E874,E877-E878,E87D-E87F,E881-E885,E886-E887,E889,E88B-E88C,E9C6,EA49,EB43,EB4B,EBE6,F10A,F10D,F115,F119,F123,F125,F138,F13E,F140,F149,F15C,F169,F172,F182,F18B,F19C,F1AA,F1B5,F1DF,F1E3,F1F6,F20F,F214,F248,F255,F26B,F26D,F287,F295,F2A4,F2AB,F2B1,F2B7,F2D6,F2DE,F2E2,F2E5,F2F2,F2F6,F300,F315,F319,F320,F33B,F33D,F342,F345,F34D,F35A,F35F,F36A,F36E,F376,F379,F387,F3DB,F3DE,F3E1,F3F2,F40C,F419,F45B,F472,F47A,F47F,F481,F489,F4A0,F4A4,F4A8,F4B9,F4D7,F4E5,F4EC,F4F9,F507,F541,F557,F55A,F55F,F561,F566,F56C,F56F,F588,F58A,F5A9,F5AD,F5BE,F5E1,F5E6,F602,F604,F606,F608,F60F,F62B,F62E,F639,F662,F680,F690,F69A,F6AA,F710,F714,F75B,F77D,F81E,F820,F84D,F86A,F8D7,F8FE
-    referencedFontAssetGUID: d15b9765f7a456340a28cee00f9beeb2
-    referencedTextAssetGUID: 
-    fontStyle: 0
-    fontStyleModifier: 0
-    renderMode: 4165
-    includeFontFeatures: 0
   m_FontWeightTable:
   - regularTypeface: {fileID: 0}
     italicTypeface: {fileID: 0}
@@ -5866,3 +5849,30 @@ MonoBehaviour:
   boldSpacing: 7
   italicStyle: 35
   tabSize: 10
+  m_fontInfo:
+    Name: 
+    PointSize: 0
+    Scale: 0
+    CharacterCount: 0
+    LineHeight: 0
+    Baseline: 0
+    Ascender: 0
+    CapHeight: 0
+    Descender: 0
+    CenterLine: 0
+    SuperscriptOffset: 0
+    SubscriptOffset: 0
+    SubSize: 0
+    Underline: 0
+    UnderlineThickness: 0
+    strikethrough: 0
+    strikethroughThickness: 0
+    TabWidth: 0
+    Padding: 0
+    AtlasWidth: 0
+    AtlasHeight: 0
+  m_glyphInfoList: []
+  m_KerningTable:
+    kerningPairs: []
+  fallbackFontAssets: []
+  atlas: {fileID: 0}

--- a/org.mixedrealitytoolkit.standardassets/Fonts/Selawik-Bold-MRTKIcons ZWrite On Atlas Material.mat
+++ b/org.mixedrealitytoolkit.standardassets/Fonts/Selawik-Bold-MRTKIcons ZWrite On Atlas Material.mat
@@ -9,6 +9,8 @@ Material:
   m_PrefabAsset: {fileID: 0}
   m_Name: Selawik-Bold-MRTKIcons ZWrite On Atlas Material
   m_Shader: {fileID: 4800000, guid: c5f3f59b19556b3479f929a84f25f776, type: 3}
+  m_Parent: {fileID: 0}
+  m_ModifiedSerializedProperties: 0
   m_ValidKeywords: []
   m_InvalidKeywords: []
   m_LightmapFlags: 4
@@ -17,6 +19,7 @@ Material:
   m_CustomRenderQueue: -1
   stringTagMap: {}
   disabledShaderPasses: []
+  m_LockedProperties: 
   m_SavedProperties:
     serializedVersion: 3
     m_TexEnvs:
@@ -107,3 +110,4 @@ Material:
     - _SpecularColor: {r: 1, g: 1, b: 1, a: 1}
     - _UnderlayColor: {r: 0, g: 0, b: 0, a: 0.5}
   m_BuildTextureStacks: []
+  m_AllowLocking: 1

--- a/org.mixedrealitytoolkit.standardassets/Fonts/Selawik-Light-MRTKIcons SDF.asset
+++ b/org.mixedrealitytoolkit.standardassets/Fonts/Selawik-Light-MRTKIcons SDF.asset
@@ -10,10 +10,8 @@ Texture2D:
   m_ImageContentsHash:
     serializedVersion: 2
     Hash: 00000000000000000000000000000000
-  m_ForcedFallbackFormat: 4
-  m_DownscaleFallback: 0
   m_IsAlphaChannelOptional: 0
-  serializedVersion: 2
+  serializedVersion: 3
   m_Width: 1024
   m_Height: 1024
   m_CompleteImageSize: 1048576
@@ -22,7 +20,8 @@ Texture2D:
   m_MipCount: 1
   m_IsReadable: 1
   m_IsPreProcessed: 0
-  m_IgnoreMasterTextureLimit: 0
+  m_IgnoreMipmapLimit: 0
+  m_MipmapLimitGroupName: 
   m_StreamingMipmaps: 0
   m_StreamingMipmapsPriority: 0
   m_VTOnly: 0
@@ -59,14 +58,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71c1514a6bd24e1e882cebbe1904ce04, type: 3}
   m_Name: Selawik-Light-MRTKIcons SDF
   m_EditorClassIdentifier: 
-  hashCode: 396684921
-  material: {fileID: 5931662821090898422}
-  materialHashCode: 1896055865
   m_Version: 1.1.0
-  m_SourceFontFileGUID: 68a6df7cc298b65448dbb27b620cdb74
-  m_SourceFontFile_EditorRef: {fileID: 12800000, guid: 68a6df7cc298b65448dbb27b620cdb74, type: 3}
-  m_SourceFontFile: {fileID: 12800000, guid: 68a6df7cc298b65448dbb27b620cdb74, type: 3}
-  m_AtlasPopulationMode: 1
   m_FaceInfo:
     m_FaceIndex: 0
     m_FamilyName: Selawik
@@ -89,6 +81,31 @@ MonoBehaviour:
     m_StrikethroughOffset: 13.6
     m_StrikethroughThickness: 1.7333984
     m_TabWidth: 19
+  m_Material: {fileID: 5931662821090898422}
+  m_SourceFontFileGUID: 68a6df7cc298b65448dbb27b620cdb74
+  m_CreationSettings:
+    sourceFontFileName: 
+    sourceFontFileGUID: 68a6df7cc298b65448dbb27b620cdb74
+    faceIndex: 0
+    pointSizeSamplingMode: 0
+    pointSize: 71
+    padding: 9
+    paddingMode: 0
+    packingMode: 0
+    atlasWidth: 1024
+    atlasHeight: 1024
+    characterSetSelectionMode: 6
+    characterSequence: 20-22,26-29,2C-37,3A-3B,3E,41-49,4B-50,52-59,5F,61-7A,2026,E80F,E818,E830,E840,E844-E845,E854,E874,E877-E878,E87D-E87F,E881-E885,E886-E887,E889,E88B-E88C,E9C6,EA49,EB43,EB4B,EBE6,F10A,F10D,F115,F119,F123,F125,F138,F13E,F140,F149,F15C,F169,F172,F182,F18B,F19C,F1AA,F1B5,F1DF,F1E3,F1F6,F20F,F214,F248,F255,F26B,F26D,F287,F295,F2A4,F2AB,F2B1,F2B7,F2D6,F2DE,F2E2,F2E5,F2F2,F2F6,F300,F315,F319,F320,F33B,F33D,F342,F345,F34D,F35A,F35F,F36A,F36E,F376,F379,F387,F3DB,F3DE,F3E1,F3F2,F40C,F419,F45B,F472,F47A,F47F,F481,F489,F4A0,F4A4,F4A8,F4B9,F4D7,F4E5,F4EC,F4F9,F507,F541,F557,F55A,F55F,F561,F566,F56C,F56F,F588,F58A,F5A9,F5AD,F5BE,F5E1,F5E6,F602,F604,F606,F608,F60F,F62B,F62E,F639,F662,F680,F690,F69A,F6AA,F710,F714,F75B,F77D,F81E,F820,F84D,F86A,F8D7,F8FE
+    referencedFontAssetGUID: a4f1c9abdecd7074aa3ae160b988d5d9
+    referencedTextAssetGUID: 
+    fontStyle: 0
+    fontStyleModifier: 0
+    renderMode: 4165
+    includeFontFeatures: 0
+  m_SourceFontFile: {fileID: 12800000, guid: 68a6df7cc298b65448dbb27b620cdb74, type: 3}
+  m_SourceFontFilePath: 
+  m_AtlasPopulationMode: 1
+  InternalDynamicOS: 0
   m_GlyphTable:
   - m_Index: 3
     m_Metrics:
@@ -4180,7 +4197,12 @@ MonoBehaviour:
   - {fileID: -1933112875938584043}
   m_AtlasTextureIndex: 0
   m_IsMultiAtlasTexturesEnabled: 0
+  m_GetFontFeatures: 1
   m_ClearDynamicDataOnBuild: 0
+  m_AtlasWidth: 1024
+  m_AtlasHeight: 1024
+  m_AtlasPadding: 9
+  m_AtlasRenderMode: 4165
   m_UsedGlyphRects:
   - m_X: 0
     m_Y: 0
@@ -5643,57 +5665,14 @@ MonoBehaviour:
     m_Y: 841
     m_Width: 104
     m_Height: 182
-  m_fontInfo:
-    Name: 
-    PointSize: 0
-    Scale: 0
-    CharacterCount: 0
-    LineHeight: 0
-    Baseline: 0
-    Ascender: 0
-    CapHeight: 0
-    Descender: 0
-    CenterLine: 0
-    SuperscriptOffset: 0
-    SubscriptOffset: 0
-    SubSize: 0
-    Underline: 0
-    UnderlineThickness: 0
-    strikethrough: 0
-    strikethroughThickness: 0
-    TabWidth: 0
-    Padding: 0
-    AtlasWidth: 0
-    AtlasHeight: 0
-  atlas: {fileID: 0}
-  m_AtlasWidth: 1024
-  m_AtlasHeight: 1024
-  m_AtlasPadding: 9
-  m_AtlasRenderMode: 4165
-  m_glyphInfoList: []
-  m_KerningTable:
-    kerningPairs: []
   m_FontFeatureTable:
+    m_MultipleSubstitutionRecords: []
+    m_LigatureSubstitutionRecords: []
     m_GlyphPairAdjustmentRecords: []
-  fallbackFontAssets: []
+    m_MarkToBaseAdjustmentRecords: []
+    m_MarkToMarkAdjustmentRecords: []
+  m_ShouldReimportFontFeatures: 0
   m_FallbackFontAssetTable: []
-  m_CreationSettings:
-    sourceFontFileName: 
-    sourceFontFileGUID: 68a6df7cc298b65448dbb27b620cdb74
-    pointSizeSamplingMode: 0
-    pointSize: 71
-    padding: 9
-    packingMode: 0
-    atlasWidth: 1024
-    atlasHeight: 1024
-    characterSetSelectionMode: 6
-    characterSequence: 20-22,26-29,2C-37,3A-3B,3E,41-49,4B-50,52-59,5F,61-7A,2026,E80F,E818,E830,E840,E844-E845,E854,E874,E877-E878,E87D-E87F,E881-E885,E886-E887,E889,E88B-E88C,E9C6,EA49,EB43,EB4B,EBE6,F10A,F10D,F115,F119,F123,F125,F138,F13E,F140,F149,F15C,F169,F172,F182,F18B,F19C,F1AA,F1B5,F1DF,F1E3,F1F6,F20F,F214,F248,F255,F26B,F26D,F287,F295,F2A4,F2AB,F2B1,F2B7,F2D6,F2DE,F2E2,F2E5,F2F2,F2F6,F300,F315,F319,F320,F33B,F33D,F342,F345,F34D,F35A,F35F,F36A,F36E,F376,F379,F387,F3DB,F3DE,F3E1,F3F2,F40C,F419,F45B,F472,F47A,F47F,F481,F489,F4A0,F4A4,F4A8,F4B9,F4D7,F4E5,F4EC,F4F9,F507,F541,F557,F55A,F55F,F561,F566,F56C,F56F,F588,F58A,F5A9,F5AD,F5BE,F5E1,F5E6,F602,F604,F606,F608,F60F,F62B,F62E,F639,F662,F680,F690,F69A,F6AA,F710,F714,F75B,F77D,F81E,F820,F84D,F86A,F8D7,F8FE
-    referencedFontAssetGUID: a4f1c9abdecd7074aa3ae160b988d5d9
-    referencedTextAssetGUID: 
-    fontStyle: 0
-    fontStyleModifier: 0
-    renderMode: 4165
-    includeFontFeatures: 0
   m_FontWeightTable:
   - regularTypeface: {fileID: 0}
     italicTypeface: {fileID: 0}
@@ -5722,6 +5701,33 @@ MonoBehaviour:
   boldSpacing: 7
   italicStyle: 35
   tabSize: 10
+  m_fontInfo:
+    Name: 
+    PointSize: 0
+    Scale: 0
+    CharacterCount: 0
+    LineHeight: 0
+    Baseline: 0
+    Ascender: 0
+    CapHeight: 0
+    Descender: 0
+    CenterLine: 0
+    SuperscriptOffset: 0
+    SubscriptOffset: 0
+    SubSize: 0
+    Underline: 0
+    UnderlineThickness: 0
+    strikethrough: 0
+    strikethroughThickness: 0
+    TabWidth: 0
+    Padding: 0
+    AtlasWidth: 0
+    AtlasHeight: 0
+  m_glyphInfoList: []
+  m_KerningTable:
+    kerningPairs: []
+  fallbackFontAssets: []
+  atlas: {fileID: 0}
 --- !u!21 &5931662821090898422
 Material:
   serializedVersion: 8
@@ -5731,6 +5737,8 @@ Material:
   m_PrefabAsset: {fileID: 0}
   m_Name: selawkl Atlas Material
   m_Shader: {fileID: 4800000, guid: c5f3f59b19556b3479f929a84f25f776, type: 3}
+  m_Parent: {fileID: 0}
+  m_ModifiedSerializedProperties: 0
   m_ValidKeywords: []
   m_InvalidKeywords: []
   m_LightmapFlags: 4
@@ -5739,6 +5747,7 @@ Material:
   m_CustomRenderQueue: -1
   stringTagMap: {}
   disabledShaderPasses: []
+  m_LockedProperties: 
   m_SavedProperties:
     serializedVersion: 3
     m_TexEnvs:
@@ -5834,3 +5843,4 @@ Material:
     - _SpecularColor: {r: 1, g: 1, b: 1, a: 1}
     - _UnderlayColor: {r: 0, g: 0, b: 0, a: 0.5}
   m_BuildTextureStacks: []
+  m_AllowLocking: 1

--- a/org.mixedrealitytoolkit.standardassets/Fonts/Selawik-Light-MRTKIcons Zwrite OnAtlas Material.mat
+++ b/org.mixedrealitytoolkit.standardassets/Fonts/Selawik-Light-MRTKIcons Zwrite OnAtlas Material.mat
@@ -9,6 +9,8 @@ Material:
   m_PrefabAsset: {fileID: 0}
   m_Name: Selawik-Light-MRTKIcons Zwrite OnAtlas Material
   m_Shader: {fileID: 4800000, guid: c5f3f59b19556b3479f929a84f25f776, type: 3}
+  m_Parent: {fileID: 0}
+  m_ModifiedSerializedProperties: 0
   m_ValidKeywords: []
   m_InvalidKeywords: []
   m_LightmapFlags: 4
@@ -17,6 +19,7 @@ Material:
   m_CustomRenderQueue: -1
   stringTagMap: {}
   disabledShaderPasses: []
+  m_LockedProperties: 
   m_SavedProperties:
     serializedVersion: 3
     m_TexEnvs:
@@ -107,3 +110,4 @@ Material:
     - _SpecularColor: {r: 1, g: 1, b: 1, a: 1}
     - _UnderlayColor: {r: 0, g: 0, b: 0, a: 0.5}
   m_BuildTextureStacks: []
+  m_AllowLocking: 1

--- a/org.mixedrealitytoolkit.standardassets/Fonts/Selawik-Regular-MRTKIcons SDF.asset
+++ b/org.mixedrealitytoolkit.standardassets/Fonts/Selawik-Regular-MRTKIcons SDF.asset
@@ -10,10 +10,8 @@ Texture2D:
   m_ImageContentsHash:
     serializedVersion: 2
     Hash: 00000000000000000000000000000000
-  m_ForcedFallbackFormat: 4
-  m_DownscaleFallback: 0
   m_IsAlphaChannelOptional: 0
-  serializedVersion: 2
+  serializedVersion: 3
   m_Width: 1024
   m_Height: 1024
   m_CompleteImageSize: 1048576
@@ -22,7 +20,8 @@ Texture2D:
   m_MipCount: 1
   m_IsReadable: 1
   m_IsPreProcessed: 0
-  m_IgnoreMasterTextureLimit: 0
+  m_IgnoreMipmapLimit: 0
+  m_MipmapLimitGroupName: 
   m_StreamingMipmaps: 0
   m_StreamingMipmapsPriority: 0
   m_VTOnly: 0
@@ -56,6 +55,8 @@ Material:
   m_PrefabAsset: {fileID: 0}
   m_Name: selawk Atlas Material
   m_Shader: {fileID: 4800000, guid: c5f3f59b19556b3479f929a84f25f776, type: 3}
+  m_Parent: {fileID: 0}
+  m_ModifiedSerializedProperties: 0
   m_ValidKeywords: []
   m_InvalidKeywords: []
   m_LightmapFlags: 4
@@ -64,6 +65,7 @@ Material:
   m_CustomRenderQueue: -1
   stringTagMap: {}
   disabledShaderPasses: []
+  m_LockedProperties: 
   m_SavedProperties:
     serializedVersion: 3
     m_TexEnvs:
@@ -159,6 +161,7 @@ Material:
     - _SpecularColor: {r: 1, g: 1, b: 1, a: 1}
     - _UnderlayColor: {r: 0, g: 0, b: 0, a: 0.5}
   m_BuildTextureStacks: []
+  m_AllowLocking: 1
 --- !u!114 &11400000
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -171,14 +174,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71c1514a6bd24e1e882cebbe1904ce04, type: 3}
   m_Name: Selawik-Regular-MRTKIcons SDF
   m_EditorClassIdentifier: 
-  hashCode: -2117870979
-  material: {fileID: -2049848100760321927}
-  materialHashCode: -137494339
   m_Version: 1.1.0
-  m_SourceFontFileGUID: c090e1a3263a6914693f828f80a9f953
-  m_SourceFontFile_EditorRef: {fileID: 12800000, guid: c090e1a3263a6914693f828f80a9f953, type: 3}
-  m_SourceFontFile: {fileID: 12800000, guid: c090e1a3263a6914693f828f80a9f953, type: 3}
-  m_AtlasPopulationMode: 1
   m_FaceInfo:
     m_FaceIndex: 0
     m_FamilyName: Selawik Regular MRTK Icons
@@ -201,6 +197,31 @@ MonoBehaviour:
     m_StrikethroughOffset: 13.6
     m_StrikethroughThickness: 1.7333984
     m_TabWidth: 19
+  m_Material: {fileID: -2049848100760321927}
+  m_SourceFontFileGUID: c090e1a3263a6914693f828f80a9f953
+  m_CreationSettings:
+    sourceFontFileName: 
+    sourceFontFileGUID: c090e1a3263a6914693f828f80a9f953
+    faceIndex: 0
+    pointSizeSamplingMode: 0
+    pointSize: 71
+    padding: 9
+    paddingMode: 0
+    packingMode: 0
+    atlasWidth: 1024
+    atlasHeight: 1024
+    characterSetSelectionMode: 6
+    characterSequence: 20-22,26-29,2C-37,3A-3B,3E,41-49,4B-50,52-59,5F,61-7A,2026,E80F,E818,E830,E840,E844-E845,E854,E874,E877-E878,E87D-E87F,E881-E885,E886-E887,E889,E88B-E88C,E9C6,EA49,EB43,EB4B,EBE6,F10A,F10D,F115,F119,F123,F125,F138,F13E,F140,F149,F15C,F169,F172,F182,F18B,F19C,F1AA,F1B5,F1DF,F1E3,F1F6,F20F,F214,F248,F255,F26B,F26D,F287,F295,F2A4,F2AB,F2B1,F2B7,F2D6,F2DE,F2E2,F2E5,F2F2,F2F6,F300,F315,F319,F320,F33B,F33D,F342,F345,F34D,F35A,F35F,F36A,F36E,F376,F379,F387,F3DB,F3DE,F3E1,F3F2,F40C,F419,F45B,F472,F47A,F47F,F481,F489,F4A0,F4A4,F4A8,F4B9,F4D7,F4E5,F4EC,F4F9,F507,F541,F557,F55A,F55F,F561,F566,F56C,F56F,F588,F58A,F5A9,F5AD,F5BE,F5E1,F5E6,F602,F604,F606,F608,F60F,F62B,F62E,F639,F662,F680,F690,F69A,F6AA,F710,F714,F75B,F77D,F81E,F820,F84D,F86A,F8D7,F8FE
+    referencedFontAssetGUID: fea6b26abeefbc547b6aca1dbda0a34d
+    referencedTextAssetGUID: 
+    fontStyle: 0
+    fontStyleModifier: 0
+    renderMode: 4165
+    includeFontFeatures: 0
+  m_SourceFontFile: {fileID: 12800000, guid: c090e1a3263a6914693f828f80a9f953, type: 3}
+  m_SourceFontFilePath: 
+  m_AtlasPopulationMode: 1
+  InternalDynamicOS: 0
   m_GlyphTable:
   - m_Index: 3
     m_Metrics:
@@ -4292,7 +4313,12 @@ MonoBehaviour:
   - {fileID: -2428600891616613165}
   m_AtlasTextureIndex: 0
   m_IsMultiAtlasTexturesEnabled: 0
+  m_GetFontFeatures: 1
   m_ClearDynamicDataOnBuild: 0
+  m_AtlasWidth: 1024
+  m_AtlasHeight: 1024
+  m_AtlasPadding: 9
+  m_AtlasRenderMode: 4165
   m_UsedGlyphRects:
   - m_X: 0
     m_Y: 0
@@ -5847,57 +5873,14 @@ MonoBehaviour:
     m_Y: 818
     m_Width: 26
     m_Height: 205
-  m_fontInfo:
-    Name: 
-    PointSize: 0
-    Scale: 0
-    CharacterCount: 0
-    LineHeight: 0
-    Baseline: 0
-    Ascender: 0
-    CapHeight: 0
-    Descender: 0
-    CenterLine: 0
-    SuperscriptOffset: 0
-    SubscriptOffset: 0
-    SubSize: 0
-    Underline: 0
-    UnderlineThickness: 0
-    strikethrough: 0
-    strikethroughThickness: 0
-    TabWidth: 0
-    Padding: 0
-    AtlasWidth: 0
-    AtlasHeight: 0
-  atlas: {fileID: 0}
-  m_AtlasWidth: 1024
-  m_AtlasHeight: 1024
-  m_AtlasPadding: 9
-  m_AtlasRenderMode: 4165
-  m_glyphInfoList: []
-  m_KerningTable:
-    kerningPairs: []
   m_FontFeatureTable:
+    m_MultipleSubstitutionRecords: []
+    m_LigatureSubstitutionRecords: []
     m_GlyphPairAdjustmentRecords: []
-  fallbackFontAssets: []
+    m_MarkToBaseAdjustmentRecords: []
+    m_MarkToMarkAdjustmentRecords: []
+  m_ShouldReimportFontFeatures: 0
   m_FallbackFontAssetTable: []
-  m_CreationSettings:
-    sourceFontFileName: 
-    sourceFontFileGUID: c090e1a3263a6914693f828f80a9f953
-    pointSizeSamplingMode: 0
-    pointSize: 71
-    padding: 9
-    packingMode: 0
-    atlasWidth: 1024
-    atlasHeight: 1024
-    characterSetSelectionMode: 6
-    characterSequence: 20-22,26-29,2C-37,3A-3B,3E,41-49,4B-50,52-59,5F,61-7A,2026,E80F,E818,E830,E840,E844-E845,E854,E874,E877-E878,E87D-E87F,E881-E885,E886-E887,E889,E88B-E88C,E9C6,EA49,EB43,EB4B,EBE6,F10A,F10D,F115,F119,F123,F125,F138,F13E,F140,F149,F15C,F169,F172,F182,F18B,F19C,F1AA,F1B5,F1DF,F1E3,F1F6,F20F,F214,F248,F255,F26B,F26D,F287,F295,F2A4,F2AB,F2B1,F2B7,F2D6,F2DE,F2E2,F2E5,F2F2,F2F6,F300,F315,F319,F320,F33B,F33D,F342,F345,F34D,F35A,F35F,F36A,F36E,F376,F379,F387,F3DB,F3DE,F3E1,F3F2,F40C,F419,F45B,F472,F47A,F47F,F481,F489,F4A0,F4A4,F4A8,F4B9,F4D7,F4E5,F4EC,F4F9,F507,F541,F557,F55A,F55F,F561,F566,F56C,F56F,F588,F58A,F5A9,F5AD,F5BE,F5E1,F5E6,F602,F604,F606,F608,F60F,F62B,F62E,F639,F662,F680,F690,F69A,F6AA,F710,F714,F75B,F77D,F81E,F820,F84D,F86A,F8D7,F8FE
-    referencedFontAssetGUID: fea6b26abeefbc547b6aca1dbda0a34d
-    referencedTextAssetGUID: 
-    fontStyle: 0
-    fontStyleModifier: 0
-    renderMode: 4165
-    includeFontFeatures: 0
   m_FontWeightTable:
   - regularTypeface: {fileID: 0}
     italicTypeface: {fileID: 0}
@@ -5926,3 +5909,30 @@ MonoBehaviour:
   boldSpacing: 7
   italicStyle: 35
   tabSize: 10
+  m_fontInfo:
+    Name: 
+    PointSize: 0
+    Scale: 0
+    CharacterCount: 0
+    LineHeight: 0
+    Baseline: 0
+    Ascender: 0
+    CapHeight: 0
+    Descender: 0
+    CenterLine: 0
+    SuperscriptOffset: 0
+    SubscriptOffset: 0
+    SubSize: 0
+    Underline: 0
+    UnderlineThickness: 0
+    strikethrough: 0
+    strikethroughThickness: 0
+    TabWidth: 0
+    Padding: 0
+    AtlasWidth: 0
+    AtlasHeight: 0
+  m_glyphInfoList: []
+  m_KerningTable:
+    kerningPairs: []
+  fallbackFontAssets: []
+  atlas: {fileID: 0}

--- a/org.mixedrealitytoolkit.standardassets/Fonts/Selawik-Regular-MRTKIcons ZWrite On Atlas Material.mat
+++ b/org.mixedrealitytoolkit.standardassets/Fonts/Selawik-Regular-MRTKIcons ZWrite On Atlas Material.mat
@@ -9,6 +9,8 @@ Material:
   m_PrefabAsset: {fileID: 0}
   m_Name: Selawik-Regular-MRTKIcons ZWrite On Atlas Material
   m_Shader: {fileID: 4800000, guid: c5f3f59b19556b3479f929a84f25f776, type: 3}
+  m_Parent: {fileID: 0}
+  m_ModifiedSerializedProperties: 0
   m_ValidKeywords: []
   m_InvalidKeywords: []
   m_LightmapFlags: 4
@@ -17,6 +19,7 @@ Material:
   m_CustomRenderQueue: -1
   stringTagMap: {}
   disabledShaderPasses: []
+  m_LockedProperties: 
   m_SavedProperties:
     serializedVersion: 3
     m_TexEnvs:
@@ -53,6 +56,8 @@ Material:
     - _ColorMask: 15
     - _CullMode: 0
     - _Diffuse: 0.5
+    - _DstBlend: 10
+    - _DstBlendAlpha: 1
     - _FaceDilate: 0
     - _FaceUVSpeedX: 0
     - _FaceUVSpeedY: 0
@@ -78,6 +83,8 @@ Material:
     - _ShaderFlags: 0
     - _Sharpness: 0
     - _SpecularPower: 2
+    - _SrcBlend: 1
+    - _SrcBlendAlpha: 1
     - _Stencil: 0
     - _StencilComp: 8
     - _StencilOp: 0
@@ -93,6 +100,7 @@ Material:
     - _VertexOffsetY: 0
     - _WeightBold: 0.75
     - _WeightNormal: 0
+    - _ZTest: 4
     - _ZWrite: 1
     m_Colors:
     - _ClipRect: {r: -32767, g: -32767, b: 32767, a: 32767}
@@ -107,3 +115,4 @@ Material:
     - _SpecularColor: {r: 1, g: 1, b: 1, a: 1}
     - _UnderlayColor: {r: 0, g: 0, b: 0, a: 0.5}
   m_BuildTextureStacks: []
+  m_AllowLocking: 1

--- a/org.mixedrealitytoolkit.standardassets/Fonts/Selawik-Semibold-MRTKIcons SDF.asset
+++ b/org.mixedrealitytoolkit.standardassets/Fonts/Selawik-Semibold-MRTKIcons SDF.asset
@@ -10,10 +10,8 @@ Texture2D:
   m_ImageContentsHash:
     serializedVersion: 2
     Hash: 00000000000000000000000000000000
-  m_ForcedFallbackFormat: 4
-  m_DownscaleFallback: 0
   m_IsAlphaChannelOptional: 0
-  serializedVersion: 2
+  serializedVersion: 3
   m_Width: 1024
   m_Height: 1024
   m_CompleteImageSize: 1048576
@@ -22,7 +20,8 @@ Texture2D:
   m_MipCount: 1
   m_IsReadable: 1
   m_IsPreProcessed: 0
-  m_IgnoreMasterTextureLimit: 0
+  m_IgnoreMipmapLimit: 0
+  m_MipmapLimitGroupName: 
   m_StreamingMipmaps: 0
   m_StreamingMipmapsPriority: 0
   m_VTOnly: 0
@@ -56,6 +55,8 @@ Material:
   m_PrefabAsset: {fileID: 0}
   m_Name: selawksb Atlas Material
   m_Shader: {fileID: 4800000, guid: c5f3f59b19556b3479f929a84f25f776, type: 3}
+  m_Parent: {fileID: 0}
+  m_ModifiedSerializedProperties: 0
   m_ValidKeywords:
   - _UI_CLIP_RECT_ROUNDED
   m_InvalidKeywords: []
@@ -65,6 +66,7 @@ Material:
   m_CustomRenderQueue: -1
   stringTagMap: {}
   disabledShaderPasses: []
+  m_LockedProperties: 
   m_SavedProperties:
     serializedVersion: 3
     m_TexEnvs:
@@ -160,6 +162,7 @@ Material:
     - _SpecularColor: {r: 1, g: 1, b: 1, a: 1}
     - _UnderlayColor: {r: 0, g: 0, b: 0, a: 0.5}
   m_BuildTextureStacks: []
+  m_AllowLocking: 1
 --- !u!114 &11400000
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -172,14 +175,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71c1514a6bd24e1e882cebbe1904ce04, type: 3}
   m_Name: Selawik-Semibold-MRTKIcons SDF
   m_EditorClassIdentifier: 
-  hashCode: 1696299344
-  material: {fileID: -1005824763306460071}
-  materialHashCode: 1110823792
   m_Version: 1.1.0
-  m_SourceFontFileGUID: 52767c1f1dd45304da1f49570e5e91ea
-  m_SourceFontFile_EditorRef: {fileID: 12800000, guid: 52767c1f1dd45304da1f49570e5e91ea, type: 3}
-  m_SourceFontFile: {fileID: 12800000, guid: 52767c1f1dd45304da1f49570e5e91ea, type: 3}
-  m_AtlasPopulationMode: 1
   m_FaceInfo:
     m_FaceIndex: 0
     m_FamilyName: Selawik
@@ -202,6 +198,31 @@ MonoBehaviour:
     m_StrikethroughOffset: 13.6
     m_StrikethroughThickness: 1.7089844
     m_TabWidth: 19
+  m_Material: {fileID: -1005824763306460071}
+  m_SourceFontFileGUID: 52767c1f1dd45304da1f49570e5e91ea
+  m_CreationSettings:
+    sourceFontFileName: 
+    sourceFontFileGUID: 52767c1f1dd45304da1f49570e5e91ea
+    faceIndex: 0
+    pointSizeSamplingMode: 0
+    pointSize: 70
+    padding: 9
+    paddingMode: 0
+    packingMode: 0
+    atlasWidth: 1024
+    atlasHeight: 1024
+    characterSetSelectionMode: 6
+    characterSequence: 20-22,26-29,2C-37,3A-3B,3E,41-49,4B-50,52-59,5F,61-7A,2026,E80F,E818,E830,E840,E844-E845,E854,E874,E877-E878,E87D-E87F,E881-E885,E886-E887,E889,E88B-E88C,E9C6,EA49,EB43,EB4B,EBE6,F10A,F10D,F115,F119,F123,F125,F138,F13E,F140,F149,F15C,F169,F172,F182,F18B,F19C,F1AA,F1B5,F1DF,F1E3,F1F6,F20F,F214,F248,F255,F26B,F26D,F287,F295,F2A4,F2AB,F2B1,F2B7,F2D6,F2DE,F2E2,F2E5,F2F2,F2F6,F300,F315,F319,F320,F33B,F33D,F342,F345,F34D,F35A,F35F,F36A,F36E,F376,F379,F387,F3DB,F3DE,F3E1,F3F2,F40C,F419,F45B,F472,F47A,F47F,F481,F489,F4A0,F4A4,F4A8,F4B9,F4D7,F4E5,F4EC,F4F9,F507,F541,F557,F55A,F55F,F561,F566,F56C,F56F,F588,F58A,F5A9,F5AD,F5BE,F5E1,F5E6,F602,F604,F606,F608,F60F,F62B,F62E,F639,F662,F680,F690,F69A,F6AA,F710,F714,F75B,F77D,F81E,F820,F84D,F86A,F8D7,F8FE
+    referencedFontAssetGUID: 533bdd8d5c92b52448ee2ecf7bd828a4
+    referencedTextAssetGUID: 
+    fontStyle: 0
+    fontStyleModifier: 0
+    renderMode: 4165
+    includeFontFeatures: 0
+  m_SourceFontFile: {fileID: 12800000, guid: 52767c1f1dd45304da1f49570e5e91ea, type: 3}
+  m_SourceFontFilePath: 
+  m_AtlasPopulationMode: 1
+  InternalDynamicOS: 0
   m_GlyphTable:
   - m_Index: 3
     m_Metrics:
@@ -4293,7 +4314,12 @@ MonoBehaviour:
   - {fileID: -8728667867636135718}
   m_AtlasTextureIndex: 0
   m_IsMultiAtlasTexturesEnabled: 0
+  m_GetFontFeatures: 1
   m_ClearDynamicDataOnBuild: 0
+  m_AtlasWidth: 1024
+  m_AtlasHeight: 1024
+  m_AtlasPadding: 9
+  m_AtlasRenderMode: 4165
   m_UsedGlyphRects:
   - m_X: 0
     m_Y: 0
@@ -5808,57 +5834,14 @@ MonoBehaviour:
     m_Y: 934
     m_Width: 88
     m_Height: 89
-  m_fontInfo:
-    Name: 
-    PointSize: 0
-    Scale: 0
-    CharacterCount: 0
-    LineHeight: 0
-    Baseline: 0
-    Ascender: 0
-    CapHeight: 0
-    Descender: 0
-    CenterLine: 0
-    SuperscriptOffset: 0
-    SubscriptOffset: 0
-    SubSize: 0
-    Underline: 0
-    UnderlineThickness: 0
-    strikethrough: 0
-    strikethroughThickness: 0
-    TabWidth: 0
-    Padding: 0
-    AtlasWidth: 0
-    AtlasHeight: 0
-  atlas: {fileID: 0}
-  m_AtlasWidth: 1024
-  m_AtlasHeight: 1024
-  m_AtlasPadding: 9
-  m_AtlasRenderMode: 4165
-  m_glyphInfoList: []
-  m_KerningTable:
-    kerningPairs: []
   m_FontFeatureTable:
+    m_MultipleSubstitutionRecords: []
+    m_LigatureSubstitutionRecords: []
     m_GlyphPairAdjustmentRecords: []
-  fallbackFontAssets: []
+    m_MarkToBaseAdjustmentRecords: []
+    m_MarkToMarkAdjustmentRecords: []
+  m_ShouldReimportFontFeatures: 0
   m_FallbackFontAssetTable: []
-  m_CreationSettings:
-    sourceFontFileName: 
-    sourceFontFileGUID: 52767c1f1dd45304da1f49570e5e91ea
-    pointSizeSamplingMode: 0
-    pointSize: 70
-    padding: 9
-    packingMode: 0
-    atlasWidth: 1024
-    atlasHeight: 1024
-    characterSetSelectionMode: 6
-    characterSequence: 20-22,26-29,2C-37,3A-3B,3E,41-49,4B-50,52-59,5F,61-7A,2026,E80F,E818,E830,E840,E844-E845,E854,E874,E877-E878,E87D-E87F,E881-E885,E886-E887,E889,E88B-E88C,E9C6,EA49,EB43,EB4B,EBE6,F10A,F10D,F115,F119,F123,F125,F138,F13E,F140,F149,F15C,F169,F172,F182,F18B,F19C,F1AA,F1B5,F1DF,F1E3,F1F6,F20F,F214,F248,F255,F26B,F26D,F287,F295,F2A4,F2AB,F2B1,F2B7,F2D6,F2DE,F2E2,F2E5,F2F2,F2F6,F300,F315,F319,F320,F33B,F33D,F342,F345,F34D,F35A,F35F,F36A,F36E,F376,F379,F387,F3DB,F3DE,F3E1,F3F2,F40C,F419,F45B,F472,F47A,F47F,F481,F489,F4A0,F4A4,F4A8,F4B9,F4D7,F4E5,F4EC,F4F9,F507,F541,F557,F55A,F55F,F561,F566,F56C,F56F,F588,F58A,F5A9,F5AD,F5BE,F5E1,F5E6,F602,F604,F606,F608,F60F,F62B,F62E,F639,F662,F680,F690,F69A,F6AA,F710,F714,F75B,F77D,F81E,F820,F84D,F86A,F8D7,F8FE
-    referencedFontAssetGUID: 533bdd8d5c92b52448ee2ecf7bd828a4
-    referencedTextAssetGUID: 
-    fontStyle: 0
-    fontStyleModifier: 0
-    renderMode: 4165
-    includeFontFeatures: 0
   m_FontWeightTable:
   - regularTypeface: {fileID: 0}
     italicTypeface: {fileID: 0}
@@ -5887,3 +5870,30 @@ MonoBehaviour:
   boldSpacing: 7
   italicStyle: 35
   tabSize: 10
+  m_fontInfo:
+    Name: 
+    PointSize: 0
+    Scale: 0
+    CharacterCount: 0
+    LineHeight: 0
+    Baseline: 0
+    Ascender: 0
+    CapHeight: 0
+    Descender: 0
+    CenterLine: 0
+    SuperscriptOffset: 0
+    SubscriptOffset: 0
+    SubSize: 0
+    Underline: 0
+    UnderlineThickness: 0
+    strikethrough: 0
+    strikethroughThickness: 0
+    TabWidth: 0
+    Padding: 0
+    AtlasWidth: 0
+    AtlasHeight: 0
+  m_glyphInfoList: []
+  m_KerningTable:
+    kerningPairs: []
+  fallbackFontAssets: []
+  atlas: {fileID: 0}

--- a/org.mixedrealitytoolkit.standardassets/Fonts/Selawik-Semibold-MRTKIcons Zwrite On Atlas Material.mat
+++ b/org.mixedrealitytoolkit.standardassets/Fonts/Selawik-Semibold-MRTKIcons Zwrite On Atlas Material.mat
@@ -9,6 +9,8 @@ Material:
   m_PrefabAsset: {fileID: 0}
   m_Name: Selawik-Semibold-MRTKIcons Zwrite On Atlas Material
   m_Shader: {fileID: 4800000, guid: c5f3f59b19556b3479f929a84f25f776, type: 3}
+  m_Parent: {fileID: 0}
+  m_ModifiedSerializedProperties: 0
   m_ValidKeywords: []
   m_InvalidKeywords: []
   m_LightmapFlags: 4
@@ -17,6 +19,7 @@ Material:
   m_CustomRenderQueue: -1
   stringTagMap: {}
   disabledShaderPasses: []
+  m_LockedProperties: 
   m_SavedProperties:
     serializedVersion: 3
     m_TexEnvs:
@@ -110,3 +113,4 @@ Material:
     - _SpecularColor: {r: 1, g: 1, b: 1, a: 1}
     - _UnderlayColor: {r: 0, g: 0, b: 0, a: 0.5}
   m_BuildTextureStacks: []
+  m_AllowLocking: 1

--- a/org.mixedrealitytoolkit.standardassets/Fonts/Selawik-Semilight-MRTKIcons SDF.asset
+++ b/org.mixedrealitytoolkit.standardassets/Fonts/Selawik-Semilight-MRTKIcons SDF.asset
@@ -10,10 +10,8 @@ Texture2D:
   m_ImageContentsHash:
     serializedVersion: 2
     Hash: 00000000000000000000000000000000
-  m_ForcedFallbackFormat: 4
-  m_DownscaleFallback: 0
   m_IsAlphaChannelOptional: 0
-  serializedVersion: 2
+  serializedVersion: 3
   m_Width: 1024
   m_Height: 1024
   m_CompleteImageSize: 1048576
@@ -22,7 +20,8 @@ Texture2D:
   m_MipCount: 1
   m_IsReadable: 1
   m_IsPreProcessed: 0
-  m_IgnoreMasterTextureLimit: 0
+  m_IgnoreMipmapLimit: 0
+  m_MipmapLimitGroupName: 
   m_StreamingMipmaps: 0
   m_StreamingMipmapsPriority: 0
   m_VTOnly: 0
@@ -59,14 +58,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71c1514a6bd24e1e882cebbe1904ce04, type: 3}
   m_Name: Selawik-Semilight-MRTKIcons SDF
   m_EditorClassIdentifier: 
-  hashCode: -1841123157
-  material: {fileID: 7186382491369329732}
-  materialHashCode: -1806114901
   m_Version: 1.1.0
-  m_SourceFontFileGUID: 18144349ca910ef40bd5e4487cadce52
-  m_SourceFontFile_EditorRef: {fileID: 12800000, guid: 18144349ca910ef40bd5e4487cadce52, type: 3}
-  m_SourceFontFile: {fileID: 12800000, guid: 18144349ca910ef40bd5e4487cadce52, type: 3}
-  m_AtlasPopulationMode: 1
   m_FaceInfo:
     m_FaceIndex: 0
     m_FamilyName: Selawik
@@ -89,6 +81,31 @@ MonoBehaviour:
     m_StrikethroughOffset: 13.6
     m_StrikethroughThickness: 1.7089844
     m_TabWidth: 19
+  m_Material: {fileID: 7186382491369329732}
+  m_SourceFontFileGUID: 18144349ca910ef40bd5e4487cadce52
+  m_CreationSettings:
+    sourceFontFileName: 
+    sourceFontFileGUID: 18144349ca910ef40bd5e4487cadce52
+    faceIndex: 0
+    pointSizeSamplingMode: 0
+    pointSize: 70
+    padding: 9
+    paddingMode: 0
+    packingMode: 0
+    atlasWidth: 1024
+    atlasHeight: 1024
+    characterSetSelectionMode: 6
+    characterSequence: 20-22,26-29,2C-37,3A-3B,3E,41-49,4B-50,52-59,5F,61-7A,2026,E80F,E818,E830,E840,E844-E845,E854,E874,E877-E878,E87D-E87F,E881-E885,E886-E887,E889,E88B-E88C,E9C6,EA49,EB43,EB4B,EBE6,F10A,F10D,F115,F119,F123,F125,F138,F13E,F140,F149,F15C,F169,F172,F182,F18B,F19C,F1AA,F1B5,F1DF,F1E3,F1F6,F20F,F214,F248,F255,F26B,F26D,F287,F295,F2A4,F2AB,F2B1,F2B7,F2D6,F2DE,F2E2,F2E5,F2F2,F2F6,F300,F315,F319,F320,F33B,F33D,F342,F345,F34D,F35A,F35F,F36A,F36E,F376,F379,F387,F3DB,F3DE,F3E1,F3F2,F40C,F419,F45B,F472,F47A,F47F,F481,F489,F4A0,F4A4,F4A8,F4B9,F4D7,F4E5,F4EC,F4F9,F507,F541,F557,F55A,F55F,F561,F566,F56C,F56F,F588,F58A,F5A9,F5AD,F5BE,F5E1,F5E6,F602,F604,F606,F608,F60F,F62B,F62E,F639,F662,F680,F690,F69A,F6AA,F710,F714,F75B,F77D,F81E,F820,F84D,F86A,F8D7,F8FE
+    referencedFontAssetGUID: b60f1b9e80ebdbd4dbabb1056b3d53e2
+    referencedTextAssetGUID: 
+    fontStyle: 0
+    fontStyleModifier: 0
+    renderMode: 4165
+    includeFontFeatures: 0
+  m_SourceFontFile: {fileID: 12800000, guid: 18144349ca910ef40bd5e4487cadce52, type: 3}
+  m_SourceFontFilePath: 
+  m_AtlasPopulationMode: 1
+  InternalDynamicOS: 0
   m_GlyphTable:
   - m_Index: 3
     m_Metrics:
@@ -4180,7 +4197,12 @@ MonoBehaviour:
   - {fileID: -2721606843106874022}
   m_AtlasTextureIndex: 0
   m_IsMultiAtlasTexturesEnabled: 0
+  m_GetFontFeatures: 1
   m_ClearDynamicDataOnBuild: 0
+  m_AtlasWidth: 1024
+  m_AtlasHeight: 1024
+  m_AtlasPadding: 9
+  m_AtlasRenderMode: 4165
   m_UsedGlyphRects:
   - m_X: 0
     m_Y: 0
@@ -5751,57 +5773,14 @@ MonoBehaviour:
     m_Y: 838
     m_Width: 84
     m_Height: 185
-  m_fontInfo:
-    Name: 
-    PointSize: 0
-    Scale: 0
-    CharacterCount: 0
-    LineHeight: 0
-    Baseline: 0
-    Ascender: 0
-    CapHeight: 0
-    Descender: 0
-    CenterLine: 0
-    SuperscriptOffset: 0
-    SubscriptOffset: 0
-    SubSize: 0
-    Underline: 0
-    UnderlineThickness: 0
-    strikethrough: 0
-    strikethroughThickness: 0
-    TabWidth: 0
-    Padding: 0
-    AtlasWidth: 0
-    AtlasHeight: 0
-  atlas: {fileID: 0}
-  m_AtlasWidth: 1024
-  m_AtlasHeight: 1024
-  m_AtlasPadding: 9
-  m_AtlasRenderMode: 4165
-  m_glyphInfoList: []
-  m_KerningTable:
-    kerningPairs: []
   m_FontFeatureTable:
+    m_MultipleSubstitutionRecords: []
+    m_LigatureSubstitutionRecords: []
     m_GlyphPairAdjustmentRecords: []
-  fallbackFontAssets: []
+    m_MarkToBaseAdjustmentRecords: []
+    m_MarkToMarkAdjustmentRecords: []
+  m_ShouldReimportFontFeatures: 0
   m_FallbackFontAssetTable: []
-  m_CreationSettings:
-    sourceFontFileName: 
-    sourceFontFileGUID: 18144349ca910ef40bd5e4487cadce52
-    pointSizeSamplingMode: 0
-    pointSize: 70
-    padding: 9
-    packingMode: 0
-    atlasWidth: 1024
-    atlasHeight: 1024
-    characterSetSelectionMode: 6
-    characterSequence: 20-22,26-29,2C-37,3A-3B,3E,41-49,4B-50,52-59,5F,61-7A,2026,E80F,E818,E830,E840,E844-E845,E854,E874,E877-E878,E87D-E87F,E881-E885,E886-E887,E889,E88B-E88C,E9C6,EA49,EB43,EB4B,EBE6,F10A,F10D,F115,F119,F123,F125,F138,F13E,F140,F149,F15C,F169,F172,F182,F18B,F19C,F1AA,F1B5,F1DF,F1E3,F1F6,F20F,F214,F248,F255,F26B,F26D,F287,F295,F2A4,F2AB,F2B1,F2B7,F2D6,F2DE,F2E2,F2E5,F2F2,F2F6,F300,F315,F319,F320,F33B,F33D,F342,F345,F34D,F35A,F35F,F36A,F36E,F376,F379,F387,F3DB,F3DE,F3E1,F3F2,F40C,F419,F45B,F472,F47A,F47F,F481,F489,F4A0,F4A4,F4A8,F4B9,F4D7,F4E5,F4EC,F4F9,F507,F541,F557,F55A,F55F,F561,F566,F56C,F56F,F588,F58A,F5A9,F5AD,F5BE,F5E1,F5E6,F602,F604,F606,F608,F60F,F62B,F62E,F639,F662,F680,F690,F69A,F6AA,F710,F714,F75B,F77D,F81E,F820,F84D,F86A,F8D7,F8FE
-    referencedFontAssetGUID: b60f1b9e80ebdbd4dbabb1056b3d53e2
-    referencedTextAssetGUID: 
-    fontStyle: 0
-    fontStyleModifier: 0
-    renderMode: 4165
-    includeFontFeatures: 0
   m_FontWeightTable:
   - regularTypeface: {fileID: 0}
     italicTypeface: {fileID: 0}
@@ -5830,6 +5809,33 @@ MonoBehaviour:
   boldSpacing: 7
   italicStyle: 35
   tabSize: 10
+  m_fontInfo:
+    Name: 
+    PointSize: 0
+    Scale: 0
+    CharacterCount: 0
+    LineHeight: 0
+    Baseline: 0
+    Ascender: 0
+    CapHeight: 0
+    Descender: 0
+    CenterLine: 0
+    SuperscriptOffset: 0
+    SubscriptOffset: 0
+    SubSize: 0
+    Underline: 0
+    UnderlineThickness: 0
+    strikethrough: 0
+    strikethroughThickness: 0
+    TabWidth: 0
+    Padding: 0
+    AtlasWidth: 0
+    AtlasHeight: 0
+  m_glyphInfoList: []
+  m_KerningTable:
+    kerningPairs: []
+  fallbackFontAssets: []
+  atlas: {fileID: 0}
 --- !u!21 &7186382491369329732
 Material:
   serializedVersion: 8
@@ -5839,6 +5845,8 @@ Material:
   m_PrefabAsset: {fileID: 0}
   m_Name: selawksl Atlas Material
   m_Shader: {fileID: 4800000, guid: c5f3f59b19556b3479f929a84f25f776, type: 3}
+  m_Parent: {fileID: 0}
+  m_ModifiedSerializedProperties: 0
   m_ValidKeywords: []
   m_InvalidKeywords: []
   m_LightmapFlags: 4
@@ -5847,6 +5855,7 @@ Material:
   m_CustomRenderQueue: -1
   stringTagMap: {}
   disabledShaderPasses: []
+  m_LockedProperties: 
   m_SavedProperties:
     serializedVersion: 3
     m_TexEnvs:
@@ -5942,3 +5951,4 @@ Material:
     - _SpecularColor: {r: 1, g: 1, b: 1, a: 1}
     - _UnderlayColor: {r: 0, g: 0, b: 0, a: 0.5}
   m_BuildTextureStacks: []
+  m_AllowLocking: 1

--- a/org.mixedrealitytoolkit.standardassets/Fonts/Selawik-Semilight-MRTKIcons Zwrite On Atlas Material.mat
+++ b/org.mixedrealitytoolkit.standardassets/Fonts/Selawik-Semilight-MRTKIcons Zwrite On Atlas Material.mat
@@ -9,6 +9,8 @@ Material:
   m_PrefabAsset: {fileID: 0}
   m_Name: Selawik-Semilight-MRTKIcons Zwrite On Atlas Material
   m_Shader: {fileID: 4800000, guid: c5f3f59b19556b3479f929a84f25f776, type: 3}
+  m_Parent: {fileID: 0}
+  m_ModifiedSerializedProperties: 0
   m_ValidKeywords: []
   m_InvalidKeywords: []
   m_LightmapFlags: 4
@@ -17,6 +19,7 @@ Material:
   m_CustomRenderQueue: -1
   stringTagMap: {}
   disabledShaderPasses: []
+  m_LockedProperties: 
   m_SavedProperties:
     serializedVersion: 3
     m_TexEnvs:
@@ -107,3 +110,4 @@ Material:
     - _SpecularColor: {r: 1, g: 1, b: 1, a: 1}
     - _UnderlayColor: {r: 0, g: 0, b: 0, a: 0.5}
   m_BuildTextureStacks: []
+  m_AllowLocking: 1

--- a/org.mixedrealitytoolkit.standardassets/Icons/MRTK_FluentIconSet SDF.asset
+++ b/org.mixedrealitytoolkit.standardassets/Icons/MRTK_FluentIconSet SDF.asset
@@ -10,10 +10,8 @@ Texture2D:
   m_ImageContentsHash:
     serializedVersion: 2
     Hash: 00000000000000000000000000000000
-  m_ForcedFallbackFormat: 4
-  m_DownscaleFallback: 0
   m_IsAlphaChannelOptional: 0
-  serializedVersion: 2
+  serializedVersion: 3
   m_Width: 512
   m_Height: 512
   m_CompleteImageSize: 262144
@@ -22,7 +20,8 @@ Texture2D:
   m_MipCount: 1
   m_IsReadable: 0
   m_IsPreProcessed: 0
-  m_IgnoreMasterTextureLimit: 0
+  m_IgnoreMipmapLimit: 0
+  m_MipmapLimitGroupName: 
   m_StreamingMipmaps: 0
   m_StreamingMipmapsPriority: 0
   m_VTOnly: 0
@@ -59,14 +58,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71c1514a6bd24e1e882cebbe1904ce04, type: 3}
   m_Name: MRTK_FluentIconSet SDF
   m_EditorClassIdentifier: 
-  hashCode: -118877881
-  material: {fileID: 5762245003366665926}
-  materialHashCode: 1087983367
   m_Version: 1.1.0
-  m_SourceFontFileGUID: 4929ff692260df04a9e9e226ad81984a
-  m_SourceFontFile_EditorRef: {fileID: 12800000, guid: 4929ff692260df04a9e9e226ad81984a, type: 3}
-  m_SourceFontFile: {fileID: 0}
-  m_AtlasPopulationMode: 0
   m_FaceInfo:
     m_FaceIndex: 0
     m_FamilyName: FluentSystemIcons
@@ -89,6 +81,31 @@ MonoBehaviour:
     m_StrikethroughOffset: 0
     m_StrikethroughThickness: 0
     m_TabWidth: 0
+  m_Material: {fileID: 5762245003366665926}
+  m_SourceFontFileGUID: 4929ff692260df04a9e9e226ad81984a
+  m_CreationSettings:
+    sourceFontFileName: 
+    sourceFontFileGUID: 4929ff692260df04a9e9e226ad81984a
+    faceIndex: 0
+    pointSizeSamplingMode: 0
+    pointSize: 39
+    padding: 5
+    paddingMode: 0
+    packingMode: 4
+    atlasWidth: 512
+    atlasHeight: 512
+    characterSetSelectionMode: 6
+    characterSequence: 005f,e800-f8fe
+    referencedFontAssetGUID: 
+    referencedTextAssetGUID: 
+    fontStyle: 0
+    fontStyleModifier: 0
+    renderMode: 4165
+    includeFontFeatures: 0
+  m_SourceFontFile: {fileID: 0}
+  m_SourceFontFilePath: 
+  m_AtlasPopulationMode: 0
+  InternalDynamicOS: 0
   m_GlyphTable:
   - m_Index: 3
     m_Metrics:
@@ -2812,7 +2829,12 @@ MonoBehaviour:
   - {fileID: -6544752470152419586}
   m_AtlasTextureIndex: 0
   m_IsMultiAtlasTexturesEnabled: 0
+  m_GetFontFeatures: 1
   m_ClearDynamicDataOnBuild: 0
+  m_AtlasWidth: 512
+  m_AtlasHeight: 512
+  m_AtlasPadding: 5
+  m_AtlasRenderMode: 4165
   m_UsedGlyphRects:
   - m_X: 0
     m_Y: 0
@@ -3707,57 +3729,14 @@ MonoBehaviour:
     m_Y: 469
     m_Width: 6
     m_Height: 3
-  m_fontInfo:
-    Name: 
-    PointSize: 0
-    Scale: 0
-    CharacterCount: 0
-    LineHeight: 0
-    Baseline: 0
-    Ascender: 0
-    CapHeight: 0
-    Descender: 0
-    CenterLine: 0
-    SuperscriptOffset: 0
-    SubscriptOffset: 0
-    SubSize: 0
-    Underline: 0
-    UnderlineThickness: 0
-    strikethrough: 0
-    strikethroughThickness: 0
-    TabWidth: 0
-    Padding: 0
-    AtlasWidth: 0
-    AtlasHeight: 0
-  atlas: {fileID: 0}
-  m_AtlasWidth: 512
-  m_AtlasHeight: 512
-  m_AtlasPadding: 5
-  m_AtlasRenderMode: 4165
-  m_glyphInfoList: []
-  m_KerningTable:
-    kerningPairs: []
   m_FontFeatureTable:
+    m_MultipleSubstitutionRecords: []
+    m_LigatureSubstitutionRecords: []
     m_GlyphPairAdjustmentRecords: []
-  fallbackFontAssets: []
+    m_MarkToBaseAdjustmentRecords: []
+    m_MarkToMarkAdjustmentRecords: []
+  m_ShouldReimportFontFeatures: 0
   m_FallbackFontAssetTable: []
-  m_CreationSettings:
-    sourceFontFileName: 
-    sourceFontFileGUID: 4929ff692260df04a9e9e226ad81984a
-    pointSizeSamplingMode: 0
-    pointSize: 39
-    padding: 5
-    packingMode: 4
-    atlasWidth: 512
-    atlasHeight: 512
-    characterSetSelectionMode: 6
-    characterSequence: 005f,e800-f8fe
-    referencedFontAssetGUID: 
-    referencedTextAssetGUID: 
-    fontStyle: 0
-    fontStyleModifier: 0
-    renderMode: 4165
-    includeFontFeatures: 0
   m_FontWeightTable:
   - regularTypeface: {fileID: 0}
     italicTypeface: {fileID: 0}
@@ -3786,6 +3765,33 @@ MonoBehaviour:
   boldSpacing: 7
   italicStyle: 35
   tabSize: 10
+  m_fontInfo:
+    Name: 
+    PointSize: 0
+    Scale: 0
+    CharacterCount: 0
+    LineHeight: 0
+    Baseline: 0
+    Ascender: 0
+    CapHeight: 0
+    Descender: 0
+    CenterLine: 0
+    SuperscriptOffset: 0
+    SubscriptOffset: 0
+    SubSize: 0
+    Underline: 0
+    UnderlineThickness: 0
+    strikethrough: 0
+    strikethroughThickness: 0
+    TabWidth: 0
+    Padding: 0
+    AtlasWidth: 0
+    AtlasHeight: 0
+  m_glyphInfoList: []
+  m_KerningTable:
+    kerningPairs: []
+  fallbackFontAssets: []
+  atlas: {fileID: 0}
 --- !u!21 &5762245003366665926
 Material:
   serializedVersion: 8
@@ -3795,6 +3801,8 @@ Material:
   m_PrefabAsset: {fileID: 0}
   m_Name: MRTK_FluentIconSet SDF Material
   m_Shader: {fileID: 4800000, guid: c5f3f59b19556b3479f929a84f25f776, type: 3}
+  m_Parent: {fileID: 0}
+  m_ModifiedSerializedProperties: 0
   m_ValidKeywords: []
   m_InvalidKeywords: []
   m_LightmapFlags: 4
@@ -3803,6 +3811,7 @@ Material:
   m_CustomRenderQueue: -1
   stringTagMap: {}
   disabledShaderPasses: []
+  m_LockedProperties: 
   m_SavedProperties:
     serializedVersion: 3
     m_TexEnvs:
@@ -3898,3 +3907,4 @@ Material:
     - _SpecularColor: {r: 1, g: 1, b: 1, a: 1}
     - _UnderlayColor: {r: 0, g: 0, b: 0, a: 0.5}
   m_BuildTextureStacks: []
+  m_AllowLocking: 1

--- a/org.mixedrealitytoolkit.standardassets/Models/MRTK_BoundingBox_RotateHandle.fbx.meta
+++ b/org.mixedrealitytoolkit.standardassets/Models/MRTK_BoundingBox_RotateHandle.fbx.meta
@@ -1,7 +1,7 @@
 fileFormatVersion: 2
 guid: a07e092f2328f7a4abe1dce46bb28386
 ModelImporter:
-  serializedVersion: 20200
+  serializedVersion: 22200
   internalIDToNameTable: []
   externalObjects: {}
   materials:
@@ -14,9 +14,8 @@ ModelImporter:
     bakeSimulation: 0
     resampleCurves: 1
     optimizeGameObjects: 0
+    removeConstantScaleCurves: 0
     motionNodeName: 
-    rigImportErrors: 
-    rigImportWarnings: 
     animationImportErrors: 
     animationImportWarnings: 
     animationRetargetingWarnings: 
@@ -39,10 +38,12 @@ ModelImporter:
     addColliders: 0
     useSRGBMaterialColor: 1
     sortHierarchyByName: 1
+    importPhysicalCameras: 1
     importVisibility: 1
     importBlendShapes: 1
     importCameras: 1
     importLights: 1
+    nodeNameCollisionStrategy: 0
     fileIdsGeneration: 2
     swapUVChannels: 0
     generateSecondaryUV: 0
@@ -54,6 +55,7 @@ ModelImporter:
     skinWeightsMode: 0
     maxBonesPerVertex: 4
     minBoneWeight: 0.001
+    optimizeBones: 1
     meshOptimizationFlags: -1
     indexFormat: 0
     secondaryUVAngleDistortion: 8
@@ -64,6 +66,7 @@ ModelImporter:
     secondaryUVMinObjectScale: 1
     secondaryUVPackMargin: 4
     useFileScale: 1
+    strictVertexDataChecks: 0
   tangentSpace:
     normalSmoothAngle: 60
     normalImportMode: 0
@@ -96,6 +99,8 @@ ModelImporter:
   humanoidOversampling: 1
   avatarSetup: 0
   addHumanoidExtraRootOnlyWhenUsingAvatar: 1
+  importBlendShapeDeformPercent: 0
+  remapMaterialsIfMaterialImportModeIsNone: 1
   additionalBone: 0
   userData: 
   assetBundleName: 

--- a/org.mixedrealitytoolkit.standardassets/Models/MRTK_BoundingBox_ScaleHandle.fbx.meta
+++ b/org.mixedrealitytoolkit.standardassets/Models/MRTK_BoundingBox_ScaleHandle.fbx.meta
@@ -1,7 +1,7 @@
 fileFormatVersion: 2
 guid: 0989b5f23ddbb124b92edd40ddd6f326
 ModelImporter:
-  serializedVersion: 20200
+  serializedVersion: 22200
   internalIDToNameTable: []
   externalObjects: {}
   materials:
@@ -14,9 +14,8 @@ ModelImporter:
     bakeSimulation: 0
     resampleCurves: 1
     optimizeGameObjects: 0
+    removeConstantScaleCurves: 0
     motionNodeName: 
-    rigImportErrors: 
-    rigImportWarnings: 
     animationImportErrors: 
     animationImportWarnings: 
     animationRetargetingWarnings: 
@@ -39,10 +38,12 @@ ModelImporter:
     addColliders: 0
     useSRGBMaterialColor: 1
     sortHierarchyByName: 1
+    importPhysicalCameras: 1
     importVisibility: 1
     importBlendShapes: 1
     importCameras: 1
     importLights: 1
+    nodeNameCollisionStrategy: 0
     fileIdsGeneration: 2
     swapUVChannels: 0
     generateSecondaryUV: 0
@@ -54,6 +55,7 @@ ModelImporter:
     skinWeightsMode: 0
     maxBonesPerVertex: 4
     minBoneWeight: 0.001
+    optimizeBones: 1
     meshOptimizationFlags: -1
     indexFormat: 0
     secondaryUVAngleDistortion: 8
@@ -64,6 +66,7 @@ ModelImporter:
     secondaryUVMinObjectScale: 1
     secondaryUVPackMargin: 4
     useFileScale: 1
+    strictVertexDataChecks: 0
   tangentSpace:
     normalSmoothAngle: 60
     normalImportMode: 0
@@ -96,6 +99,8 @@ ModelImporter:
   humanoidOversampling: 1
   avatarSetup: 0
   addHumanoidExtraRootOnlyWhenUsingAvatar: 1
+  importBlendShapeDeformPercent: 0
+  remapMaterialsIfMaterialImportModeIsNone: 1
   additionalBone: 0
   userData: 
   assetBundleName: 

--- a/org.mixedrealitytoolkit.standardassets/Models/MRTK_BoundingBox_ScaleHandle_Slate.fbx.meta
+++ b/org.mixedrealitytoolkit.standardassets/Models/MRTK_BoundingBox_ScaleHandle_Slate.fbx.meta
@@ -1,7 +1,7 @@
 fileFormatVersion: 2
 guid: 5dfeada92ad6cbf42981059538d03d87
 ModelImporter:
-  serializedVersion: 20200
+  serializedVersion: 22200
   internalIDToNameTable: []
   externalObjects: {}
   materials:
@@ -14,9 +14,8 @@ ModelImporter:
     bakeSimulation: 0
     resampleCurves: 1
     optimizeGameObjects: 0
+    removeConstantScaleCurves: 0
     motionNodeName: 
-    rigImportErrors: 
-    rigImportWarnings: 
     animationImportErrors: 
     animationImportWarnings: 
     animationRetargetingWarnings: 
@@ -39,10 +38,12 @@ ModelImporter:
     addColliders: 0
     useSRGBMaterialColor: 1
     sortHierarchyByName: 1
+    importPhysicalCameras: 1
     importVisibility: 1
     importBlendShapes: 1
     importCameras: 1
     importLights: 1
+    nodeNameCollisionStrategy: 0
     fileIdsGeneration: 2
     swapUVChannels: 0
     generateSecondaryUV: 0
@@ -54,6 +55,7 @@ ModelImporter:
     skinWeightsMode: 0
     maxBonesPerVertex: 4
     minBoneWeight: 0.001
+    optimizeBones: 1
     meshOptimizationFlags: -1
     indexFormat: 0
     secondaryUVAngleDistortion: 8
@@ -64,6 +66,7 @@ ModelImporter:
     secondaryUVMinObjectScale: 1
     secondaryUVPackMargin: 4
     useFileScale: 1
+    strictVertexDataChecks: 0
   tangentSpace:
     normalSmoothAngle: 60
     normalImportMode: 0
@@ -96,6 +99,8 @@ ModelImporter:
   humanoidOversampling: 1
   avatarSetup: 0
   addHumanoidExtraRootOnlyWhenUsingAvatar: 1
+  importBlendShapeDeformPercent: 0
+  remapMaterialsIfMaterialImportModeIsNone: 1
   additionalBone: 0
   userData: 
   assetBundleName: 

--- a/org.mixedrealitytoolkit.standardassets/Models/MRTK_BoundingBox_TranslateHandle.fbx.meta
+++ b/org.mixedrealitytoolkit.standardassets/Models/MRTK_BoundingBox_TranslateHandle.fbx.meta
@@ -1,7 +1,7 @@
 fileFormatVersion: 2
 guid: 6241bb4be90fdb446815078d56b9111f
 ModelImporter:
-  serializedVersion: 20200
+  serializedVersion: 22200
   internalIDToNameTable: []
   externalObjects: {}
   materials:
@@ -14,9 +14,8 @@ ModelImporter:
     bakeSimulation: 0
     resampleCurves: 1
     optimizeGameObjects: 0
+    removeConstantScaleCurves: 0
     motionNodeName: 
-    rigImportErrors: 
-    rigImportWarnings: 
     animationImportErrors: 
     animationImportWarnings: 
     animationRetargetingWarnings: 
@@ -39,10 +38,12 @@ ModelImporter:
     addColliders: 0
     useSRGBMaterialColor: 1
     sortHierarchyByName: 1
+    importPhysicalCameras: 1
     importVisibility: 1
     importBlendShapes: 1
     importCameras: 1
     importLights: 1
+    nodeNameCollisionStrategy: 0
     fileIdsGeneration: 2
     swapUVChannels: 0
     generateSecondaryUV: 0
@@ -54,6 +55,7 @@ ModelImporter:
     skinWeightsMode: 0
     maxBonesPerVertex: 4
     minBoneWeight: 0.001
+    optimizeBones: 1
     meshOptimizationFlags: -1
     indexFormat: 0
     secondaryUVAngleDistortion: 8
@@ -64,6 +66,7 @@ ModelImporter:
     secondaryUVMinObjectScale: 1
     secondaryUVPackMargin: 4
     useFileScale: 1
+    strictVertexDataChecks: 0
   tangentSpace:
     normalSmoothAngle: 60
     normalImportMode: 0
@@ -96,6 +99,8 @@ ModelImporter:
   humanoidOversampling: 1
   avatarSetup: 0
   addHumanoidExtraRootOnlyWhenUsingAvatar: 1
+  importBlendShapeDeformPercent: 0
+  remapMaterialsIfMaterialImportModeIsNone: 1
   additionalBone: 0
   userData: 
   assetBundleName: 

--- a/org.mixedrealitytoolkit.standardassets/Models/MRTK_UIBackplate.fbx.meta
+++ b/org.mixedrealitytoolkit.standardassets/Models/MRTK_UIBackplate.fbx.meta
@@ -1,7 +1,7 @@
 fileFormatVersion: 2
 guid: fbc47027e54e49848fdfd6d5e20510e7
 ModelImporter:
-  serializedVersion: 21300
+  serializedVersion: 22200
   internalIDToNameTable:
   - first:
       1: 100000
@@ -34,8 +34,6 @@ ModelImporter:
     optimizeGameObjects: 0
     removeConstantScaleCurves: 0
     motionNodeName: 
-    rigImportErrors: 
-    rigImportWarnings: 
     animationImportErrors: 
     animationImportWarnings: 
     animationRetargetingWarnings: 
@@ -58,6 +56,7 @@ ModelImporter:
     addColliders: 0
     useSRGBMaterialColor: 1
     sortHierarchyByName: 1
+    importPhysicalCameras: 1
     importVisibility: 1
     importBlendShapes: 1
     importCameras: 1
@@ -85,6 +84,7 @@ ModelImporter:
     secondaryUVMinObjectScale: 1
     secondaryUVPackMargin: 4
     useFileScale: 1
+    strictVertexDataChecks: 0
   tangentSpace:
     normalSmoothAngle: 60
     normalImportMode: 0
@@ -117,6 +117,7 @@ ModelImporter:
   humanoidOversampling: 1
   avatarSetup: 0
   addHumanoidExtraRootOnlyWhenUsingAvatar: 0
+  importBlendShapeDeformPercent: 0
   remapMaterialsIfMaterialImportModeIsNone: 1
   additionalBone: 0
   userData: 

--- a/org.mixedrealitytoolkit.standardassets/Models/MagicWindow_190x62.fbx.meta
+++ b/org.mixedrealitytoolkit.standardassets/Models/MagicWindow_190x62.fbx.meta
@@ -1,7 +1,7 @@
 fileFormatVersion: 2
 guid: 5956447e821b856469f9f20caa08e3c2
 ModelImporter:
-  serializedVersion: 20200
+  serializedVersion: 22200
   internalIDToNameTable: []
   externalObjects: {}
   materials:
@@ -14,9 +14,8 @@ ModelImporter:
     bakeSimulation: 0
     resampleCurves: 1
     optimizeGameObjects: 0
+    removeConstantScaleCurves: 0
     motionNodeName: 
-    rigImportErrors: 
-    rigImportWarnings: 
     animationImportErrors: 
     animationImportWarnings: 
     animationRetargetingWarnings: 
@@ -39,10 +38,12 @@ ModelImporter:
     addColliders: 0
     useSRGBMaterialColor: 1
     sortHierarchyByName: 1
+    importPhysicalCameras: 1
     importVisibility: 1
     importBlendShapes: 1
     importCameras: 1
     importLights: 1
+    nodeNameCollisionStrategy: 0
     fileIdsGeneration: 2
     swapUVChannels: 0
     generateSecondaryUV: 0
@@ -54,6 +55,7 @@ ModelImporter:
     skinWeightsMode: 0
     maxBonesPerVertex: 4
     minBoneWeight: 0.001
+    optimizeBones: 1
     meshOptimizationFlags: -1
     indexFormat: 0
     secondaryUVAngleDistortion: 8
@@ -64,6 +66,7 @@ ModelImporter:
     secondaryUVMinObjectScale: 1
     secondaryUVPackMargin: 4
     useFileScale: 1
+    strictVertexDataChecks: 0
   tangentSpace:
     normalSmoothAngle: 60
     normalImportMode: 0
@@ -96,6 +99,8 @@ ModelImporter:
   humanoidOversampling: 1
   avatarSetup: 0
   addHumanoidExtraRootOnlyWhenUsingAvatar: 1
+  importBlendShapeDeformPercent: 0
+  remapMaterialsIfMaterialImportModeIsNone: 1
   additionalBone: 0
   userData: 
   assetBundleName: 

--- a/org.mixedrealitytoolkit.standardassets/Models/Rounded_Bound12.fbx.meta
+++ b/org.mixedrealitytoolkit.standardassets/Models/Rounded_Bound12.fbx.meta
@@ -1,7 +1,7 @@
 fileFormatVersion: 2
 guid: a156e896c3dcba241befc3f0e7385b84
 ModelImporter:
-  serializedVersion: 20200
+  serializedVersion: 22200
   internalIDToNameTable: []
   externalObjects: {}
   materials:
@@ -14,9 +14,8 @@ ModelImporter:
     bakeSimulation: 0
     resampleCurves: 1
     optimizeGameObjects: 0
+    removeConstantScaleCurves: 0
     motionNodeName: 
-    rigImportErrors: 
-    rigImportWarnings: 
     animationImportErrors: 
     animationImportWarnings: 
     animationRetargetingWarnings: 
@@ -39,10 +38,12 @@ ModelImporter:
     addColliders: 0
     useSRGBMaterialColor: 1
     sortHierarchyByName: 1
+    importPhysicalCameras: 1
     importVisibility: 1
     importBlendShapes: 1
     importCameras: 1
     importLights: 1
+    nodeNameCollisionStrategy: 0
     fileIdsGeneration: 2
     swapUVChannels: 0
     generateSecondaryUV: 0
@@ -54,6 +55,7 @@ ModelImporter:
     skinWeightsMode: 0
     maxBonesPerVertex: 4
     minBoneWeight: 0.001
+    optimizeBones: 1
     meshOptimizationFlags: -1
     indexFormat: 0
     secondaryUVAngleDistortion: 8
@@ -64,6 +66,7 @@ ModelImporter:
     secondaryUVMinObjectScale: 1
     secondaryUVPackMargin: 4
     useFileScale: 1
+    strictVertexDataChecks: 0
   tangentSpace:
     normalSmoothAngle: 60
     normalImportMode: 0
@@ -96,6 +99,8 @@ ModelImporter:
   humanoidOversampling: 1
   avatarSetup: 0
   addHumanoidExtraRootOnlyWhenUsingAvatar: 1
+  importBlendShapeDeformPercent: 0
+  remapMaterialsIfMaterialImportModeIsNone: 1
   additionalBone: 0
   userData: 
   assetBundleName: 

--- a/org.mixedrealitytoolkit.standardassets/Models/Rounded_Button8.fbx.meta
+++ b/org.mixedrealitytoolkit.standardassets/Models/Rounded_Button8.fbx.meta
@@ -1,7 +1,7 @@
 fileFormatVersion: 2
 guid: 817117ab22c8d33418218d97ff6c9774
 ModelImporter:
-  serializedVersion: 21300
+  serializedVersion: 22200
   internalIDToNameTable: []
   externalObjects: {}
   materials:
@@ -16,8 +16,6 @@ ModelImporter:
     optimizeGameObjects: 0
     removeConstantScaleCurves: 0
     motionNodeName: 
-    rigImportErrors: 
-    rigImportWarnings: 
     animationImportErrors: 
     animationImportWarnings: 
     animationRetargetingWarnings: 
@@ -40,6 +38,7 @@ ModelImporter:
     addColliders: 0
     useSRGBMaterialColor: 1
     sortHierarchyByName: 1
+    importPhysicalCameras: 1
     importVisibility: 1
     importBlendShapes: 1
     importCameras: 1
@@ -67,6 +66,7 @@ ModelImporter:
     secondaryUVMinObjectScale: 1
     secondaryUVPackMargin: 4
     useFileScale: 1
+    strictVertexDataChecks: 0
   tangentSpace:
     normalSmoothAngle: 60
     normalImportMode: 0
@@ -99,6 +99,7 @@ ModelImporter:
   humanoidOversampling: 1
   avatarSetup: 0
   addHumanoidExtraRootOnlyWhenUsingAvatar: 0
+  importBlendShapeDeformPercent: 0
   remapMaterialsIfMaterialImportModeIsNone: 1
   additionalBone: 0
   userData: 

--- a/org.mixedrealitytoolkit.standardassets/Models/thick_4x4.fbx.meta
+++ b/org.mixedrealitytoolkit.standardassets/Models/thick_4x4.fbx.meta
@@ -1,7 +1,7 @@
 fileFormatVersion: 2
 guid: 350ca4e076aa4fbf9531e1a12bd1529e
 ModelImporter:
-  serializedVersion: 21300
+  serializedVersion: 22200
   internalIDToNameTable:
   - first:
       1: 100000
@@ -34,8 +34,6 @@ ModelImporter:
     optimizeGameObjects: 0
     removeConstantScaleCurves: 0
     motionNodeName: 
-    rigImportErrors: 
-    rigImportWarnings: 
     animationImportErrors: 
     animationImportWarnings: 
     animationRetargetingWarnings: 
@@ -58,6 +56,7 @@ ModelImporter:
     addColliders: 0
     useSRGBMaterialColor: 1
     sortHierarchyByName: 1
+    importPhysicalCameras: 1
     importVisibility: 1
     importBlendShapes: 1
     importCameras: 1
@@ -85,6 +84,7 @@ ModelImporter:
     secondaryUVMinObjectScale: 1
     secondaryUVPackMargin: 4
     useFileScale: 1
+    strictVertexDataChecks: 0
   tangentSpace:
     normalSmoothAngle: 60
     normalImportMode: 0
@@ -117,6 +117,7 @@ ModelImporter:
   humanoidOversampling: 1
   avatarSetup: 0
   addHumanoidExtraRootOnlyWhenUsingAvatar: 0
+  importBlendShapeDeformPercent: 0
   remapMaterialsIfMaterialImportModeIsNone: 1
   additionalBone: 0
   userData: 

--- a/org.mixedrealitytoolkit.standardassets/Models/thick_6x6.fbx.meta
+++ b/org.mixedrealitytoolkit.standardassets/Models/thick_6x6.fbx.meta
@@ -1,7 +1,7 @@
 fileFormatVersion: 2
 guid: 05123a8b693b9134d8918ad90d864c0b
 ModelImporter:
-  serializedVersion: 20200
+  serializedVersion: 22200
   internalIDToNameTable: []
   externalObjects: {}
   materials:
@@ -14,9 +14,8 @@ ModelImporter:
     bakeSimulation: 0
     resampleCurves: 1
     optimizeGameObjects: 0
+    removeConstantScaleCurves: 0
     motionNodeName: 
-    rigImportErrors: 
-    rigImportWarnings: 
     animationImportErrors: 
     animationImportWarnings: 
     animationRetargetingWarnings: 
@@ -39,10 +38,12 @@ ModelImporter:
     addColliders: 0
     useSRGBMaterialColor: 1
     sortHierarchyByName: 1
+    importPhysicalCameras: 1
     importVisibility: 1
     importBlendShapes: 1
     importCameras: 1
     importLights: 1
+    nodeNameCollisionStrategy: 0
     fileIdsGeneration: 2
     swapUVChannels: 0
     generateSecondaryUV: 0
@@ -54,6 +55,7 @@ ModelImporter:
     skinWeightsMode: 0
     maxBonesPerVertex: 4
     minBoneWeight: 0.001
+    optimizeBones: 1
     meshOptimizationFlags: -1
     indexFormat: 0
     secondaryUVAngleDistortion: 8
@@ -64,6 +66,7 @@ ModelImporter:
     secondaryUVMinObjectScale: 1
     secondaryUVPackMargin: 4
     useFileScale: 1
+    strictVertexDataChecks: 0
   tangentSpace:
     normalSmoothAngle: 60
     normalImportMode: 0
@@ -96,6 +99,8 @@ ModelImporter:
   humanoidOversampling: 1
   avatarSetup: 0
   addHumanoidExtraRootOnlyWhenUsingAvatar: 1
+  importBlendShapeDeformPercent: 0
+  remapMaterialsIfMaterialImportModeIsNone: 1
   additionalBone: 0
   userData: 
   assetBundleName: 

--- a/org.mixedrealitytoolkit.standardassets/Models/thick_8x4.fbx.meta
+++ b/org.mixedrealitytoolkit.standardassets/Models/thick_8x4.fbx.meta
@@ -1,7 +1,7 @@
 fileFormatVersion: 2
 guid: 5d1a0e539954477d8f80559f6385c0d1
 ModelImporter:
-  serializedVersion: 21300
+  serializedVersion: 22200
   internalIDToNameTable:
   - first:
       1: 100000
@@ -34,8 +34,6 @@ ModelImporter:
     optimizeGameObjects: 0
     removeConstantScaleCurves: 0
     motionNodeName: 
-    rigImportErrors: 
-    rigImportWarnings: 
     animationImportErrors: 
     animationImportWarnings: 
     animationRetargetingWarnings: 
@@ -58,6 +56,7 @@ ModelImporter:
     addColliders: 0
     useSRGBMaterialColor: 1
     sortHierarchyByName: 1
+    importPhysicalCameras: 1
     importVisibility: 1
     importBlendShapes: 1
     importCameras: 1
@@ -85,6 +84,7 @@ ModelImporter:
     secondaryUVMinObjectScale: 1
     secondaryUVPackMargin: 4
     useFileScale: 1
+    strictVertexDataChecks: 0
   tangentSpace:
     normalSmoothAngle: 60
     normalImportMode: 0
@@ -117,6 +117,7 @@ ModelImporter:
   humanoidOversampling: 1
   avatarSetup: 0
   addHumanoidExtraRootOnlyWhenUsingAvatar: 0
+  importBlendShapeDeformPercent: 0
   remapMaterialsIfMaterialImportModeIsNone: 1
   additionalBone: 0
   userData: 

--- a/org.mixedrealitytoolkit.standardassets/Models/thick_8x8.fbx.meta
+++ b/org.mixedrealitytoolkit.standardassets/Models/thick_8x8.fbx.meta
@@ -1,7 +1,7 @@
 fileFormatVersion: 2
 guid: c7287e9b9162af844bddf95967e4b991
 ModelImporter:
-  serializedVersion: 20200
+  serializedVersion: 22200
   internalIDToNameTable: []
   externalObjects: {}
   materials:
@@ -14,9 +14,8 @@ ModelImporter:
     bakeSimulation: 0
     resampleCurves: 1
     optimizeGameObjects: 0
+    removeConstantScaleCurves: 0
     motionNodeName: 
-    rigImportErrors: 
-    rigImportWarnings: 
     animationImportErrors: 
     animationImportWarnings: 
     animationRetargetingWarnings: 
@@ -39,10 +38,12 @@ ModelImporter:
     addColliders: 0
     useSRGBMaterialColor: 1
     sortHierarchyByName: 1
+    importPhysicalCameras: 1
     importVisibility: 1
     importBlendShapes: 1
     importCameras: 1
     importLights: 1
+    nodeNameCollisionStrategy: 0
     fileIdsGeneration: 2
     swapUVChannels: 0
     generateSecondaryUV: 0
@@ -54,6 +55,7 @@ ModelImporter:
     skinWeightsMode: 0
     maxBonesPerVertex: 4
     minBoneWeight: 0.001
+    optimizeBones: 1
     meshOptimizationFlags: -1
     indexFormat: 0
     secondaryUVAngleDistortion: 8
@@ -64,6 +66,7 @@ ModelImporter:
     secondaryUVMinObjectScale: 1
     secondaryUVPackMargin: 4
     useFileScale: 1
+    strictVertexDataChecks: 0
   tangentSpace:
     normalSmoothAngle: 60
     normalImportMode: 0
@@ -96,6 +99,8 @@ ModelImporter:
   humanoidOversampling: 1
   avatarSetup: 0
   addHumanoidExtraRootOnlyWhenUsingAvatar: 1
+  importBlendShapeDeformPercent: 0
+  remapMaterialsIfMaterialImportModeIsNone: 1
   additionalBone: 0
   userData: 
   assetBundleName: 

--- a/org.mixedrealitytoolkit.standardassets/Models/thick_curved_L.fbx.meta
+++ b/org.mixedrealitytoolkit.standardassets/Models/thick_curved_L.fbx.meta
@@ -1,7 +1,7 @@
 fileFormatVersion: 2
 guid: 8b2e6ce7571cdbb41b30213f6afeef85
 ModelImporter:
-  serializedVersion: 21300
+  serializedVersion: 22200
   internalIDToNameTable: []
   externalObjects: {}
   materials:
@@ -16,8 +16,6 @@ ModelImporter:
     optimizeGameObjects: 0
     removeConstantScaleCurves: 0
     motionNodeName: 
-    rigImportErrors: 
-    rigImportWarnings: 
     animationImportErrors: 
     animationImportWarnings: 
     animationRetargetingWarnings: 
@@ -40,6 +38,7 @@ ModelImporter:
     addColliders: 0
     useSRGBMaterialColor: 1
     sortHierarchyByName: 1
+    importPhysicalCameras: 1
     importVisibility: 1
     importBlendShapes: 1
     importCameras: 1
@@ -67,6 +66,7 @@ ModelImporter:
     secondaryUVMinObjectScale: 1
     secondaryUVPackMargin: 4
     useFileScale: 1
+    strictVertexDataChecks: 0
   tangentSpace:
     normalSmoothAngle: 60
     normalImportMode: 0
@@ -99,6 +99,7 @@ ModelImporter:
   humanoidOversampling: 1
   avatarSetup: 0
   addHumanoidExtraRootOnlyWhenUsingAvatar: 1
+  importBlendShapeDeformPercent: 0
   remapMaterialsIfMaterialImportModeIsNone: 1
   additionalBone: 0
   userData: 

--- a/org.mixedrealitytoolkit.standardassets/Models/thick_curved_R.fbx.meta
+++ b/org.mixedrealitytoolkit.standardassets/Models/thick_curved_R.fbx.meta
@@ -1,7 +1,7 @@
 fileFormatVersion: 2
 guid: 79b6e51cdd3c67a4d868789ad3118950
 ModelImporter:
-  serializedVersion: 21300
+  serializedVersion: 22200
   internalIDToNameTable: []
   externalObjects: {}
   materials:
@@ -16,8 +16,6 @@ ModelImporter:
     optimizeGameObjects: 0
     removeConstantScaleCurves: 0
     motionNodeName: 
-    rigImportErrors: 
-    rigImportWarnings: 
     animationImportErrors: 
     animationImportWarnings: 
     animationRetargetingWarnings: 
@@ -40,6 +38,7 @@ ModelImporter:
     addColliders: 0
     useSRGBMaterialColor: 1
     sortHierarchyByName: 1
+    importPhysicalCameras: 1
     importVisibility: 1
     importBlendShapes: 1
     importCameras: 1
@@ -67,6 +66,7 @@ ModelImporter:
     secondaryUVMinObjectScale: 1
     secondaryUVPackMargin: 4
     useFileScale: 1
+    strictVertexDataChecks: 0
   tangentSpace:
     normalSmoothAngle: 60
     normalImportMode: 0
@@ -99,6 +99,7 @@ ModelImporter:
   humanoidOversampling: 1
   avatarSetup: 0
   addHumanoidExtraRootOnlyWhenUsingAvatar: 1
+  importBlendShapeDeformPercent: 0
   remapMaterialsIfMaterialImportModeIsNone: 1
   additionalBone: 0
   userData: 

--- a/org.mixedrealitytoolkit.standardassets/Models/thick_rounded8.fbx.meta
+++ b/org.mixedrealitytoolkit.standardassets/Models/thick_rounded8.fbx.meta
@@ -1,7 +1,7 @@
 fileFormatVersion: 2
 guid: c44b8341995a8a34b9f769117568aeb5
 ModelImporter:
-  serializedVersion: 20200
+  serializedVersion: 22200
   internalIDToNameTable: []
   externalObjects: {}
   materials:
@@ -14,9 +14,8 @@ ModelImporter:
     bakeSimulation: 0
     resampleCurves: 1
     optimizeGameObjects: 0
+    removeConstantScaleCurves: 0
     motionNodeName: 
-    rigImportErrors: 
-    rigImportWarnings: 
     animationImportErrors: 
     animationImportWarnings: 
     animationRetargetingWarnings: 
@@ -39,10 +38,12 @@ ModelImporter:
     addColliders: 0
     useSRGBMaterialColor: 1
     sortHierarchyByName: 1
+    importPhysicalCameras: 1
     importVisibility: 1
     importBlendShapes: 1
     importCameras: 1
     importLights: 1
+    nodeNameCollisionStrategy: 0
     fileIdsGeneration: 2
     swapUVChannels: 0
     generateSecondaryUV: 0
@@ -54,6 +55,7 @@ ModelImporter:
     skinWeightsMode: 0
     maxBonesPerVertex: 4
     minBoneWeight: 0.001
+    optimizeBones: 1
     meshOptimizationFlags: -1
     indexFormat: 0
     secondaryUVAngleDistortion: 8
@@ -64,6 +66,7 @@ ModelImporter:
     secondaryUVMinObjectScale: 1
     secondaryUVPackMargin: 4
     useFileScale: 1
+    strictVertexDataChecks: 0
   tangentSpace:
     normalSmoothAngle: 60
     normalImportMode: 0
@@ -96,6 +99,8 @@ ModelImporter:
   humanoidOversampling: 1
   avatarSetup: 0
   addHumanoidExtraRootOnlyWhenUsingAvatar: 1
+  importBlendShapeDeformPercent: 0
+  remapMaterialsIfMaterialImportModeIsNone: 1
   additionalBone: 0
   userData: 
   assetBundleName: 

--- a/org.mixedrealitytoolkit.standardassets/Shaders/Bounds/Shell_Rounded_Bound.shader.meta
+++ b/org.mixedrealitytoolkit.standardassets/Shaders/Bounds/Shell_Rounded_Bound.shader.meta
@@ -4,7 +4,6 @@ ShaderImporter:
   externalObjects: {}
   defaultTextures: []
   nonModifiableTextures: []
-  preprocessorOverride: 0
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/org.mixedrealitytoolkit.standardassets/Shaders/DashedRay.shader.meta
+++ b/org.mixedrealitytoolkit.standardassets/Shaders/DashedRay.shader.meta
@@ -4,7 +4,6 @@ ShaderImporter:
   externalObjects: {}
   defaultTextures: []
   nonModifiableTextures: []
-  preprocessorOverride: 0
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/org.mixedrealitytoolkit.standardassets/Shaders/MixedRealityShaderUtils.cginc.meta
+++ b/org.mixedrealitytoolkit.standardassets/Shaders/MixedRealityShaderUtils.cginc.meta
@@ -1,10 +1,7 @@
 fileFormatVersion: 2
 guid: cedaa595cb0474547be4311d4632a59e
-ShaderImporter:
+ShaderIncludeImporter:
   externalObjects: {}
-  defaultTextures: []
-  nonModifiableTextures: []
-  preprocessorOverride: 0
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/org.mixedrealitytoolkit.standardassets/Shaders/RoundedQuadGlow.shader.meta
+++ b/org.mixedrealitytoolkit.standardassets/Shaders/RoundedQuadGlow.shader.meta
@@ -4,7 +4,6 @@ ShaderImporter:
   externalObjects: {}
   defaultTextures: []
   nonModifiableTextures: []
-  preprocessorOverride: 0
   userData: 
   assetBundleName: 
   assetBundleVariant: 


### PR DESCRIPTION
Wanted to save materials and textures for a second PR to prevent this one from getting even larger.