### PR TITLE
Fix global code validation script

### DIFF
--- a/Pipelines/Scripts/validatecode.ps1
+++ b/Pipelines/Scripts/validatecode.ps1
@@ -183,7 +183,12 @@ function CheckForMetaFile {
         [string]$FileName
     )
     process {
-        if (-not $FileName.EndsWith("~") -and -not (Test-Path ($FileName + ".meta"))) {
+        $isIgnoredByUnity = $FileName -match "~([\\/]|$)" -or 
+                            $FileName -match "[\\/]\." -or 
+                            $FileName -match "[\\/]cvs([\\/]|$)" -or 
+                            $FileName.EndsWith(".tmp")
+
+        if (-not $isIgnoredByUnity -and -not (Test-Path ($FileName + ".meta"))) {
             Write-Warning "Meta file missing for $FileName. Please be sure to check it in alongside this file."
             $true;
         }


### PR DESCRIPTION
Adds additional skip checks for folders/files ignored by Unity:

- Files and folders which start with a dot (.)
- Files with the extension .tmp
- Files and folders named cvs
- Files and folders ending with a tilde (~)