### PR TITLE
Update state visualizer and add tests

### DIFF
--- a/org.mixedrealitytoolkit.uxcore/CHANGELOG.md
+++ b/org.mixedrealitytoolkit.uxcore/CHANGELOG.md
@@ -7,7 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Added
 
 * Added the ability to map different icon sets together to have matching names (prerequisite for theming work). [PR #1077](https://github.com/MixedRealityToolkit/MixedRealityToolkit-Unity/pull/1077)
-* Add "Sort and Deduplicate" option to `FontIconSetDefinition`. [PR #1119](https://github.com/MixedRealityToolkit/MixedRealityToolkit-Unity/pull/1119)
+* Added "Sort and Deduplicate" option to `FontIconSetDefinition`. [PR #1119](https://github.com/MixedRealityToolkit/MixedRealityToolkit-Unity/pull/1119)
+* Added tests for hot-swapping `Interactable` and `Animator` on `StatefulVisualizer`. [PR #1123](https://github.com/MixedRealityToolkit/MixedRealityToolkit-Unity/pull/1123)
 
 ### Changed
 
@@ -18,6 +19,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 * Fixed "leaked managed shell" issue in `UGUIInputAdapter`. [PR #1096](https://github.com/MixedRealityToolkit/MixedRealityToolkit-Unity/pull/1096)
 * Fixed "Attribute 'SerializeField' is not valid on this declaration type. It is only valid on 'field' declarations" error on `DialogButton` in Unity 6.3. [PR #1108](https://github.com/MixedRealityToolkit/MixedRealityToolkit-Unity/pull/1108)
+* Fixed bug where the interactable could be changed but the visualizer would stay subscribed to the old interactable. [PR #1123](https://github.com/MixedRealityToolkit/MixedRealityToolkit-Unity/pull/1123)
+* Fixed bug where the animator could be changed but the visualizer wouldn't update the `AnimationPlayableOutput`. [PR #1123](https://github.com/MixedRealityToolkit/MixedRealityToolkit-Unity/pull/1123)
 
 ## [4.0.0-pre.2] - 2025-12-05
 

--- a/org.mixedrealitytoolkit.uxcore/FontIcons/FontIconSelectorMigrationUtility.cs.meta
+++ b/org.mixedrealitytoolkit.uxcore/FontIcons/FontIconSelectorMigrationUtility.cs.meta
@@ -1,2 +1,11 @@
 fileFormatVersion: 2
 guid: 2ad50c43ce4334344b21243c33f0279c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/org.mixedrealitytoolkit.uxcore/StateVisualizer/StateVisualizer.cs
+++ b/org.mixedrealitytoolkit.uxcore/StateVisualizer/StateVisualizer.cs
@@ -569,6 +569,11 @@ namespace MixedReality.Toolkit.UX
         /// Adds the provided effect to the state with name <paramref name="stateName"/>.
         /// Creates the state if it doesn't exist.
         /// </summary>
+        /// <remarks>
+        /// If this method is called at runtime after the component has been initialized,
+        /// you must manually call <see cref="Rebuild"/> to regenerate the <see cref="PlayableGraph"/>
+        /// so the new effect's playables are properly evaluated and connected.
+        /// </remarks>
         /// <param name="stateName">The name of the state to add the effect to.</param>
         /// <param name="effect">The effect to add.</param>
         internal void AddEffect(string stateName, IEffect effect)
@@ -584,6 +589,11 @@ namespace MixedReality.Toolkit.UX
         /// <summary>
         /// Removes the specified effect from the state with name <paramref name="stateName"/>.
         /// </summary>
+        /// <remarks>
+        /// If this method is called at runtime after the component has been initialized,
+        /// you must manually call <see cref="Rebuild"/> to properly disconnect and destroy
+        /// the removed effect's playables from the <see cref="PlayableGraph"/>.
+        /// </remarks>
         /// <param name="stateName">The name of the state to remove the effect from.</param>
         /// <param name="effect">The effect to remove.</param>
         /// <returns><see langword="true"/> if the effect was removed, <see langword="false"/> otherwise.</returns>

--- a/org.mixedrealitytoolkit.uxcore/StateVisualizer/StateVisualizer.cs
+++ b/org.mixedrealitytoolkit.uxcore/StateVisualizer/StateVisualizer.cs
@@ -144,10 +144,20 @@ namespace MixedReality.Toolkit.UX
             {
                 if (animator != value)
                 {
+                    if (animator != null)
+                    {
+                        animator.enabled = false;
+                    }
+
                     animator = value;
+
                     if (playableGraph.IsValid())
                     {
                         animationPlayableOutput.SetTarget(animator);
+                        if (animator != null)
+                        {
+                            animator.enabled = playableGraph.IsPlaying();
+                        }
                     }
                 }
             }

--- a/org.mixedrealitytoolkit.uxcore/StateVisualizer/StateVisualizer.cs
+++ b/org.mixedrealitytoolkit.uxcore/StateVisualizer/StateVisualizer.cs
@@ -152,6 +152,9 @@ namespace MixedReality.Toolkit.UX
         // A shared scratchpad for counting unique mixable effects during graph construction without allocating.
         private static readonly HashSet<IEffect> mixableEffectScratchpad = new HashSet<IEffect>();
 
+        // Tracks which interactable we are currently subscribed to, to prevent redundant delegate allocations.
+        private StatefulInteractable subscribedInteractable;
+
         /// <summary>
         /// A Unity Editor only event function that is called when the script is loaded or a value changes in the Unity Inspector.
         /// </summary>
@@ -197,14 +200,6 @@ namespace MixedReality.Toolkit.UX
         /// </remarks>
         internal void Rebuild()
         {
-            // Unsubscribe all existing interactable event listeners before rebuilding,
-            // otherwise Start() will add duplicates on top of the existing ones.
-            foreach (UnityAction unsubscribe in unsubscribeActions)
-            {
-                unsubscribe();
-            }
-            unsubscribeActions.Clear();
-
             if (playableGraph.IsValid())
             {
                 playableGraph.Destroy();
@@ -218,10 +213,25 @@ namespace MixedReality.Toolkit.UX
         /// </summary>
         protected virtual void Start()
         {
+            // If the graph is already valid, Start() has already executed (e.g. manually invoked
+            // by Rebuild() before Unity's natural Start lifecycle). Return early to prevent
+            // memory leaks of unmanaged PlayableGraphs and duplicate event subscriptions.
+            if (playableGraph.IsValid())
+            {
+                return;
+            }
+
             OnValidate();
 
-            if (interactable != null)
+            if (interactable != null && interactable != subscribedInteractable)
             {
+                // Unsubscribe from any previous interactable if we are hot-swapping
+                foreach (UnityAction unsubscribe in unsubscribeActions)
+                {
+                    unsubscribe();
+                }
+                unsubscribeActions.Clear();
+
                 unsubscribeActions.Add(Subscribe(interactable.hoverEntered, WakeUp));
                 unsubscribeActions.Add(Subscribe(interactable.hoverExited, WakeUp));
                 unsubscribeActions.Add(Subscribe(interactable.selectEntered, WakeUp));
@@ -230,6 +240,8 @@ namespace MixedReality.Toolkit.UX
                 unsubscribeActions.Add(Subscribe(interactable.IsToggled.OnExited, WakeUp));
                 unsubscribeActions.Add(Subscribe(interactable.OnEnabled, WakeUp));
                 unsubscribeActions.Add(Subscribe(interactable.OnDisabled, WakeUp));
+
+                subscribedInteractable = interactable;
             }
 
             // Creates the graph, the mixer and binds them to the Animator.

--- a/org.mixedrealitytoolkit.uxcore/StateVisualizer/StateVisualizer.cs
+++ b/org.mixedrealitytoolkit.uxcore/StateVisualizer/StateVisualizer.cs
@@ -212,7 +212,7 @@ namespace MixedReality.Toolkit.UX
 
         /// <summary>
         /// A Unity event function that is called on the frame when a script is enabled just before any of the update methods are called the first time.
-        /// </summary> 
+        /// </summary>
         protected virtual void Start()
         {
             OnValidate();
@@ -255,6 +255,14 @@ namespace MixedReality.Toolkit.UX
                         // Connect all AnimationEffects to our single, reusable AnimationMixer.
                         if (effect is IAnimationMixableEffect mixableEffect)
                         {
+                            // Guard against duplicate entries, which can occur if the same
+                            // effect instance appears more than once across stateContainers.
+                            if (mixableIndices.ContainsKey(mixableEffect))
+                            {
+                                Debug.LogWarning($"{nameof(StateVisualizer)}: Duplicate IAnimationMixableEffect instance detected in stateContainers ({effect.GetType().Name}). Skipping duplicate.");
+                                continue;
+                            }
+
                             // Expand the mixer's slots to fit our new playable.
                             int currentSlot = animationMixerPlayable.GetInputCount();
                             animationMixerPlayable.SetInputCount(currentSlot + 1);
@@ -329,10 +337,10 @@ namespace MixedReality.Toolkit.UX
             }
 
             // If we're asleep, quit early.
-            if (!animator.enabled) 
+            if (!animator.enabled)
             {
                 enabled = false;
-                return; 
+                return;
             }
 
             // Returns true if all effects are done playing.
@@ -497,7 +505,7 @@ namespace MixedReality.Toolkit.UX
         // is a non-issue for now.
 
         /// <summary>
-        /// Sets the parameter value on each state. 
+        /// Sets the parameter value on each state.
         /// Override + extend this method to implement custom state parameters.
         /// </summary>
         /// <returns>
@@ -554,11 +562,11 @@ namespace MixedReality.Toolkit.UX
         /// Call <see cref="StateVisualizer.UpdateStateValues"/> before calling this method.
         /// </summary>
         /// <remarks>
-        /// The <see cref="StateVisualizer"/> and connected <see cref="Animator"/> will be put to 
+        /// The <see cref="StateVisualizer"/> and connected <see cref="Animator"/> will be put to
         /// sleep if this returns <see langword="true"/>.
         /// </remarks>
         /// <returns>
-        /// <see langword="true"/> if all effects are done playing, <see langword="false"/> otherwise. 
+        /// <see langword="true"/> if all effects are done playing, <see langword="false"/> otherwise.
         /// </returns>
         private bool EvaluateEffects()
         {

--- a/org.mixedrealitytoolkit.uxcore/StateVisualizer/StateVisualizer.cs
+++ b/org.mixedrealitytoolkit.uxcore/StateVisualizer/StateVisualizer.cs
@@ -122,7 +122,7 @@ namespace MixedReality.Toolkit.UX
                 if (interactable != value)
                 {
                     interactable = value;
-                    if (Application.isPlaying && playableGraph.IsValid())
+                    if (playableGraph.IsValid())
                     {
                         UpdateInteractableSubscription();
                     }
@@ -140,11 +140,24 @@ namespace MixedReality.Toolkit.UX
         public Animator Animator
         {
             get => animator;
-            set => animator = value;
+            set
+            {
+                if (animator != value)
+                {
+                    animator = value;
+                    if (playableGraph.IsValid())
+                    {
+                        animationPlayableOutput.SetTarget(animator);
+                    }
+                }
+            }
         }
 
         // The PlayableGraph that injects animation data into the Animator.
         private PlayableGraph playableGraph;
+
+        // The animation output for the PlayableGraph.
+        private AnimationPlayableOutput animationPlayableOutput;
 
         // The single animation mixer that all animation-based effects mix into.
         private AnimationLayerMixerPlayable animationMixerPlayable;
@@ -225,7 +238,7 @@ namespace MixedReality.Toolkit.UX
 
                 // If we hot-swapped at runtime, immediately wake up so the visualizer
                 // evaluates the new interactable's current state (e.g. if it is already hovered).
-                if (Application.isPlaying && playableGraph.IsValid())
+                if (playableGraph.IsValid())
                 {
                     WakeUp();
                 }
@@ -273,7 +286,7 @@ namespace MixedReality.Toolkit.UX
             playableGraph = PlayableGraph.Create();
 
             // We can use a single animation output for all animation-based playables.
-            var animationPlayableOutput = AnimationPlayableOutput.Create(playableGraph, "Animation", GetComponent<Animator>());
+            animationPlayableOutput = AnimationPlayableOutput.Create(playableGraph, "Animation", animator);
 
             // AnimationLayerMixerPlayable does not support dynamic resizing via SetInputCount well.
             // We must pre-calculate the required number of inputs before creation to prevent Playable exceptions.

--- a/org.mixedrealitytoolkit.uxcore/StateVisualizer/StateVisualizer.cs
+++ b/org.mixedrealitytoolkit.uxcore/StateVisualizer/StateVisualizer.cs
@@ -183,6 +183,34 @@ namespace MixedReality.Toolkit.UX
         }
 
         /// <summary>
+        /// Tears down the current <see cref="PlayableGraph"/> and rebuilds it from the
+        /// current state of <see cref="stateContainers"/>.
+        /// </summary>
+        /// <remarks>
+        /// Call this after modifying the effect lists at runtime — for example, after a
+        /// theme switch via <see cref="MixedReality.Toolkit.Theming.StateVisualizerEffectSetBinder"/>.
+        /// Any effects added since the last <see cref="Start"/> call will not participate in
+        /// the graph until <see cref="Rebuild"/> is called.
+        /// </remarks>
+        internal void Rebuild()
+        {
+            // Unsubscribe all existing interactable event listeners before rebuilding,
+            // otherwise Start() will add duplicates on top of the existing ones.
+            foreach (UnityAction unsubscribe in unsubscribeActions)
+            {
+                unsubscribe();
+            }
+            unsubscribeActions.Clear();
+
+            if (playableGraph.IsValid())
+            {
+                playableGraph.Destroy();
+            }
+            mixableIndices.Clear();
+            Start();
+        }
+
+        /// <summary>
         /// A Unity event function that is called on the frame when a script is enabled just before any of the update methods are called the first time.
         /// </summary> 
         protected virtual void Start()

--- a/org.mixedrealitytoolkit.uxcore/StateVisualizer/StateVisualizer.cs
+++ b/org.mixedrealitytoolkit.uxcore/StateVisualizer/StateVisualizer.cs
@@ -117,7 +117,17 @@ namespace MixedReality.Toolkit.UX
 
                 return interactable;
             }
-            set => interactable = value;
+            set
+            {
+                if (interactable != value)
+                {
+                    interactable = value;
+                    if (Application.isPlaying && playableGraph.IsValid())
+                    {
+                        UpdateInteractableSubscription();
+                    }
+                }
+            }
         }
 
         [SerializeField]
@@ -188,6 +198,40 @@ namespace MixedReality.Toolkit.UX
             return () => evt.RemoveListener(callback);
         }
 
+        private void UpdateInteractableSubscription()
+        {
+            if (interactable != subscribedInteractable)
+            {
+                // Unsubscribe from any previous interactable if we are hot-swapping
+                foreach (UnityAction unsubscribe in unsubscribeActions)
+                {
+                    unsubscribe();
+                }
+                unsubscribeActions.Clear();
+
+                if (interactable != null)
+                {
+                    unsubscribeActions.Add(Subscribe(interactable.hoverEntered, WakeUp));
+                    unsubscribeActions.Add(Subscribe(interactable.hoverExited, WakeUp));
+                    unsubscribeActions.Add(Subscribe(interactable.selectEntered, WakeUp));
+                    unsubscribeActions.Add(Subscribe(interactable.selectExited, WakeUp));
+                    unsubscribeActions.Add(Subscribe(interactable.IsToggled.OnEntered, WakeUp));
+                    unsubscribeActions.Add(Subscribe(interactable.IsToggled.OnExited, WakeUp));
+                    unsubscribeActions.Add(Subscribe(interactable.OnEnabled, WakeUp));
+                    unsubscribeActions.Add(Subscribe(interactable.OnDisabled, WakeUp));
+                }
+
+                subscribedInteractable = interactable;
+
+                // If we hot-swapped at runtime, immediately wake up so the visualizer
+                // evaluates the new interactable's current state (e.g. if it is already hovered).
+                if (Application.isPlaying && playableGraph.IsValid())
+                {
+                    WakeUp();
+                }
+            }
+        }
+
         /// <summary>
         /// Tears down the current <see cref="PlayableGraph"/> and rebuilds it from the
         /// current state of <see cref="stateContainers"/>.
@@ -223,26 +267,7 @@ namespace MixedReality.Toolkit.UX
 
             OnValidate();
 
-            if (interactable != null && interactable != subscribedInteractable)
-            {
-                // Unsubscribe from any previous interactable if we are hot-swapping
-                foreach (UnityAction unsubscribe in unsubscribeActions)
-                {
-                    unsubscribe();
-                }
-                unsubscribeActions.Clear();
-
-                unsubscribeActions.Add(Subscribe(interactable.hoverEntered, WakeUp));
-                unsubscribeActions.Add(Subscribe(interactable.hoverExited, WakeUp));
-                unsubscribeActions.Add(Subscribe(interactable.selectEntered, WakeUp));
-                unsubscribeActions.Add(Subscribe(interactable.selectExited, WakeUp));
-                unsubscribeActions.Add(Subscribe(interactable.IsToggled.OnEntered, WakeUp));
-                unsubscribeActions.Add(Subscribe(interactable.IsToggled.OnExited, WakeUp));
-                unsubscribeActions.Add(Subscribe(interactable.OnEnabled, WakeUp));
-                unsubscribeActions.Add(Subscribe(interactable.OnDisabled, WakeUp));
-
-                subscribedInteractable = interactable;
-            }
+            UpdateInteractableSubscription();
 
             // Creates the graph, the mixer and binds them to the Animator.
             playableGraph = PlayableGraph.Create();

--- a/org.mixedrealitytoolkit.uxcore/StateVisualizer/StateVisualizer.cs
+++ b/org.mixedrealitytoolkit.uxcore/StateVisualizer/StateVisualizer.cs
@@ -149,6 +149,9 @@ namespace MixedReality.Toolkit.UX
         // A runtime scratchpad for recording where each IMixableEffect is connected on the mixer.
         private Dictionary<IEffect, int> mixableIndices = new Dictionary<IEffect, int>();
 
+        // A shared scratchpad for counting unique mixable effects during graph construction without allocating.
+        private static readonly HashSet<IEffect> mixableEffectScratchpad = new HashSet<IEffect>();
+
         /// <summary>
         /// A Unity Editor only event function that is called when the script is loaded or a value changes in the Unity Inspector.
         /// </summary>
@@ -235,10 +238,28 @@ namespace MixedReality.Toolkit.UX
             // We can use a single animation output for all animation-based playables.
             var animationPlayableOutput = AnimationPlayableOutput.Create(playableGraph, "Animation", GetComponent<Animator>());
 
+            // AnimationLayerMixerPlayable does not support dynamic resizing via SetInputCount well.
+            // We must pre-calculate the required number of inputs before creation to prevent Playable exceptions.
+            mixableEffectScratchpad.Clear();
+            foreach (var kvp in stateContainers)
+            {
+                foreach (IEffect effect in kvp.Value.Effects)
+                {
+                    if (effect is IAnimationMixableEffect)
+                    {
+                        mixableEffectScratchpad.Add(effect);
+                    }
+                }
+            }
+
             // We use a single master mixer for all animation-based playables.
             // Two-way animation playables mix into this mixer.
-            animationMixerPlayable = AnimationLayerMixerPlayable.Create(playableGraph, 1);
+            // We start with at least 1 input to prevent Playable API issues with 0-input layer mixers.
+            animationMixerPlayable = AnimationLayerMixerPlayable.Create(playableGraph, Mathf.Max(1, mixableEffectScratchpad.Count));
             animationPlayableOutput.SetSourcePlayable(animationMixerPlayable);
+            mixableEffectScratchpad.Clear();
+
+            int currentSlot = 0;
 
             foreach (var kvp in stateContainers)
             {
@@ -263,11 +284,6 @@ namespace MixedReality.Toolkit.UX
                                 continue;
                             }
 
-                            // Expand the mixer's slots to fit our new playable.
-                            int currentSlot = animationMixerPlayable.GetInputCount();
-                            animationMixerPlayable.SetInputCount(currentSlot + 1);
-                            // animationMixerPlayable.SetInputWeight(currentSlot, 1);
-
                             // Configure the layer in the mixer, based on the effect's settings.
                             // For now, additive mixing is blocked by a Unity bug, described at the following links.
                             // AnimationLayerMixerPlayable writes defaults into the object's state upon being disabled,
@@ -280,6 +296,8 @@ namespace MixedReality.Toolkit.UX
 
                             // Record the index for later retrieval.
                             mixableIndices.Add(mixableEffect, currentSlot);
+
+                            currentSlot++;
                         }
                         else
                         {
@@ -295,10 +313,41 @@ namespace MixedReality.Toolkit.UX
                 }
             }
 
-            // Start awake. We'll go back to sleep if nothing happens.
-            animator.enabled = true;
-            playableGraph.Play();
-            enabled = true;
+            // Update state values to match the current interactable state before setting weights.
+            UpdateStateValues();
+
+            // Snap the weights to the current state value initially so Rebuild() doesn't cause
+            // a visual glitch by lerping from 0, or flashing the bind pose.
+            foreach (var kvp in stateContainers)
+            {
+                foreach (IEffect effect in kvp.Value.Effects)
+                {
+                    if (effect is IAnimationMixableEffect mixableEffect && mixableIndices.TryGetValue(mixableEffect, out int slot))
+                    {
+                        animationMixerPlayable.SetInputWeight(slot, kvp.Value.Value);
+                    }
+                }
+            }
+
+            // Determine if we actually need to be awake.
+            bool allEffectsDone = EvaluateEffects();
+
+            if (allEffectsDone && interactable != null && !interactable.isSelected && !interactable.isHovered)
+            {
+                // Start asleep if nothing is happening. This prevents the Animator from
+                // briefly waking up and applying bind poses with 0 weights, which overwrites
+                // values set by other components (like theme binders).
+                animator.enabled = false;
+                playableGraph.Stop();
+                enabled = false;
+            }
+            else
+            {
+                animator.enabled = true;
+                playableGraph.Play();
+                enabled = true;
+                sleepTimer = keepAliveTime;
+            }
         }
 
         /// <summary>

--- a/org.mixedrealitytoolkit.uxcore/StateVisualizer/StateVisualizer.cs
+++ b/org.mixedrealitytoolkit.uxcore/StateVisualizer/StateVisualizer.cs
@@ -154,6 +154,7 @@ namespace MixedReality.Toolkit.UX
                     if (playableGraph.IsValid())
                     {
                         animationPlayableOutput.SetTarget(animator);
+                        playableGraph.Evaluate();
                         if (animator != null)
                         {
                             animator.enabled = playableGraph.IsPlaying();
@@ -395,6 +396,7 @@ namespace MixedReality.Toolkit.UX
                 // Start asleep if nothing is happening. This prevents the Animator from
                 // briefly waking up and applying bind poses with 0 weights, which overwrites
                 // values set by other components (like theme binders).
+                playableGraph.Evaluate();
                 animator.enabled = false;
                 playableGraph.Stop();
                 enabled = false;
@@ -465,6 +467,7 @@ namespace MixedReality.Toolkit.UX
                 if (sleepTimer <= 0 && interactable != null && !interactable.isSelected && !interactable.isHovered)
                 {
                     // All effects are done, let's go to sleep.
+                    playableGraph.Evaluate();
                     animator.enabled = false;
                     playableGraph.Stop();
                     enabled = false;

--- a/org.mixedrealitytoolkit.uxcore/StateVisualizer/StateVisualizer.cs
+++ b/org.mixedrealitytoolkit.uxcore/StateVisualizer/StateVisualizer.cs
@@ -720,16 +720,17 @@ namespace MixedReality.Toolkit.UX
         private bool UpdateWeight(IAnimationMixableEffect mixableEffect, State state)
         {
             bool done = true;
+            int inputIndex = mixableIndices[mixableEffect];
 
             if (mixableEffect.WeightMode == WeightType.MatchStateValue)
             {
                 // Set the playable's weight directly to the state's value.
-                animationMixerPlayable.SetInputWeight(mixableEffect.Playable, state.Value);
+                animationMixerPlayable.SetInputWeight(inputIndex, state.Value);
             }
             else if (mixableEffect.WeightMode == WeightType.Transition)
             {
                 // Grab the current weight, using our cached mixable indices.
-                float currentWeight = animationMixerPlayable.GetInputWeight(mixableIndices[mixableEffect]);
+                float currentWeight = animationMixerPlayable.GetInputWeight(inputIndex);
 
                 // Compute the direction of the transition.
                 bool shouldBeActive = !Mathf.Approximately(state.Value, 0.0f);
@@ -748,7 +749,7 @@ namespace MixedReality.Toolkit.UX
             else
             {
                 // WeightType.Constant is the only remaining option; the weight is always 1.0.
-                animationMixerPlayable.SetInputWeight(mixableEffect.Playable, 1.0f);
+                animationMixerPlayable.SetInputWeight(inputIndex, 1.0f);
             }
 
             return done;

--- a/org.mixedrealitytoolkit.uxcore/StateVisualizer/StateVisualizer.cs
+++ b/org.mixedrealitytoolkit.uxcore/StateVisualizer/StateVisualizer.cs
@@ -380,9 +380,7 @@ namespace MixedReality.Toolkit.UX
             }
 
             // Determine if we actually need to be awake.
-            bool allEffectsDone = EvaluateEffects();
-
-            if (allEffectsDone && interactable != null && !interactable.isSelected && !interactable.isHovered)
+            if (EvaluateEffects() && interactable != null && !interactable.isSelected && !interactable.isHovered)
             {
                 // Start asleep if nothing is happening. This prevents the Animator from
                 // briefly waking up and applying bind poses with 0 weights, which overwrites

--- a/org.mixedrealitytoolkit.uxcore/Tests/Runtime/FontIconSelectorTests.cs.meta
+++ b/org.mixedrealitytoolkit.uxcore/Tests/Runtime/FontIconSelectorTests.cs.meta
@@ -1,2 +1,11 @@
 fileFormatVersion: 2
 guid: f1a3703ea830e754cae0879bfd198ff4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/org.mixedrealitytoolkit.uxcore/Tests/Runtime/StateVisualizerTests.cs
+++ b/org.mixedrealitytoolkit.uxcore/Tests/Runtime/StateVisualizerTests.cs
@@ -475,6 +475,7 @@ namespace MixedReality.Toolkit.UX.Runtime.Tests
 
             Assert.IsFalse(anim2.enabled, "The old Animator should still be disabled after hot-swap.");
             Assert.IsFalse(anim3.enabled, "The newly swapped Animator should remain asleep because the PlayableGraph is stopped.");
+            Assert.AreEqual(42f, cube3.transform.localPosition.y, 0.001f, "The newly swapped Animator should instantly inherit the evaluated pose before being put back to sleep.");
 
             yield return rightHand.MoveTo(cube1.transform.position);
             yield return RuntimeTestUtilities.WaitForUpdates();

--- a/org.mixedrealitytoolkit.uxcore/Tests/Runtime/StateVisualizerTests.cs
+++ b/org.mixedrealitytoolkit.uxcore/Tests/Runtime/StateVisualizerTests.cs
@@ -340,6 +340,149 @@ namespace MixedReality.Toolkit.UX.Runtime.Tests
 
             Assert.IsTrue(cube.GetComponent<Animator>() != null, "An animator wasn't automatically added when it was missing!");
         }
+
+        /// <summary>
+        /// Tests that setting a new Interactable safely unsubscribes from the old and subscribes to the new.
+        /// </summary>
+        [UnityTest]
+        public IEnumerator TestInteractableHotSwap()
+        {
+            GameObject cube1 = GameObject.CreatePrimitive(PrimitiveType.Cube);
+            StatefulInteractable interactable1 = cube1.AddComponent<StatefulInteractable>();
+            interactable1.DisableInteractorType(typeof(IPokeInteractor));
+            cube1.AddComponent<Animator>();
+            StateVisualizer sv = cube1.AddComponent<StateVisualizer>();
+
+            cube1.transform.position = InputTestUtilities.InFrontOfUser(new Vector3(-0.2f, 0.1f, 1));
+            cube1.transform.localScale = Vector3.one * 0.1f;
+
+            GameObject cube2 = GameObject.CreatePrimitive(PrimitiveType.Cube);
+            StatefulInteractable interactable2 = cube2.AddComponent<StatefulInteractable>();
+            interactable2.DisableInteractorType(typeof(IPokeInteractor));
+            cube2.transform.position = InputTestUtilities.InFrontOfUser(new Vector3(0.2f, 0.1f, 1));
+            cube2.transform.localScale = Vector3.one * 0.1f;
+
+            CustomTestEffect customEffect = new CustomTestEffect();
+            sv.AddEffect("Select", customEffect);
+
+            var rightHand = new TestHand(Handedness.Right);
+            yield return rightHand.Show(InputTestUtilities.InFrontOfUser(0.5f));
+            yield return RuntimeTestUtilities.WaitForUpdates();
+
+            // Interact with cube 1
+            yield return rightHand.MoveTo(cube1.transform.position);
+            yield return RuntimeTestUtilities.WaitForUpdates();
+            yield return rightHand.SetHandshape(HandshapeId.Pinch);
+            yield return RuntimeTestUtilities.WaitForUpdates();
+            Assert.AreEqual(1.0f, customEffect.LastSetParameter, 0.00001f, "Effect should trigger on interactable 1.");
+
+            yield return rightHand.SetHandshape(HandshapeId.Open);
+            yield return RuntimeTestUtilities.WaitForUpdates();
+            Assert.AreEqual(0.0f, customEffect.LastSetParameter, 0.00001f, "Effect should reset.");
+
+            // Swap interactable
+            sv.Interactable = interactable2;
+            yield return RuntimeTestUtilities.WaitForUpdates();
+
+            // Interact with cube 1 again (should NOT trigger)
+            yield return rightHand.SetHandshape(HandshapeId.Pinch);
+            yield return RuntimeTestUtilities.WaitForUpdates();
+            Assert.AreEqual(0.0f, customEffect.LastSetParameter, 0.00001f, "Effect should NOT trigger on interactable 1 after hot-swap.");
+
+            yield return rightHand.SetHandshape(HandshapeId.Open);
+            yield return RuntimeTestUtilities.WaitForUpdates();
+
+            // Interact with cube 2
+            yield return rightHand.MoveTo(cube2.transform.position);
+            yield return RuntimeTestUtilities.WaitForUpdates();
+            yield return rightHand.SetHandshape(HandshapeId.Pinch);
+            yield return RuntimeTestUtilities.WaitForUpdates();
+            Assert.AreEqual(1.0f, customEffect.LastSetParameter, 0.00001f, "Effect should trigger on interactable 2 after hot-swap.");
+        }
+
+        /// <summary>
+        /// Tests that setting a new Animator at runtime successfully triggers a Rebuild and updates the target.
+        /// </summary>
+        [UnityTest]
+        public IEnumerator TestAnimatorHotSwap()
+        {
+            GameObject cube1 = GameObject.CreatePrimitive(PrimitiveType.Cube);
+            StatefulInteractable interactable = cube1.AddComponent<StatefulInteractable>();
+            interactable.DisableInteractorType(typeof(IPokeInteractor));
+            Animator anim1 = cube1.AddComponent<Animator>();
+            StateVisualizer sv = cube1.AddComponent<StateVisualizer>();
+
+            cube1.transform.position = InputTestUtilities.InFrontOfUser(new Vector3(0.1f, 0.1f, 1));
+            cube1.transform.localScale = Vector3.one * 0.1f;
+
+            // Add the effect BEFORE Start() so we don't need to manually Rebuild() to pick it up.
+            CustomTestEffect customEffect = new CustomTestEffect();
+            sv.AddEffect("Select", customEffect);
+
+            yield return RuntimeTestUtilities.WaitForUpdates();
+
+            GameObject cube2 = GameObject.CreatePrimitive(PrimitiveType.Cube);
+            Animator anim2 = cube2.AddComponent<Animator>();
+
+            Assert.AreEqual(anim1, sv.Animator, "SV should default to Animator on the same GameObject.");
+
+            // Swap animator
+            sv.Animator = anim2;
+            yield return RuntimeTestUtilities.WaitForUpdates();
+
+            Assert.AreEqual(anim2, sv.Animator, "SV Animator should be updated.");
+
+            var rightHand = new TestHand(Handedness.Right);
+            yield return rightHand.Show(cube1.transform.position);
+            yield return RuntimeTestUtilities.WaitForUpdates();
+
+            Assert.IsTrue(anim2.enabled, "The new Animator should be enabled when the StateVisualizer wakes up.");
+
+            yield return rightHand.SetHandshape(HandshapeId.Pinch);
+            yield return RuntimeTestUtilities.WaitForUpdates();
+            Assert.AreEqual(1.0f, customEffect.LastSetParameter, 0.00001f, "Effect should trigger after Animator hot-swap.");
+
+            // Verify destruction doesn't cause PlayableGraph leaks/errors
+            Object.Destroy(cube1);
+            Object.Destroy(cube2);
+            yield return RuntimeTestUtilities.WaitForUpdates();
+        }
+
+        /// <summary>
+        /// Tests that calling Rebuild() multiple times doesn't cause crashes, leaks, or break existing effects.
+        /// </summary>
+        [UnityTest]
+        public IEnumerator TestRebuild()
+        {
+            GameObject cube = GameObject.CreatePrimitive(PrimitiveType.Cube);
+            StatefulInteractable interactable = cube.AddComponent<StatefulInteractable>();
+            interactable.DisableInteractorType(typeof(IPokeInteractor));
+            cube.AddComponent<Animator>();
+            StateVisualizer sv = cube.AddComponent<StateVisualizer>();
+            cube.transform.position = InputTestUtilities.InFrontOfUser(new Vector3(0.1f, 0.1f, 1));
+            cube.transform.localScale = Vector3.one * 0.1f;
+            yield return RuntimeTestUtilities.WaitForUpdates();
+
+            CustomTestEffect customEffect = new CustomTestEffect();
+            sv.AddEffect("Select", customEffect);
+
+            // Call rebuild multiple times to ensure no crashes or obvious leaks.
+            sv.Rebuild();
+            sv.Rebuild();
+            sv.Rebuild();
+
+            yield return RuntimeTestUtilities.WaitForUpdates();
+
+            var rightHand = new TestHand(Handedness.Right);
+            yield return rightHand.Show(InputTestUtilities.InFrontOfUser(0.5f));
+            yield return RuntimeTestUtilities.WaitForUpdates();
+            yield return rightHand.MoveTo(cube.transform.position);
+            yield return RuntimeTestUtilities.WaitForUpdates();
+            yield return rightHand.SetHandshape(HandshapeId.Pinch);
+            yield return RuntimeTestUtilities.WaitForUpdates();
+
+            Assert.AreEqual(1.0f, customEffect.LastSetParameter, 0.00001f, "Effect should trigger after multiple Rebuilds.");
+        }
     }
 }
 #pragma warning restore CS1591

--- a/org.mixedrealitytoolkit.uxcore/Tests/Runtime/StateVisualizerTests.cs
+++ b/org.mixedrealitytoolkit.uxcore/Tests/Runtime/StateVisualizerTests.cs
@@ -10,6 +10,7 @@ using NUnit.Framework;
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
+using UnityEngine.Animations;
 using UnityEngine.Playables;
 using UnityEngine.TestTools;
 
@@ -138,6 +139,27 @@ namespace MixedReality.Toolkit.UX.Runtime.Tests
                 LastSetParameter = parameter;
                 return true;
             }
+        }
+
+        /// <summary>
+        /// A minimal mixable effect to verify PlayableGraph connections.
+        /// </summary>
+        private class TestMixableEffect : IAnimationMixableEffect, IPlayableEffect
+        {
+            public Playable Playable { get; private set; }
+
+            public float TransitionDuration => 0f;
+
+            public IAnimationMixableEffect.WeightType WeightMode => IAnimationMixableEffect.WeightType.MatchStateValue;
+
+            public void Setup(PlayableGraph graph, GameObject owner)
+            {
+                AnimationClip clip = new AnimationClip();
+                clip.SetCurve("", typeof(Transform), "localPosition.y", AnimationCurve.Constant(0f, 1f, 42f));
+                Playable = AnimationClipPlayable.Create(graph, clip);
+            }
+
+            public bool Evaluate(float parameter) => true;
         }
 
         /// <summary>
@@ -419,32 +441,55 @@ namespace MixedReality.Toolkit.UX.Runtime.Tests
             CustomTestEffect customEffect = new CustomTestEffect();
             sv.AddEffect("Select", customEffect);
 
+            TestMixableEffect mixableEffect = new TestMixableEffect();
+            sv.AddEffect("Select", mixableEffect);
+
             yield return RuntimeTestUtilities.WaitForUpdates();
 
             GameObject cube2 = GameObject.CreatePrimitive(PrimitiveType.Cube);
             Animator anim2 = cube2.AddComponent<Animator>();
 
-            Assert.AreEqual(anim1, sv.Animator, "SV should default to Animator on the same GameObject.");
-
-            // Swap animator
-            sv.Animator = anim2;
-            yield return RuntimeTestUtilities.WaitForUpdates();
-
-            Assert.AreEqual(anim2, sv.Animator, "SV Animator should be updated.");
-
             var rightHand = new TestHand(Handedness.Right);
             yield return rightHand.Show(cube1.transform.position);
             yield return RuntimeTestUtilities.WaitForUpdates();
 
-            Assert.IsTrue(anim2.enabled, "The new Animator should be enabled when the StateVisualizer wakes up.");
+            Assert.AreEqual(anim1, sv.Animator, "SV should default to Animator on the same GameObject.");
+            Assert.IsTrue(anim1.enabled, "The initial Animator should be enabled because the StateVisualizer is hovered.");
+
+            // Swap animator while awake
+            sv.Animator = anim2;
+
+            Assert.IsFalse(anim1.enabled, "The old Animator should be disabled immediately after hot-swap.");
+            Assert.IsTrue(anim2.enabled, "The new Animator should instantly inherit the playing state from the PlayableGraph.");
+            Assert.AreEqual(anim2, sv.Animator, "SV Animator should be updated.");
+
+            // Wait for it to go to sleep
+            yield return rightHand.MoveTo(Vector3.zero);
+            yield return new WaitForSeconds(0.25f);
+            Assert.IsFalse(anim2.enabled, "The new Animator should have been put to sleep by the visualizer after keepAliveTime elapsed.");
+
+            // Hot swap while asleep
+            GameObject cube3 = GameObject.CreatePrimitive(PrimitiveType.Cube);
+            Animator anim3 = cube3.AddComponent<Animator>();
+            sv.Animator = anim3;
+
+            Assert.IsFalse(anim2.enabled, "The old Animator should still be disabled after hot-swap.");
+            Assert.IsFalse(anim3.enabled, "The newly swapped Animator should remain asleep because the PlayableGraph is stopped.");
+
+            yield return rightHand.MoveTo(cube1.transform.position);
+            yield return RuntimeTestUtilities.WaitForUpdates();
+
+            Assert.IsTrue(anim3.enabled, "The new Animator should be enabled when the StateVisualizer wakes up.");
 
             yield return rightHand.SetHandshape(HandshapeId.Pinch);
             yield return RuntimeTestUtilities.WaitForUpdates();
             Assert.AreEqual(1.0f, customEffect.LastSetParameter, 0.00001f, "Effect should trigger after Animator hot-swap.");
+            Assert.AreEqual(42f, cube3.transform.localPosition.y, 0.001f, "The mixable effect should have animated the new Animator's GameObject.");
 
             // Verify destruction doesn't cause PlayableGraph leaks/errors
             Object.Destroy(cube1);
             Object.Destroy(cube2);
+            Object.Destroy(cube3);
             yield return RuntimeTestUtilities.WaitForUpdates();
         }
 

--- a/org.mixedrealitytoolkit.uxcore/Theming/AssemblyInfo.cs.meta
+++ b/org.mixedrealitytoolkit.uxcore/Theming/AssemblyInfo.cs.meta
@@ -1,2 +1,11 @@
 fileFormatVersion: 2
 guid: dca329abb86cbed439db681cb5c19650
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
* Fixed bug where the interactable could be changed but the visualizer would stay subscribed to the old interactable.
* Fixed bug where the animator could be changed but the visualizer wouldn't update the `AnimationPlayableOutput`.
* Added tests for hot-swapping `Interactable` and `Animator` on `StatefulVisualizer`.

<img width="260" height="155" alt="image" src="https://github.com/user-attachments/assets/937e46fc-2f32-4f67-98d6-68fa6fbad080" />
