### PR TITLE
Add #if UNITY_EDITOR to PackageValidator

### DIFF
--- a/org.mixedrealitytoolkit.core/CHANGELOG.md
+++ b/org.mixedrealitytoolkit.core/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Changed
 
 * Updated code style in `HandsSubsystemDescriptor`, `MRTKSubsystemDescriptor`, `DictationSubsystemDescriptor`, and `XRSubsystemHelpers`. [PR #1109](https://github.com/MixedRealityToolkit/MixedRealityToolkit-Unity/pull/1109)
+* Updated `PackageValidator` to only be valid if `UNITY_EDITOR` is true. [PR #1125](https://github.com/MixedRealityToolkit/MixedRealityToolkit-Unity/pull/1125)
 
 ### Fixed
 

--- a/org.mixedrealitytoolkit.core/Tests/TestUtilities/PackageValidator.cs
+++ b/org.mixedrealitytoolkit.core/Tests/TestUtilities/PackageValidator.cs
@@ -1,9 +1,7 @@
 // Copyright (c) Mixed Reality Toolkit Contributors
 // Licensed under the BSD 3-Clause
 
-// Disable "missing XML comment" warning for tests. While nice to have, this documentation is not required.
-#pragma warning disable CS1591
-#if HAS_ASSET_STORE_VALIDATION
+#if HAS_ASSET_STORE_VALIDATION && UNITY_EDITOR
 
 using System;
 using System.Collections.Generic;
@@ -26,12 +24,7 @@ namespace MixedReality.Toolkit.Core.Tests.EditMode
         /// </exception>
         public static PackageValidatorResults Validate(string packageName)
         {
-            PackageInfo info = UpmPackageInfo(packageName);
-            if (info == null)
-            {
-                throw new ArgumentException($"No package found with name \"{packageName}\"");
-            }
-
+            PackageInfo info = UpmPackageInfo(packageName) ?? throw new ArgumentException($"No package found with name \"{packageName}\"");
             string packageId = $"{info.name}@{info.version}";
             ValidationSuite.ValidatePackage(packageId, ValidationType.AssetStore);
 
@@ -70,5 +63,5 @@ namespace MixedReality.Toolkit.Core.Tests.EditMode
         }
     }
 }
-#endif // HAS_ASSET_STORE_VALIDATION
-#pragma warning restore CS1591
+
+#endif // HAS_ASSET_STORE_VALIDATION && UNITY_EDITOR


### PR DESCRIPTION
Prevents attempts to use editor-only code outside the editor.

EditMode tests continue to pass:

<img width="478" height="90" alt="image" src="https://github.com/user-attachments/assets/b5437929-ad6d-4955-8db7-ae28e89f58e1" />
